### PR TITLE
perf: reduce app stage re-renders

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -545,6 +545,82 @@ export default function App() {
     commitRouteState,
   });
 
+  const handleMapOpenPlaceFeed = useCallback(() => {
+    if (!selectedPlace) {
+      return;
+    }
+    handleOpenPlaceFeedWithReturn(selectedPlace.id);
+  }, [handleOpenPlaceFeedWithReturn, selectedPlace]);
+
+  const handleMapOpenPlace = useCallback((placeId: string) => {
+    setSelectedRoutePreview(null);
+    openPlace(placeId);
+  }, [openPlace, setSelectedRoutePreview]);
+
+  const handleMapOpenFestival = useCallback((festivalId: string) => {
+    setSelectedRoutePreview(null);
+    openFestival(festivalId);
+  }, [openFestival, setSelectedRoutePreview]);
+
+  const handleClearRoutePreview = useCallback(() => {
+    setSelectedRoutePreview(null);
+  }, [setSelectedRoutePreview]);
+
+  const handleExpandPlaceDrawer = useCallback(() => {
+    if (!selectedPlace) {
+      return;
+    }
+    commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'full' }, 'replace');
+  }, [commitRouteState, selectedPlace]);
+
+  const handleCollapsePlaceDrawer = useCallback(() => {
+    if (!selectedPlace) {
+      return;
+    }
+    commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'partial' }, 'replace');
+  }, [commitRouteState, selectedPlace]);
+
+  const handleExpandFestivalDrawer = useCallback(() => {
+    if (!selectedFestival) {
+      return;
+    }
+    commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'full' }, 'replace');
+  }, [commitRouteState, selectedFestival]);
+
+  const handleCollapseFestivalDrawer = useCallback(() => {
+    if (!selectedFestival) {
+      return;
+    }
+    commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'partial' }, 'replace');
+  }, [commitRouteState, selectedFestival]);
+
+  const handleRequestLogin = useCallback(() => {
+    goToTab('my');
+  }, [goToTab]);
+
+  const handleLocateCurrentPosition = useCallback(() => {
+    void refreshCurrentPosition(true);
+  }, [refreshCurrentPosition]);
+
+  const handleClearPlaceFilter = useCallback(() => {
+    setFeedPlaceFilterId(null);
+  }, [setFeedPlaceFilterId]);
+
+  const handleChangeRouteSort = useCallback((sort: 'popular' | 'latest') => {
+    setCommunityRouteSort(sort);
+    void fetchCommunityRoutes(sort).catch(reportBackgroundError);
+  }, [fetchCommunityRoutes, reportBackgroundError, setCommunityRouteSort]);
+
+  const handleRetryMyPage = useCallback(async () => {
+    if (!sessionUser) {
+      return;
+    }
+    await refreshMyPageForUser(sessionUser, true);
+  }, [refreshMyPageForUser, sessionUser]);
+
+  const handleOpenCommentFromMyPage = useCallback((reviewId: string, commentId: string) => {
+    handleOpenCommentWithReturn(reviewId, commentId);
+  }, [handleOpenCommentWithReturn]);
   return (
     <div className="map-app-shell">
       <div className={[
@@ -595,43 +671,20 @@ export default function App() {
               reviewSubmitting={reviewSubmitting}
               canCreateReview={canCreateReview}
               hasCreatedReviewToday={hasCreatedReviewToday}
-              initialMapViewport={{ lat: initialMapViewport.lat, lng: initialMapViewport.lng, zoom: initialMapViewport.zoom }}
-              onOpenPlaceFeed={() => {
-                if (!selectedPlace) {
-                  return;
-                }
-                handleOpenPlaceFeedWithReturn(selectedPlace.id);
-              }}
-              onOpenPlace={(placeId) => {
-                setSelectedRoutePreview(null);
-                openPlace(placeId);
-              }}
-              onOpenFestival={(festivalId) => {
-                setSelectedRoutePreview(null);
-                openFestival(festivalId);
-              }}
+              initialMapViewport={initialMapViewport}
+              onOpenPlaceFeed={handleMapOpenPlaceFeed}
+              onOpenPlace={handleMapOpenPlace}
+              onOpenFestival={handleMapOpenFestival}
               onCloseDrawer={closeDrawer}
-              onClearRoutePreview={() => setSelectedRoutePreview(null)}
-              onExpandPlaceDrawer={() =>
-                selectedPlace &&
-                commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'full' }, 'replace')
-              }
-              onCollapsePlaceDrawer={() =>
-                selectedPlace &&
-                commitRouteState({ tab: 'map', placeId: selectedPlace.id, festivalId: null, drawerState: 'partial' }, 'replace')
-              }
-              onExpandFestivalDrawer={() =>
-                selectedFestival &&
-                commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'full' }, 'replace')
-              }
-              onCollapseFestivalDrawer={() =>
-                selectedFestival &&
-                commitRouteState({ tab: 'map', placeId: null, festivalId: selectedFestival.id, drawerState: 'partial' }, 'replace')
-              }
-              onRequestLogin={() => goToTab('my')}
+              onClearRoutePreview={handleClearRoutePreview}
+              onExpandPlaceDrawer={handleExpandPlaceDrawer}
+              onCollapsePlaceDrawer={handleCollapsePlaceDrawer}
+              onExpandFestivalDrawer={handleExpandFestivalDrawer}
+              onCollapseFestivalDrawer={handleCollapseFestivalDrawer}
+              onRequestLogin={handleRequestLogin}
               onClaimStamp={handleClaimStamp}
               onCreateReview={handleCreateReview}
