### PR TITLE
feat: support review image updates in my page

### DIFF
--- a/deploy/api-worker-shell/index.js
+++ b/deploy/api-worker-shell/index.js
@@ -3254,6 +3254,10 @@ async function handleUpdateReview(request, env, reviewId) {
   const payload = await readJsonBody(request);
   const body = String(payload.body ?? '').trim();
   const mood = String(payload.mood ?? '').trim();
+  const imageUrlProvided = Object.prototype.hasOwnProperty.call(payload, 'imageUrl');
+  const imageUrl = imageUrlProvided
+    ? (payload.imageUrl ? String(payload.imageUrl) : null)
+    : undefined;
 
   if (!body) {
     return jsonResponse(400, { detail: '?꾧린瑜?議곌툑 ???곸뼱 二쇱꽭??' }, env, request);
@@ -3267,6 +3271,7 @@ async function handleUpdateReview(request, env, reviewId) {
     body: JSON.stringify({
       body,
       mood,
+      ...(imageUrlProvided ? { image_url: imageUrl } : {}),
       badge: BADGE_BY_MOOD[mood] ?? '\uD604\uC7A5 \uBC29\uBB38',
       updated_at: new Date().toISOString(),
     }),

--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -75,7 +75,7 @@ interface AppPageStageProps {
   onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
   onOpenCommentFromMyPage: (reviewId: string, commentId: string) => void;
   onOpenReview: (reviewId: string) => Promise<void>;
-  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood }) => Promise<void>;
+  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
   onMarkNotificationRead: (notificationId: string) => Promise<void>;
   onMarkAllNotificationsRead: () => Promise<void>;
   onDeleteNotification: (notificationId: string) => Promise<void>;

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -27,7 +27,7 @@ interface MyPagePanelProps {
   onOpenPlace: (placeId: string) => void;
   onOpenComment: (reviewId: string, commentId: string) => void;
   onOpenReview: (reviewId: string) => void;
-  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood }) => Promise<void>;
+  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
   onDeleteReview: (reviewId: string) => Promise<void>;
   onMarkNotificationRead: (notificationId: string) => Promise<void>;
   onMarkAllNotificationsRead: () => Promise<void>;
@@ -158,6 +158,8 @@ export function MyPagePanel({
   const [editingReviewId, setEditingReviewId] = useState<string | null>(null);
   const [editingReviewBody, setEditingReviewBody] = useState('');
   const [editingReviewMood, setEditingReviewMood] = useState<ReviewMood>('혼자서');
+  const [editingReviewFile, setEditingReviewFile] = useState<File | null>(null);
+  const [editingReviewRemoveImage, setEditingReviewRemoveImage] = useState(false);
   const [reviewUpdatingId, setReviewUpdatingId] = useState<string | null>(null);
   const [reviewEditError, setReviewEditError] = useState<string | null>(null);
   const [notificationBusyId, setNotificationBusyId] = useState<string | null>(null);
@@ -188,6 +190,8 @@ export function MyPagePanel({
     setEditingReviewId(review.id);
     setEditingReviewBody(review.body);
     setEditingReviewMood(review.mood);
+    setEditingReviewFile(null);
+    setEditingReviewRemoveImage(false);
     setReviewEditError(null);
   }
 
@@ -195,6 +199,8 @@ export function MyPagePanel({
     setEditingReviewId(null);
     setEditingReviewBody('');
     setEditingReviewMood('혼자서');
+    setEditingReviewFile(null);
+    setEditingReviewRemoveImage(false);
     setReviewEditError(null);
   }
 
@@ -522,6 +528,58 @@ export function MyPagePanel({
                             disabled={reviewUpdatingId === review.id}
                           />
                         </label>
+                        <div className="route-builder-field">
+                          <span>피드 이미지</span>
+                          {review.imageUrl && !editingReviewFile && !editingReviewRemoveImage && (
+                            <img
+                              src={review.imageUrl}
+                              alt={`${review.placeName} 기존 피드 이미지`}
+                              className="review-card__image"
+                              style={{ width: '100%', maxHeight: '220px', objectFit: 'cover', borderRadius: '16px' }}
+                            />
+                          )}
+                          {editingReviewFile && <p className="section-copy">새 이미지 선택됨: {editingReviewFile.name}</p>}
+                          {review.imageUrl && editingReviewRemoveImage && !editingReviewFile && (
+                            <p className="section-copy">기존 이미지는 삭제됩니다.</p>
+                          )}
+                          <input
+                            type="file"
+                            accept="image/*"
+                            disabled={reviewUpdatingId === review.id}
+                            onChange={(event) => {
+                              const nextFile = event.target.files?.[0] ?? null;
+                              setEditingReviewFile(nextFile);
+                              if (nextFile) {
+                                setEditingReviewRemoveImage(false);
+                              }
+                            }}
+                          />
+                          <div className="chip-row compact-gap">
+                            {review.imageUrl && (
+                              <button
+                                type="button"
+                                className={editingReviewRemoveImage ? 'chip is-active' : 'chip'}
+                                onClick={() => {
+                                  setEditingReviewRemoveImage((current) => !current);
+                                  setEditingReviewFile(null);
+                                }}
+                                disabled={reviewUpdatingId === review.id}
+                              >
+                                이미지 삭제
+                              </button>
+                            )}
+                            {editingReviewFile && (
+                              <button
+                                type="button"
+                                className="chip"
+                                onClick={() => setEditingReviewFile(null)}
+                                disabled={reviewUpdatingId === review.id}
+                              >
+                                새 이미지 취소
+                              </button>
+                            )}
+                          </div>
+                        </div>
                         {reviewEditError ? <p className="form-error-copy">{reviewEditError}</p> : null}
                         <div className="review-card__actions review-card__actions--my-feed">
                           <button
@@ -542,6 +600,8 @@ export function MyPagePanel({
                               void onUpdateReview(review.id, {
                                 body: editingReviewBody.trim(),
                                 mood: editingReviewMood,
+                                file: editingReviewFile,
+                                removeImage: editingReviewRemoveImage,
                               })
                                 .then(() => {
                                   cancelEditingReview();

--- a/src/hooks/useAppReviewActions.ts
+++ b/src/hooks/useAppReviewActions.ts
@@ -124,16 +124,25 @@ export function useAppReviewActions({
     }
   }
 
-  async function handleUpdateReview(reviewId: string, payload: { body: string; mood: ReviewMood }) {
+  async function handleUpdateReview(reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) {
     if (!sessionUser) {
       goToTab('my');
       setNotice('피드를 수정하려면 먼저 로그인해 주세요.');
       return;
     }
 
+    let imageUrl: string | null | undefined;
+    if (payload.file) {
+      const uploaded = await uploadReviewImage(payload.file);
+      imageUrl = uploaded.url;
+    } else if (payload.removeImage) {
+      imageUrl = null;
+    }
+
     const updatedReview = await updateReview(reviewId, {
       body: payload.body.trim(),
       mood: payload.mood,
+      imageUrl,
     });
     patchReviewCollections(reviewId, () => updatedReview);
     setMyPage((current) => {

--- a/src/types.ts
+++ b/src/types.ts
@@ -214,6 +214,7 @@ export interface ReviewCreateRequest {
 export interface ReviewUpdateRequest {
   body: string;
   mood: ReviewMood;
+  imageUrl?: string | null;
 }
 
 export interface CommentCreateRequest {


### PR DESCRIPTION
## 변경 내용
- `마이 > 피드` 수정 화면에서만 이미지 교체/삭제가 가능하도록 추가했습니다.
- 다른 화면의 수정 진입점이나 기존 흐름은 변경하지 않았습니다.
- 리뷰 수정 시 이미지가 바뀐 경우에만 서버로 전달되도록 연결했습니다.

## 확인 내용
- 마이페이지 피드 수정에서 새 이미지 업로드가 가능하도록 연결했습니다.
- 기존 이미지를 제거하는 흐름을 추가했습니다.
- `npm run typecheck`는 현재 환경에 `tsc`가 없어 실행하지 못했습니다.