### PR TITLE
Move notifications into global floating center

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,6 +32,7 @@ import { CourseTab } from './components/CourseTab';
 import { EventTab } from './components/EventTab';
 import { FeedTab } from './components/FeedTab';
 import { FloatingBackButton } from './components/FloatingBackButton';
+import { GlobalNotificationCenter } from './components/GlobalNotificationCenter';
 import { GlobalStatusBanner } from './components/GlobalStatusBanner';
 import { MapTabStage } from './components/MapTabStage';
 import { MyPagePanel } from './components/MyPagePanel';
@@ -639,9 +640,7 @@ export default function App() {
       setSelectedFestivalId((current) => (current && festivalResult.some((festival) => festival.id === current) ? current : null));
 
       if (bootstrap.auth.user) {
-        if (activeTab === 'my') {
-          await refreshMyPageForUser(bootstrap.auth.user, true);
-        }
+        await refreshMyPageForUser(bootstrap.auth.user, true);
       } else {
         setMyPage(null);
       }
@@ -1088,6 +1087,25 @@ export default function App() {
     });
   }
 
+  async function handleOpenGlobalNotification(notification: NonNullable<typeof myPage>['notifications'][number]) {
+    if (!notification.isRead) {
+      await handleMarkNotificationRead(notification.id);
+    }
+
+    if (notification.reviewId && notification.commentId) {
+      handleOpenCommentWithReturn(notification.reviewId, notification.commentId);
+      return;
+    }
+    if (notification.reviewId) {
+      handleOpenReviewWithReturn(notification.reviewId);
+      return;
+    }
+    if (notification.routeId) {
+      goToTab('my');
+      setMyPageTab('routes');
+    }
+  }
+
   async function handleToggleAdminPlace(placeId: string, nextValue: boolean) {
     if (!sessionUser?.isAdmin) {
       return;
@@ -1298,174 +1316,191 @@ export default function App() {
       <div className={[
         'phone-shell',
         activeTab === 'map' ? 'phone-shell--map' : '',
-        globalStatus ? 'phone-shell--with-status' : '',
       ].filter(Boolean).join(' ')}>
-        {globalStatus && <GlobalStatusBanner tone={globalStatus.tone} message={globalStatus.message} layout={activeTab === 'map' ? 'map' : 'page'} />}
-        {activeTab === 'map' ? (
-          <MapTabStage
-            activeCategory={activeCategory}
-            setActiveCategory={setActiveCategory}
-            filteredPlaces={filteredPlaces}
-            festivals={festivals}
-            selectedPlace={selectedPlace}
-            selectedFestival={selectedFestival}
-            currentPosition={currentPosition}
-            mapLocationStatus={mapLocationStatus}
-            mapLocationFocusKey={mapLocationFocusKey}
-            drawerState={drawerState}
-            sessionUser={sessionUser}
-            selectedPlaceReviews={selectedPlaceReviews}
-            routePreview={selectedRoutePreview}
-            routePreviewPlaces={routePreviewPlaces}
-            visitCount={visitCount}
-            latestStamp={latestStamp}
-            todayStamp={todayStamp}
-            stampActionStatus={stampActionStatus}
-            stampActionMessage={stampActionMessage}
-            reviewProofMessage={reviewProofMessage}
-            reviewError={reviewError}
-            reviewSubmitting={reviewSubmitting}
-            canCreateReview={canCreateReview}
-            hasCreatedReviewToday={hasCreatedReviewToday}
-            onOpenFeedReview={() => {
-              if (!selectedPlace) {
-                return;
-              }
-              handleOpenPlaceFeedWithReturn(selectedPlace.id);
-            }}
-            initialMapCenter={{ lat: initialMapViewport.lat, lng: initialMapViewport.lng }}
-            initialMapZoom={initialMapViewport.zoom}
-            onOpenPlace={(placeId) => {
-              setSelectedRoutePreview(null);
-              openPlace(placeId);
-            }}
-            onOpenFestival={(festivalId) => {
-              setSelectedRoutePreview(null);
-              openFestival(festivalId);
-            }}
-            onCloseDrawer={closeDrawer}
-            onClearRoutePreview={() => setSelectedRoutePreview(null)}
-            onExpandPlaceDrawer={() =>
-              selectedPlace &&
-              commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'full' }, 'replace')
-            }
-            onCollapsePlaceDrawer={() =>
-              selectedPlace &&
-              commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'partial' }, 'replace')
-            }
-            onExpandFestivalDrawer={() =>
-              selectedFestival &&
-              commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'full' }, 'replace')
-            }
-            onCollapseFestivalDrawer={() =>
-              selectedFestival &&
-              commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'partial' }, 'replace')
-            }
-            onRequestLogin={() => goToTab('my')}
-            onClaimStamp={handleClaimStamp}
-            onCreateReview={handleCreateReview}
-            onLocateCurrentPosition={() => void refreshCurrentPosition(true)}
-            onMapViewportChange={updateMapViewportInUrl}
-          />
-        ) : (
-          <div className={globalStatus ? 'page-stage page-stage--with-banner' : 'page-stage'}>
-
-            {activeTab === 'feed' && (
-              <FeedTab
-                reviews={reviews}
-                sessionUser={sessionUser}
-                reviewLikeUpdatingId={reviewLikeUpdatingId}
-                placeFilterId={feedPlaceFilterId}
-                placeFilterName={feedPlaceFilterId ? placeNameById[feedPlaceFilterId] ?? null : null}
-                commentSubmittingReviewId={commentSubmittingReviewId}
-                commentMutatingId={commentMutatingId}
-                deletingReviewId={deletingReviewId}
-                activeCommentReviewId={activeCommentReviewId}
-                highlightedCommentId={highlightedCommentId}
-                highlightedReviewId={highlightedReviewId}
-                hasMore={feedHasMore && !feedPlaceFilterId}
-                loadingMore={feedLoadingMore}
-                onLoadMore={loadMoreFeedReviews}
-                onToggleReviewLike={handleToggleReviewLike}
-                onCreateComment={handleCreateComment}
-                onUpdateComment={handleUpdateComment}
-                onDeleteComment={handleDeleteComment}
-                onDeleteReview={handleDeleteReview}
-                onRequestLogin={() => goToTab('my')}
-                onClearPlaceFilter={() => setFeedPlaceFilterId(null)}
-                onOpenPlace={handleOpenPlaceWithReturn}
-                onOpenComments={handleOpenReviewComments}
-                onCloseComments={handleCloseReviewComments}
-              />
-            )}
-
-            {activeTab === 'event' && (
-              <EventTab festivals={festivals} />
-            )}
-
-            {activeTab === 'course' && (
-              <CourseTab
-                curatedCourses={courses}
-                communityRoutes={communityRoutes}
-                sort={communityRouteSort}
-                sessionUser={sessionUser}
-                routeLikeUpdatingId={routeLikeUpdatingId}
-                placeNameById={placeNameById}
-                onChangeSort={(sort) => {
-                  setCommunityRouteSort(sort);
-                  void fetchCommunityRoutes(sort)
-                    .catch(reportBackgroundError);
-                }}
-                onToggleLike={handleToggleRouteLike}
-                onOpenPlace={handleOpenPlaceWithReturn}
-                onOpenRoutePreview={handleOpenRoutePreview}
-                onRequestLogin={() => goToTab('my')}
-              />
-            )}
-
-            {activeTab === 'my' && (
-              <MyPagePanel
-                sessionUser={sessionUser}
-                myPage={myPage}
-                providers={providers}
-                myPageError={myPageError}
-                activeTab={myPageTab}
-                isLoggingOut={isLoggingOut}
-                profileSaving={profileSaving}
-                profileError={profileError}
-                routeSubmitting={routeSubmitting}
-                routeError={routeError}
-                adminSummary={adminSummary}
-                adminBusyPlaceId={adminBusyPlaceId}
-                adminLoading={adminLoading}
-                onChangeTab={setMyPageTab}
-                onLogin={startProviderLogin}
-                onRetry={async () => { if (sessionUser) { await refreshMyPageForUser(sessionUser, true); } }}
-                onLogout={handleLogout}
-                onSaveNickname={handleUpdateProfile}
-                onPublishRoute={handlePublishRoute}
-                onOpenPlace={handleOpenPlaceWithReturn}
-                onOpenComment={(reviewId, commentId) => handleOpenCommentWithReturn(reviewId, commentId)}
-                onOpenReview={handleOpenReviewWithReturn}
-                onUpdateReview={handleUpdateReview}
-                onDeleteReview={handleDeleteReview}
-                onMarkNotificationRead={handleMarkNotificationRead}
-                onMarkAllNotificationsRead={handleMarkAllNotificationsRead}
-                onDeleteNotification={handleDeleteNotification}
-                commentsHasMore={myCommentsHasMore}
-                commentsLoadingMore={myCommentsLoadingMore}
-                onLoadMoreComments={loadMoreMyComments}
-                onRefreshAdmin={handleRefreshAdminImport}
-                onToggleAdminPlace={handleToggleAdminPlace}
-                onToggleAdminManualOverride={handleToggleAdminManualOverride}
-              />
-            )}
+        {globalStatus && (
+          <div className="phone-shell__status-slot">
+            <GlobalStatusBanner tone={globalStatus.tone} message={globalStatus.message} layout={activeTab === 'map' ? 'map' : 'page'} />
           </div>
         )}
+        {sessionUser && myPage && (
+          <div className="phone-shell__utility-slot">
+            <GlobalNotificationCenter
+              sessionUserName={sessionUser.nickname}
+              notifications={myPage.notifications}
+              unreadCount={myPage.unreadNotificationCount}
+              onOpenNotification={handleOpenGlobalNotification}
+              onMarkAllNotificationsRead={handleMarkAllNotificationsRead}
+              onDeleteNotification={handleDeleteNotification}
+            />
+          </div>
+        )}
+        <div className={globalStatus ? 'phone-shell__body phone-shell__body--with-status' : 'phone-shell__body'}>
+          {activeTab === 'map' ? (
+            <MapTabStage
+              activeCategory={activeCategory}
+              setActiveCategory={setActiveCategory}
+              filteredPlaces={filteredPlaces}
+              festivals={festivals}
+              selectedPlace={selectedPlace}
+              selectedFestival={selectedFestival}
+              currentPosition={currentPosition}
+              mapLocationStatus={mapLocationStatus}
+              mapLocationFocusKey={mapLocationFocusKey}
+              drawerState={drawerState}
+              sessionUser={sessionUser}
+              selectedPlaceReviews={selectedPlaceReviews}
+              routePreview={selectedRoutePreview}
+              routePreviewPlaces={routePreviewPlaces}
+              visitCount={visitCount}
+              latestStamp={latestStamp}
+              todayStamp={todayStamp}
+              stampActionStatus={stampActionStatus}
+              stampActionMessage={stampActionMessage}
+              reviewProofMessage={reviewProofMessage}
+              reviewError={reviewError}
+              reviewSubmitting={reviewSubmitting}
+              canCreateReview={canCreateReview}
+              hasCreatedReviewToday={hasCreatedReviewToday}
+              onOpenFeedReview={() => {
+                if (!selectedPlace) {
+                  return;
+                }
+                handleOpenPlaceFeedWithReturn(selectedPlace.id);
+              }}
+              initialMapCenter={{ lat: initialMapViewport.lat, lng: initialMapViewport.lng }}
+              initialMapZoom={initialMapViewport.zoom}
+              onOpenPlace={(placeId) => {
+                setSelectedRoutePreview(null);
+                openPlace(placeId);
+              }}
+              onOpenFestival={(festivalId) => {
+                setSelectedRoutePreview(null);
+                openFestival(festivalId);
+              }}
+              onCloseDrawer={closeDrawer}
+              onClearRoutePreview={() => setSelectedRoutePreview(null)}
+              onExpandPlaceDrawer={() =>
+                selectedPlace &&
+                commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'full' }, 'replace')
+              }
+              onCollapsePlaceDrawer={() =>
+                selectedPlace &&
+                commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'partial' }, 'replace')
+              }
+              onExpandFestivalDrawer={() =>
+                selectedFestival &&
+                commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'full' }, 'replace')
+              }
+              onCollapseFestivalDrawer={() =>
+                selectedFestival &&
+                commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'partial' }, 'replace')
+              }
+              onRequestLogin={() => goToTab('my')}
+              onClaimStamp={handleClaimStamp}
+              onCreateReview={handleCreateReview}
+              onLocateCurrentPosition={() => void refreshCurrentPosition(true)}
+              onMapViewportChange={updateMapViewportInUrl}
+            />
+          ) : (
+            <div className="page-stage">
 
-        {canNavigateBack && <FloatingBackButton onNavigateBack={handleNavigateBack} />}
+              {activeTab === 'feed' && (
+                <FeedTab
+                  reviews={reviews}
+                  sessionUser={sessionUser}
+                  reviewLikeUpdatingId={reviewLikeUpdatingId}
+                  placeFilterId={feedPlaceFilterId}
+                  placeFilterName={feedPlaceFilterId ? placeNameById[feedPlaceFilterId] ?? null : null}
+                  commentSubmittingReviewId={commentSubmittingReviewId}
+                  commentMutatingId={commentMutatingId}
+                  deletingReviewId={deletingReviewId}
+                  activeCommentReviewId={activeCommentReviewId}
+                  highlightedCommentId={highlightedCommentId}
+                  highlightedReviewId={highlightedReviewId}
+                  hasMore={feedHasMore && !feedPlaceFilterId}
+                  loadingMore={feedLoadingMore}
+                  onLoadMore={loadMoreFeedReviews}
+                  onToggleReviewLike={handleToggleReviewLike}
+                  onCreateComment={handleCreateComment}
+                  onUpdateComment={handleUpdateComment}
+                  onDeleteComment={handleDeleteComment}
+                  onDeleteReview={handleDeleteReview}
+                  onRequestLogin={() => goToTab('my')}
+                  onClearPlaceFilter={() => setFeedPlaceFilterId(null)}
+                  onOpenPlace={handleOpenPlaceWithReturn}
+                  onOpenComments={handleOpenReviewComments}
+                  onCloseComments={handleCloseReviewComments}
+                />
+              )}
 
-        <BottomNav activeTab={activeTab} onChange={handleBottomNavChange} />
+              {activeTab === 'event' && (
+                <EventTab festivals={festivals} />
+              )}
+
+              {activeTab === 'course' && (
+                <CourseTab
+                  curatedCourses={courses}
+                  communityRoutes={communityRoutes}
+                  sort={communityRouteSort}
+                  sessionUser={sessionUser}
+                  routeLikeUpdatingId={routeLikeUpdatingId}
+                  placeNameById={placeNameById}
+                  onChangeSort={(sort) => {
+                    setCommunityRouteSort(sort);
+                    void fetchCommunityRoutes(sort)
+                      .catch(reportBackgroundError);
+                  }}
+                  onToggleLike={handleToggleRouteLike}
+                  onOpenPlace={handleOpenPlaceWithReturn}
+                  onOpenRoutePreview={handleOpenRoutePreview}
+                  onRequestLogin={() => goToTab('my')}
+                />
+              )}
+
+              {activeTab === 'my' && (
+                <MyPagePanel
+                  sessionUser={sessionUser}
+                  myPage={myPage}
+                  providers={providers}
+                  myPageError={myPageError}
+                  activeTab={myPageTab}
+                  isLoggingOut={isLoggingOut}
+                  profileSaving={profileSaving}
+                  profileError={profileError}
+                  routeSubmitting={routeSubmitting}
+                  routeError={routeError}
+                  adminSummary={adminSummary}
+                  adminBusyPlaceId={adminBusyPlaceId}
+                  adminLoading={adminLoading}
+                  onChangeTab={setMyPageTab}
+                  onLogin={startProviderLogin}
+                  onRetry={async () => { if (sessionUser) { await refreshMyPageForUser(sessionUser, true); } }}
+                  onLogout={handleLogout}
+                  onSaveNickname={handleUpdateProfile}
+                  onPublishRoute={handlePublishRoute}
+                  onOpenPlace={handleOpenPlaceWithReturn}
+                  onOpenComment={(reviewId, commentId) => handleOpenCommentWithReturn(reviewId, commentId)}
+                  onOpenReview={handleOpenReviewWithReturn}
+                  onUpdateReview={handleUpdateReview}
+                  onDeleteReview={handleDeleteReview}
+                  onMarkNotificationRead={handleMarkNotificationRead}
+                  onMarkAllNotificationsRead={handleMarkAllNotificationsRead}
+                  onDeleteNotification={handleDeleteNotification}
+                  commentsHasMore={myCommentsHasMore}
+                  commentsLoadingMore={myCommentsLoadingMore}
+                  onLoadMoreComments={loadMoreMyComments}
+                  onRefreshAdmin={handleRefreshAdminImport}
+                  onToggleAdminPlace={handleToggleAdminPlace}
+                  onToggleAdminManualOverride={handleToggleAdminManualOverride}
+                />
+              )}
+            </div>
+          )}
+
+          {canNavigateBack && <FloatingBackButton onNavigateBack={handleNavigateBack} />}
+
+          <BottomNav activeTab={activeTab} onChange={handleBottomNavChange} />
+        </div>
       </div>
     </div>
   );

