### PR TITLE
fix: stabilize app loader callbacks

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   getAuthSession,
   getMyCommentsPage,
@@ -290,7 +290,7 @@ export default function App() {
     upsertReviewCollections,
   });
 
-  async function loadMoreFeedReviews() {
+  const loadMoreFeedReviews = useCallback(async () => {
     if (feedLoadingMore || !feedHasMore) {
       return;
     }
@@ -310,9 +310,9 @@ export default function App() {
     } finally {
       setFeedLoadingMore(false);
     }
-  }
+  }, [feedHasMore, feedLoadingMore, feedNextCursor, setFeedHasMore, setFeedLoadingMore, setFeedNextCursor, setReviews]);
 
-  async function loadMoreMyComments(initial = false) {
+  const loadMoreMyComments = useCallback(async (initial = false) => {
     if (!sessionUser || !myPage) {
       return;
     }
@@ -343,7 +343,7 @@ export default function App() {
     } finally {
       setMyCommentsLoadingMore(false);
     }
-  }
+  }, [myCommentsHasMore, myCommentsLoadingMore, myCommentsNextCursor, myPage, sessionUser, setMyCommentsHasMore, setMyCommentsLoadedOnce, setMyCommentsLoadingMore, setMyCommentsNextCursor, setMyPage]);
   useAppFeedbackEffects({
     selectedPlace,
     selectedPlaceDistanceMeters,
@@ -713,6 +713,3 @@ export default function App() {
     </div>
   );
 }
-
-
-

--- a/src/hooks/useAppTabDataLoaders.ts
+++ b/src/hooks/useAppTabDataLoaders.ts
@@ -1,4 +1,5 @@
-﻿import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+﻿import { useCallback } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getAdminSummary, getCommunityRoutes, getCuratedCourses, getMySummary, getReviewFeedPage } from '../api/client';
 import type {
   AdminSummaryResponse,
@@ -52,7 +53,7 @@ export function useAppTabDataLoaders({
   setMyPage,
   setMyPageError,
 }: UseAppTabDataLoadersParams) {
-  async function fetchCommunityRoutes(sort: CommunityRouteSort, force = false) {
+  const fetchCommunityRoutes = useCallback(async (sort: CommunityRouteSort, force = false) => {
     const cached = communityRoutesCacheRef.current[sort];
     if (!force && cached) {
       setCommunityRoutes(cached);
@@ -62,9 +63,9 @@ export function useAppTabDataLoaders({
     const nextRoutes = await getCommunityRoutes(sort);
     replaceCommunityRoutes(nextRoutes, sort);
     return nextRoutes;
-  }
+  }, [communityRoutesCacheRef, replaceCommunityRoutes, setCommunityRoutes]);
 
-  async function ensureFeedReviews(force = false) {
+  const ensureFeedReviews = useCallback(async (force = false) => {
     if (!force && feedLoadedRef.current) {
       return;
     }
@@ -74,9 +75,9 @@ export function useAppTabDataLoaders({
     setFeedNextCursor(page.nextCursor);
     setFeedHasMore(Boolean(page.nextCursor));
     feedLoadedRef.current = true;
-  }
+  }, [feedLoadedRef, setFeedHasMore, setFeedNextCursor, setReviews]);
 
-  async function ensureCuratedCourses(force = false) {
+  const ensureCuratedCourses = useCallback(async (force = false) => {
     if (!force && coursesLoadedRef.current) {
       return;
     }
@@ -84,9 +85,9 @@ export function useAppTabDataLoaders({
     const response = await getCuratedCourses();
     setCourses(response.courses);
     coursesLoadedRef.current = true;
-  }
+  }, [coursesLoadedRef, setCourses]);
 
-  async function refreshAdminSummary(force = false) {
+  const refreshAdminSummary = useCallback(async (force = false) => {
     if (!sessionUser?.isAdmin) {
       setAdminSummary(null);
       return null;
@@ -104,9 +105,9 @@ export function useAppTabDataLoaders({
     } finally {
       setAdminLoading(false);
     }
-  }
+  }, [activeTab, adminSummary, sessionUser, setAdminLoading, setAdminSummary]);
 
-  async function refreshMyPageForUser(user: SessionUser | null, force = false) {
+  const refreshMyPageForUser = useCallback(async (user: SessionUser | null, force = false) => {
     if (!user) {
       setMyPage(null);
       setMyPageError(null);
@@ -130,7 +131,7 @@ export function useAppTabDataLoaders({
       }
       throw error;
     }
-  }
+  }, [activeTab, myPage, setMyPage, setMyPageError]);
 
   return {
     fetchCommunityRoutes,


### PR DESCRIPTION
## 작업 개요
리팩터링 이후 웹 체감 속도가 느려진 문제를 수정했습니다.

## 원인
일부 loader 함수가 매 렌더마다 새로 생성되면서
`useAppBootstrapLifecycle` 내부 effect가 필요 이상으로 다시 실행되고 있었습니다.

그 결과:
- bootstrap 관련 요청 재실행 가능성 증가
- my/feed/course/admin 로더 재호출 가능성 증가
- 화면 진입/탭 전환 시 체감 성능 저하

## 수정 내용
- `src/hooks/useAppTabDataLoaders.ts`
  - `fetchCommunityRoutes`
  - `ensureFeedReviews`
  - `ensureCuratedCourses`
  - `refreshAdminSummary`
  - `refreshMyPageForUser`
  를 `useCallback`으로 고정

- `src/App.tsx`
  - `loadMoreFeedReviews`
  - `loadMoreMyComments`
  를 `useCallback`으로 고정

## 기대 효과
- 불필요한 effect 재실행 감소
- 불필요한 데이터 로딩 감소
- 탭 전환 / 초기 진입 시 체감 성능 안정화

## 참고
- 로컬 전용 파일인 `deploy/api-worker-shell/.dev.vars`는 PR에 포함하지 않았습니다.
