### PR TITLE
Align map header utility actions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -700,7 +700,7 @@ export default function App() {
             <GlobalStatusBanner tone={globalStatus.tone} message={globalStatus.message} layout={activeTab === 'map' ? 'map' : 'page'} />
           </div>
         )}
-        <div className={activeTab === 'map' ? 'phone-shell__utility-slot phone-shell__utility-slot--map' : 'phone-shell__utility-slot'}>
+        <div className="phone-shell__utility-slot">
           <GlobalFeedbackButton />
           {sessionUser && hydratedMyPage && (
             <GlobalNotificationCenter

--- a/src/styles/refinements.css
+++ b/src/styles/refinements.css
@@ -464,14 +464,8 @@ input.visually-hidden[type='file'] {
   }
 }
 
-.phone-shell__utility-slot--map {
-  top: 18px !important;
-  right: 22px !important;
-  gap: 12px !important;
-}
-
-.phone-shell__utility-slot--map .feedback-button,
-.phone-shell__utility-slot--map .notification-bell {
+.phone-shell--map .phone-shell__utility-slot .feedback-button,
+.phone-shell--map .phone-shell__utility-slot .notification-bell {
   background: rgba(255, 252, 249, 0.98) !important;
   border-color: rgba(255, 197, 217, 0.62) !important;
   box-shadow: 0 12px 24px rgba(255, 143, 183, 0.12) !important;


### PR DESCRIPTION
지도 헤더 유틸 버튼 정렬 통일

## 요약
- 지도 화면의 피드백/알림 버튼 위치를 다른 레이아웃과 동일한 기준으로 정렬했습니다.
- 지도 화면에서만 쓰던 별도 위치 오프셋을 제거했습니다.
- 버튼의 시각 톤은 유지하고, 배치 규칙만 공통 헤더 기준으로 맞췄습니다.

## 검증
- npm run build

## 비고
- 이 PR은 지도 헤더 유틸 버튼 정렬 이슈만 다룹니다.