--- a/src/components/GlobalNotificationCenter.tsx
+++ b/src/components/GlobalNotificationCenter.tsx
@@ -1,0 +1,165 @@
+import { useState } from 'react';
+import type { MyPageResponse } from '../types';
+
+type NotificationItem = NonNullable<MyPageResponse>['notifications'][number];
+
+interface GlobalNotificationCenterProps {
+  sessionUserName: string | null;
+  notifications: NotificationItem[];
+  unreadCount: number;
+  onOpenNotification: (notification: NotificationItem) => Promise<void>;
+  onMarkAllNotificationsRead: () => Promise<void>;
+  onDeleteNotification: (notificationId: string) => Promise<void>;
+}
+
+function BellIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="review-action-button__svg" aria-hidden="true">
+      <path
+        d="M12 4.75a4.25 4.25 0 0 0-4.25 4.25v2.23c0 .92-.3 1.81-.86 2.54l-1.1 1.47a1 1 0 0 0 .8 1.6h11.82a1 1 0 0 0 .8-1.6l-1.1-1.47a4.24 4.24 0 0 1-.86-2.54V9A4.25 4.25 0 0 0 12 4.75Z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+      <path
+        d="M10.25 18.25a2 2 0 0 0 3.5 0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.8"
+        strokeLinecap="round"
+      />
+    </svg>
+  );
+}
+
+function getNotificationLabel(notification: NotificationItem) {
+  switch (notification.type) {
+    case 'review-created':
+      return '피드';
+    case 'route-published':
+      return '코스';
+    case 'review-comment':
+      return '댓글';
+    case 'comment-reply':
+      return '답글';
+    default:
+      return '알림';
+  }
+}
+
+export function GlobalNotificationCenter({
+  sessionUserName,
+  notifications,
+  unreadCount,
+  onOpenNotification,
+  onMarkAllNotificationsRead,
+  onDeleteNotification,
+}: GlobalNotificationCenterProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [busyAll, setBusyAll] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleOpenNotification(notification: NotificationItem) {
+    try {
+      setBusyId(notification.id);
+      setError(null);
+      await onOpenNotification(notification);
+      setIsOpen(false);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림을 열지 못했어요.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleMarkAll() {
+    try {
+      setBusyAll(true);
+      setError(null);
+      await onMarkAllNotificationsRead();
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림 상태를 바꾸지 못했어요.');
+    } finally {
+      setBusyAll(false);
+    }
+  }
+
+  async function handleDelete(event: React.MouseEvent<HTMLButtonElement>, notificationId: string) {
+    event.stopPropagation();
+    try {
+      setBusyId(notificationId);
+      setError(null);
+      await onDeleteNotification(notificationId);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림을 삭제하지 못했어요.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return (
+    <div className="global-notification-center">
+      <button
+        type="button"
+        className={isOpen ? 'secondary-button icon-button notification-bell is-complete' : 'secondary-button icon-button notification-bell'}
+        onClick={() => setIsOpen((current) => !current)}
+        aria-label="알림 열기"
+      >
+        <BellIcon />
+        {unreadCount > 0 && <span className="notification-bell__dot" aria-hidden="true" />}
+      </button>
+      {isOpen && (
+        <section className="global-notification-panel">
+          <div className="notification-panel__header">
+            <div>
+              <p className="eyebrow">ALERT</p>
+              <h3>{sessionUserName ? `${sessionUserName}님의 새 알림` : '새 알림'}</h3>
+              <p className="section-copy">어느 탭에 있든 여기서 바로 확인하고 이동할 수 있어요.</p>
+            </div>
+            <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAll()} disabled={busyAll || unreadCount === 0}>
+              {busyAll ? '처리 중' : '모두 읽음'}
+            </button>
+          </div>
+          {error && <p className="form-error-copy">{error}</p>}
+          <div className="notification-list">
+            {notifications.map((notification) => (
+              <article
+                key={notification.id}
+                className={notification.isRead ? 'notification-item' : 'notification-item is-unread'}
+              >
+                <button
+                  type="button"
+                  className="notification-item__content"
+                  onClick={() => void handleOpenNotification(notification)}
+                  disabled={busyId === notification.id}
+                >
+                  <div className="notification-item__top">
+                    <span className="soft-tag">{getNotificationLabel(notification)}</span>
+                    <span className="notification-item__time">
+                      {notification.actorName ? `${notification.actorName} · ${notification.createdAt}` : notification.createdAt}
+                    </span>
+                  </div>
+                  <strong>{notification.title}</strong>
+                  <p>{notification.body}</p>
+                </button>
+                <button
+                  type="button"
+                  className="notification-item__delete"
+                  aria-label="알림 삭제"
+                  onClick={(event) => void handleDelete(event, notification.id)}
+                  disabled={busyId === notification.id}
+                >
+                  ×
+                </button>
+              </article>
+            ))}
+            {notifications.length === 0 && <p className="empty-copy">새로운 알림이 아직 없어요.</p>}
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -309,18 +309,6 @@ export function MyPagePanel({
           <h2>{sessionUser.nickname}님의 기록</h2>
           <p>스탬프를 모으고 피드를 남기고, 하나의 여행 세션을 코스로 발행할 수 있어요.</p>
         </div>
-        <div className="panel-header__actions">
-          <button
-            type="button"
-            className={showNotifications ? 'secondary-button icon-button notification-bell is-complete' : 'secondary-button icon-button notification-bell'}
-            onClick={() => setShowNotifications((current) => !current)}
-            aria-label="알림 열기"
-            disabled={!myPage}
-          >
-            <BellIcon />
-            {unreadNotificationCount > 0 && <span className="notification-bell__dot" aria-hidden="true" />}
-          </button>
-        </div>
       </header>
 
       {!myPage && myPageError && (
@@ -339,9 +327,8 @@ export function MyPagePanel({
         <div className="section-title-row section-title-row--tight">
           <div>
             <p className="eyebrow">ACCOUNT</p>
-            <h3>계정과 알림 관리</h3>
+            <h3>계정 관리</h3>
           </div>
-          {myPage && <span className={unreadNotificationCount > 0 ? 'counter-pill' : 'counter-pill counter-pill--muted'}>{unreadNotificationCount}개</span>}
         </div>
         <div className="account-action-row">
           <button type="button" className={showSettings ? 'secondary-button is-complete' : 'secondary-button'} onClick={() => setShowSettings((current) => !current)}>
@@ -352,55 +339,6 @@ export function MyPagePanel({
           </button>
         </div>
       </section>
-      {showNotifications && myPage && (
-        <section className="sheet-card stack-gap notification-panel">
-          <div className="notification-panel__header">
-            <div>
-              <p className="eyebrow">ALERT</p>
-              <h3>새로운 인터랙션</h3>
-              <p className="section-copy">피드, 댓글, 코스 발행 같은 사용자 활동을 여기서 바로 확인해요.</p>
-            </div>
-            <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAllNotifications()} disabled={notificationsBusy || unreadNotificationCount === 0}>
-              {notificationsBusy ? '처리 중' : '모두 읽음'}
-            </button>
-          </div>
-          {notificationError && <p className="form-error-copy">{notificationError}</p>}
-          <div className="notification-list">
-            {myPage.notifications.map((notification) => (
-              <article
-                key={notification.id}
-                className={notification.isRead ? 'notification-item' : 'notification-item is-unread'}
-              >
-                <button
-                  type="button"
-                  className="notification-item__content"
-                  onClick={() => void handleOpenNotification(notification)}
-                  disabled={notificationBusyId === notification.id}
-                >
-                  <div className="notification-item__top">
-                    <span className="soft-tag">{getNotificationLabel(notification)}</span>
-                    <span className="notification-item__time">
-                      {notification.actorName ? `${notification.actorName} · ${notification.createdAt}` : notification.createdAt}
-                    </span>
-                  </div>
-                  <strong>{notification.title}</strong>
-                  <p>{notification.body}</p>
-                </button>
-                <button
-                  type="button"
-                  className="notification-item__delete"
-                  aria-label="알림 삭제"
-                  onClick={(event) => void handleDeleteNotificationClick(event, notification.id)}
-                  disabled={notificationBusyId === notification.id}
-                >
-                  ×
-                </button>
-              </article>
-            ))}
-            {myPage.notifications.length === 0 && <p className="empty-copy">새로운 알림이 아직 없어요.</p>}
-          </div>
-        </section>
-      )}
       {(showSettings || !sessionUser.profileCompletedAt) && (
         <section className="sheet-card stack-gap settings-card">
           <div className="settings-card__header">

--- a/src/index.css
+++ b/src/index.css
@@ -97,6 +97,59 @@ textarea {
   display: block;
 }
 
+.phone-shell__status-slot {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 40;
+  padding: 10px 84px 0 16px;
+  pointer-events: none;
+}
+
+.phone-shell__utility-slot {
+  position: absolute;
+  top: 10px;
+  right: 16px;
+  z-index: 42;
+}
+
+.phone-shell__body {
+  position: absolute;
+  inset: 0;
+}
+
+.phone-shell__body--with-status {
+  top: 62px;
+}
+
+.phone-shell__status-slot .global-status-banner {
+  position: relative;
+  left: auto;
+  right: auto;
+  top: auto;
+  pointer-events: auto;
+}
+
+.global-notification-center {
+  position: relative;
+}
+
+.global-notification-panel {
+  position: absolute;
+  top: 56px;
+  right: 0;
+  width: min(332px, calc(100vw - 40px));
+  max-height: min(62vh, 520px);
+  overflow-y: auto;
+  padding: 14px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 197, 217, 0.42);
+  background: rgba(255, 252, 249, 0.98);
+  box-shadow: 0 20px 42px rgba(66, 40, 60, 0.18);
+  backdrop-filter: blur(18px);
+}
+
 .map-stage {
   position: relative;
   width: 100%;
@@ -190,15 +243,7 @@ textarea {
   background: linear-gradient(180deg, rgba(255, 248, 251, 0.92), rgba(255, 253, 248, 0.96));
 }
 
-.page-stage--with-banner .page-panel {
-  inset: 86px 12px calc(76px + env(safe-area-inset-bottom)) 12px;
-}
-
 .global-status-banner {
-  position: absolute;
-  left: 16px;
-  right: 16px;
-  z-index: 40;
   padding: 12px 14px;
   border-radius: 18px;
   background: rgba(255, 255, 255, 0.92);
@@ -207,14 +252,6 @@ textarea {
   color: var(--ink);
   font-size: 13px;
   font-weight: 600;
-}
-
-.global-status-banner--page {
-  top: 16px;
-}
-
-.global-status-banner--map {
-  top: 158px;
 }
 
 .global-status-banner--error {


### PR DESCRIPTION
## 요약

알림 기능을 앱 전역 UX로 확장했습니다.

기존에는 지도 상단 상태 알림이 맥락별로 따로 보이고, 알림 UI도 마이페이지 내부에만 머물러 있었습니다.

- 상태 알림을 전 네비게이션 공통 상단 배너로 통합
- 종모양 알림 버튼을 전역 상단 UI로 이동
- 알림 패널을 본문을 밀지 않는 플로팅 패널로 변경
- 사용자 인터랙션 기반 알림을 저장/조회/읽음/삭제할 수 있도록 서버와 DB까지 확장

## 주요 변경사항

### 1. 전역 상태 배너
- 지도 전용 알림을 앱 공통 상단 슬롯으로 이동
- 어느 탭에 있든 동일한 위치에서 상태 메시지 확인 가능
- 지도 내부 오버레이처럼 겹치지 않도록 레이아웃 구조 조정

### 2. 전역 알림 센터
- 종모양 버튼을 전역 상단 유틸 영역으로 이동
- 마이페이지 전용 알림 UI 제거
- 알림 패널은 플로팅 방식으로 열리며 본문 레이아웃을 밀지 않음
- 새 알림이 있으면 빨간 점 표시
- 알림 클릭 시 관련 화면으로 바로 이동
  - 피드 작성 완료
  - 코스 발행 완료
  - 내 피드 댓글
  - 내 댓글 답글

### 3. 알림 서버/DB 추가
- `user_notification` 테이블 추가
- 알림 생성/목록 조회/읽음 처리/전체 읽음/삭제 API 추가
- 아래 이벤트 발생 시 알림 적재
  - 피드 작성 완료
  - 코스 발행 완료
  - 내 피드에 댓글 작성
  - 내 댓글에 답글 작성

## 확인 포인트

- 로그인한 상태에서 어떤 탭에 있든 우상단 종모양 버튼이 보여야 함
- 종모양 클릭 시 알림 패널이 플로팅으로 열려야 함
- 패널이 본문 카드를 아래로 밀지 않아야 함
- 읽지 않은 알림은 빨간 점으로 표시되어야 함
- 알림 클릭 시 해당 피드/댓글/코스 위치로 이동해야 함
- 마이페이지 내부에 별도 알림 카드/벨 버튼이 남아 있지 않아야 함