### PR TITLE
fix: prevent status banner overlap

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -114,7 +114,7 @@ textarea {
   left: 0;
   right: 0;
   z-index: 40;
-  padding: 10px 84px 0 16px;
+  padding: 10px 138px 0 16px;
   pointer-events: none;
 }
 
@@ -138,6 +138,9 @@ textarea {
   left: auto;
   right: auto;
   top: auto;
+  display: block;
+  width: 100%;
+  min-width: 0;
   pointer-events: auto;
 }
 


### PR DESCRIPTION
## Summary
- prevent the global status banner from overlapping the feedback and notification buttons
- keep the banner width constrained within the remaining header space

## Validation
- npm.cmd run typecheck
- npm.cmd run build