### PR TITLE
fix: correct broken review badge text

### DIFF
--- a/deploy/api-worker-shell/index.js
+++ b/deploy/api-worker-shell/index.js
@@ -9,7 +9,6 @@ const BADGE_BY_MOOD = {
   '혼자서': '로컬 탐방',
   '데이트': '데이트 코스',
   '야경 맛집': '야경 성공',
-  '야경픽': '야경 성공',
 };
 
 const SESSION_COOKIE_NAME = 'jamissue_worker_session';

--- a/deploy/api-worker-shell/index.js
+++ b/deploy/api-worker-shell/index.js
@@ -4,10 +4,12 @@ const PROVIDERS = [
 ];
 
 const BADGE_BY_MOOD = {
-  설렘: '첫 방문',
-  친구랑: '친구 추천',
-  혼자서: '로컬 탐방',
-  야경픽: '야경 성공',
+  '설렘': '첫 방문',
+  '친구랑': '친구 추천',
+  '혼자서': '로컬 탐방',
+  '데이트': '데이트 코스',
+  '야경 맛집': '야경 성공',
+  '야경픽': '야경 성공',
 };
 
 const SESSION_COOKIE_NAME = 'jamissue_worker_session';
@@ -3207,7 +3209,7 @@ async function handleCreateReview(request, env) {
       stamp_id: Number(stampId),
       body,
       mood,
-      badge: BADGE_BY_MOOD[mood] ?? "현장 방문",
+      badge: BADGE_BY_MOOD[mood] ?? "\uD604\uC7A5 \uBC29\uBB38",
       image_url: imageUrl,
     }),
   });
@@ -3266,7 +3268,7 @@ async function handleUpdateReview(request, env, reviewId) {
     body: JSON.stringify({
       body,
       mood,
-      badge: BADGE_BY_MOOD[mood] ?? '?꾩옣 諛⑸Ц',
+      badge: BADGE_BY_MOOD[mood] ?? '\uD604\uC7A5 \uBC29\uBB38',
       updated_at: new Date().toISOString(),
     }),
   });


### PR DESCRIPTION
## 변경 내용
- 피드 수정 시 배지 텍스트가 깨져 보이던 문제를 수정했습니다.
- `데이트`, `야경 맛집` 무드에 대한 배지 매핑을 정리했습니다.
- 매핑되지 않은 경우 fallback 문구를 `현장 방문`으로 통일했습니다.

## 확인 내용
- 워커의 리뷰 생성/수정 경로에서 배지 문자열이 정상값을 사용하도록 수정했습니다.
- 브랜치를 원격에 푸시했습니다.