-              onLocateCurrentPosition={() => void refreshCurrentPosition(true)}
+              onLocateCurrentPosition={handleLocateCurrentPosition}
               onMapViewportChange={updateMapViewportInUrl}
             />
           ) : (
@@ -675,24 +728,21 @@ export default function App() {
               onUpdateComment={handleUpdateComment}
               onDeleteComment={handleDeleteComment}
               onDeleteReview={handleDeleteReview}
-              onRequestLogin={() => goToTab('my')}
-              onClearPlaceFilter={() => setFeedPlaceFilterId(null)}
+              onRequestLogin={handleRequestLogin}
+              onClearPlaceFilter={handleClearPlaceFilter}
               onOpenPlace={handleOpenPlaceWithReturn}
               onOpenComments={handleOpenReviewComments}
               onCloseComments={handleCloseReviewComments}
-              onChangeRouteSort={(sort) => {
-                setCommunityRouteSort(sort);
-                void fetchCommunityRoutes(sort).catch(reportBackgroundError);
-              }}
+              onChangeRouteSort={handleChangeRouteSort}
               onToggleRouteLike={handleToggleRouteLike}
               onOpenRoutePreview={handleOpenRoutePreview}
               onChangeMyPageTab={setMyPageTab}
               onLogin={startProviderLogin}
-              onRetryMyPage={async () => { if (sessionUser) { await refreshMyPageForUser(sessionUser, true); } }}
+              onRetryMyPage={handleRetryMyPage}
               onLogout={handleLogout}
               onSaveNickname={handleUpdateProfile}
               onPublishRoute={handlePublishRoute}
-              onOpenCommentFromMyPage={(reviewId, commentId) => handleOpenCommentWithReturn(reviewId, commentId)}
+              onOpenCommentFromMyPage={handleOpenCommentFromMyPage}
               onOpenReview={handleOpenReviewWithReturn}
               onUpdateReview={handleUpdateReview}
               onMarkNotificationRead={handleMarkNotificationRead}

--- a/src/components/AppMapStageView.tsx
+++ b/src/components/AppMapStageView.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { MapTabStage } from './MapTabStage';
 import type {
   ApiStatus,
@@ -53,7 +54,7 @@ interface AppMapStageViewProps {
   onMapViewportChange: (lat: number, lng: number, zoom: number) => void;
 }
 
-export function AppMapStageView({
+export const AppMapStageView = memo(function AppMapStageView({
   initialMapViewport,
   onOpenPlaceFeed,
   ...props
@@ -66,4 +67,4 @@ export function AppMapStageView({
       initialMapZoom={initialMapViewport.zoom}
     />
   );
-}
+});

--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import { CourseTab } from './CourseTab';
 import { EventTab } from './EventTab';
 import { FeedTab } from './FeedTab';
@@ -84,7 +85,7 @@ interface AppPageStageProps {
   onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
 }
 
-export function AppPageStage({
+export const AppPageStage = memo(function AppPageStage({
   activeTab,
   reviews,
   sessionUser,
@@ -237,4 +238,4 @@ export function AppPageStage({
       )}
     </div>
   );
-}
+});


### PR DESCRIPTION
## 작업 개요
웹 체감 렉을 줄이기 위해 App 하위 스테이지 렌더를 안정화했습니다.

## 변경 내용
- `App`의 inline callback/inline object를 `useCallback` 기반으로 정리
- `AppMapStageView` memo 적용
- `AppPageStage` memo 적용
- stage props가 불필요하게 매번 새로 바뀌지 않도록 정리

## 기대 효과
- 부모(App) 재렌더 시 map/page stage 불필요 재렌더 감소
- 지도/피드/마이페이지 진입 시 체감 렉 완화

## 참고
- 기능 변경 없이 렌더 최적화만 적용했습니다.
- 로컬 전용 파일 `.dev.vars`는 PR에 포함하지 않았습니다.