### PR TITLE
Consume current-location map focus once

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -152,6 +152,7 @@ export function NaverMap({
   const onViewportChangeRef = useRef(onViewportChange);
   const idleListenerRef = useRef<any>(null);
   const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastHandledCurrentLocationFocusKeyRef = useRef(0);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const clientId = getClientConfig().naverMapClientId;
@@ -434,8 +435,20 @@ export function NaverMap({
       return;
     }
 
+    if (focusCurrentLocationKey === lastHandledCurrentLocationFocusKeyRef.current) {
+      return;
+    }
+
+    // A direct place/festival selection is a newer intent than an old
+    // "show my location" focus request, so consume and discard it here.
+    if (selectedPlaceId || selectedFestivalId) {
+      lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
+      return;
+    }
+
+    lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
     mapRef.current.panTo(new window.naver.maps.LatLng(currentPosition.latitude, currentPosition.longitude));
-  }, [currentPosition, focusCurrentLocationKey, status]);
+  }, [currentPosition, focusCurrentLocationKey, selectedFestivalId, selectedPlaceId, status]);
 
   useEffect(() => {
     if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {


### PR DESCRIPTION
지도 네비게이션에서 내 위치 보기를 한 뒤에 
피드네비게이션에 가서 이 장소 보기를 클릭했는데, 
그 장소로 가고 나서는 자꾸 내 위치로 끌려감.

내 위치 보기는 한 번만 포커스해야 하는데, 
현재 구조에선 그 상태가 살아 있어서 
currentPosition이 다시 갱신될 때마다 
지도가 또 내 위치로 끌려간다.

내 위치 보기 포커스는 1회성이고, 
그보다 나중에 장소를 누르면 그 포커스는 버려져야 함.