### PR TITLE
Preserve route preview in map back navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -94,6 +94,8 @@ export default function App() {
   const setHighlightedCommentId = useAppUIStore((state) => state.setHighlightedCommentId);
   const highlightedReviewId = useAppUIStore((state) => state.highlightedReviewId);
   const setHighlightedReviewId = useAppUIStore((state) => state.setHighlightedReviewId);
+  const selectedRoutePreview = useAppUIStore((state) => state.selectedRoutePreview);
+  const setSelectedRoutePreview = useAppUIStore((state) => state.setSelectedRoutePreview);
   const returnView = useAppUIStore((state) => state.returnView);
   const setReturnView = useAppUIStore((state) => state.setReturnView);
   const [notice, setNotice] = useState<string | null>(getInitialNotice);
@@ -162,8 +164,6 @@ export default function App() {
     setAdminBusyPlaceId,
     adminLoading,
     setAdminLoading,
-    selectedRoutePreview,
-    setSelectedRoutePreview,
     communityRoutesCacheRef,
     placeReviewsCacheRef,
     feedLoadedRef,
@@ -622,17 +622,22 @@ export default function App() {
 
   const handleMapOpenPlace = useCallback((placeId: string) => {
     setSelectedRoutePreview(null);
-    openPlace(placeId);
-  }, [openPlace, setSelectedRoutePreview]);
+    commitRouteState({ tab: 'map', placeId, festivalId: null, drawerState: 'partial' }, 'push', { routePreview: null });
+  }, [commitRouteState, setSelectedRoutePreview]);
 
   const handleMapOpenFestival = useCallback((festivalId: string) => {
     setSelectedRoutePreview(null);
-    openFestival(festivalId);
-  }, [openFestival, setSelectedRoutePreview]);
+    commitRouteState({ tab: 'map', placeId: null, festivalId, drawerState: 'partial' }, 'push', { routePreview: null });
+  }, [commitRouteState, setSelectedRoutePreview]);
 
   const handleClearRoutePreview = useCallback(() => {
     setSelectedRoutePreview(null);
-  }, [setSelectedRoutePreview]);
+    commitRouteState(
+      { tab: 'map', placeId: selectedPlaceId, festivalId: selectedFestivalId, drawerState },
+      'replace',
+      { routePreview: null },
+    );
+  }, [commitRouteState, drawerState, selectedFestivalId, selectedPlaceId, setSelectedRoutePreview]);
 
   const handleExpandPlaceDrawer = useCallback(() => {
     if (!selectedPlace) {

--- a/src/hooks/useAppDataState.ts
+++ b/src/hooks/useAppDataState.ts
@@ -7,7 +7,6 @@ import type {
   CommunityRouteSort,
   FestivalItem,
   MyPageResponse,
-  RoutePreview,
   SessionUser,
   UserRoute,
 } from '../types';
@@ -39,8 +38,6 @@ export function useAppDataState(selectedPlaceId: string | null) {
   const [adminSummary, setAdminSummary] = useState<AdminSummaryResponse | null>(null);
   const [adminBusyPlaceId, setAdminBusyPlaceId] = useState<string | null>(null);
   const [adminLoading, setAdminLoading] = useState(false);
-  const [selectedRoutePreview, setSelectedRoutePreview] = useState<RoutePreview | null>(null);
-
   const communityRoutesCacheRef = useRef<Partial<Record<CommunityRouteSort, UserRoute[]>>>({});
   const placeReviewsCacheRef = useRef<Record<string, BootstrapResponse['reviews']>>({});
   const feedLoadedRef = useRef(false);
@@ -126,8 +123,6 @@ export function useAppDataState(selectedPlaceId: string | null) {
     setAdminBusyPlaceId,
     adminLoading,
     setAdminLoading,
-    selectedRoutePreview,
-    setSelectedRoutePreview,
     communityRoutesCacheRef,
     placeReviewsCacheRef,
     feedLoadedRef,

--- a/src/hooks/useAppMapActions.ts
+++ b/src/hooks/useAppMapActions.ts
@@ -3,6 +3,7 @@ import { claimStamp } from '../api/client';
 import { getCurrentDevicePosition } from '../lib/geolocation';
 import { formatDistanceMeters } from '../lib/visits';
 import type { ApiStatus, DrawerState, Place, SessionUser, StampState, Tab } from '../types';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 
 type HistoryMode = 'push' | 'replace';
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -21,6 +22,7 @@ interface UseAppMapActionsParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
     historyMode?: HistoryMode,
+    options?: RouteStateCommitOptions,
   ) => void;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<unknown>;
   formatErrorMessage: (error: unknown) => string;

--- a/src/hooks/useAppMutationActions.ts
+++ b/src/hooks/useAppMutationActions.ts
@@ -19,6 +19,7 @@ import {
 } from '../api/client';
 import { countCommentsInThread } from '../lib/reviews';
 import { getCurrentDevicePosition } from '../lib/geolocation';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 import type {
   AdminSummaryResponse,
   DrawerState,
@@ -65,6 +66,7 @@ interface UseAppMutationActionsParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
     historyMode?: HistoryMode,
+    options?: RouteStateCommitOptions,
   ) => void;
   goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
   patchReviewCollections: (reviewId: string, updater: (review: Review) => Review) => void;

--- a/src/hooks/useAppNavigationActions.ts
+++ b/src/hooks/useAppNavigationActions.ts
@@ -2,6 +2,7 @@
 import type { MyPageTabKey, Review, RoutePreview, Tab } from '../types';
 import type { ReturnViewState } from '../store/app-ui-store';
 import type { Dispatch, SetStateAction } from 'react';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 type HistoryMode = 'push' | 'replace';
@@ -33,6 +34,7 @@ interface UseAppNavigationActionsParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: 'closed' | 'partial' | 'full' },
     historyMode?: HistoryMode,
+    options?: RouteStateCommitOptions,
   ) => void;
   goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
   openPlace: (placeId: string) => void;

--- a/src/hooks/useAppNavigationHelpers.ts
+++ b/src/hooks/useAppNavigationHelpers.ts
@@ -7,6 +7,7 @@ import type {
   RoutePreview,
   Tab,
 } from '../types';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 
 interface UseAppNavigationHelpersParams {
   activeTab: Tab;
@@ -32,6 +33,7 @@ interface UseAppNavigationHelpersParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
     historyMode?: 'push' | 'replace',
+    options?: RouteStateCommitOptions,
   ) => void;
   openPlace: (placeId: string) => void;
   openFestival: (festivalId: string) => void;
@@ -108,7 +110,11 @@ export function useAppNavigationHelpers({
     }
     setSelectedRoutePreview(route);
     handleCloseReviewComments();
-    commitRouteState({ tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' }, activeTab === 'map' ? 'replace' : 'push');
+    commitRouteState(
+      { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' },
+      activeTab === 'map' ? 'replace' : 'push',
+      { routePreview: route },
+    );
   }
 
   function handleOpenPlaceWithReturn(placeId: string) {
@@ -121,7 +127,7 @@ export function useAppNavigationHelpers({
       }));
     }
     setSelectedRoutePreview(null);
-    openPlace(placeId);
+    commitRouteState({ tab: 'map', placeId, festivalId: null, drawerState: 'partial' }, 'push', { routePreview: null });
   }
 
   function handleOpenFestivalWithReturn(festivalId: string) {
@@ -129,7 +135,7 @@ export function useAppNavigationHelpers({
       setReturnView(snapshotReturnView());
     }
     setSelectedRoutePreview(null);
-    openFestival(festivalId);
+    commitRouteState({ tab: 'map', placeId: null, festivalId, drawerState: 'partial' }, 'push', { routePreview: null });
   }
 
   async function ensureReviewLoadedById(reviewId: string | null) {

--- a/src/hooks/useAppReviewActions.ts
+++ b/src/hooks/useAppReviewActions.ts
@@ -10,6 +10,7 @@ import {
   uploadReviewImage,
 } from '../api/client';
 import { countCommentsInThread, toReviewSummary } from '../lib/reviews';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 import type {
   Comment,
   DrawerState,
@@ -48,6 +49,7 @@ interface UseAppReviewActionsParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
     historyMode?: HistoryMode,
+    options?: RouteStateCommitOptions,
   ) => void;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
   patchReviewCollections: (reviewId: string, updater: (review: Review) => Review) => void;

--- a/src/hooks/useAppRouteState.ts
+++ b/src/hooks/useAppRouteState.ts
@@ -1,12 +1,20 @@
 ﻿import { useCallback, useEffect } from 'react';
 import { useAppUIStore } from '../store/app-ui-store';
-import type { DrawerState, Tab } from '../types';
+import type { DrawerState, RoutePreview, Tab } from '../types';
 
 export type RouteState = {
   tab: Tab;
   placeId: string | null;
   festivalId: string | null;
   drawerState: DrawerState;
+};
+
+export type AppHistoryState = RouteState & {
+  routePreview: RoutePreview | null;
+};
+
+export type RouteStateCommitOptions = {
+  routePreview?: RoutePreview | null;
 };
 
 const validTabs: Tab[] = ['map', 'event', 'feed', 'course', 'my'];
@@ -29,6 +37,36 @@ export function getInitialRouteState(): RouteState {
     placeId: placeId || null,
     festivalId: festivalId || null,
     drawerState: resolvedDrawer,
+  };
+}
+
+function isRoutePreview(value: unknown): value is RoutePreview {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<RoutePreview>;
+  return typeof candidate.id === 'string'
+    && typeof candidate.title === 'string'
+    && typeof candidate.subtitle === 'string'
+    && typeof candidate.mood === 'string'
+    && Array.isArray(candidate.placeIds)
+    && Array.isArray(candidate.placeNames);
+}
+
+export function getRoutePreviewFromHistoryState(historyState: unknown): RoutePreview | null {
+  if (!historyState || typeof historyState !== 'object') {
+    return null;
+  }
+
+  const routePreview = (historyState as Partial<AppHistoryState>).routePreview;
+  return isRoutePreview(routePreview) ? routePreview : null;
+}
+
+export function buildHistoryState(routeState: RouteState, routePreview: RoutePreview | null): AppHistoryState {
+  return {
+    ...routeState,
+    routePreview: routePreview ?? null,
   };
 }
 
@@ -153,6 +191,7 @@ function initializeRouteStore() {
     selectedPlaceId: routeState.tab === 'map' ? routeState.placeId : null,
     selectedFestivalId: routeState.tab === 'map' ? routeState.festivalId : null,
     drawerState: routeState.tab === 'map' ? routeState.drawerState : 'closed',
+    selectedRoutePreview: getRoutePreviewFromHistoryState(window.history.state),
   });
   routeStoreInitialized = true;
 }
@@ -164,34 +203,42 @@ export function useAppRouteState() {
   const drawerState = useAppUIStore((state) => state.drawerState);
   const selectedPlaceId = useAppUIStore((state) => state.selectedPlaceId);
   const selectedFestivalId = useAppUIStore((state) => state.selectedFestivalId);
+  const selectedRoutePreview = useAppUIStore((state) => state.selectedRoutePreview);
   const setActiveTab = useAppUIStore((state) => state.setActiveTab);
   const setDrawerState = useAppUIStore((state) => state.setDrawerState);
   const setSelectedPlaceId = useAppUIStore((state) => state.setSelectedPlaceId);
   const setSelectedFestivalId = useAppUIStore((state) => state.setSelectedFestivalId);
+  const setSelectedRoutePreview = useAppUIStore((state) => state.setSelectedRoutePreview);
 
-  const applyRouteState = useCallback((routeState: RouteState) => {
+  const applyRouteState = useCallback((routeState: RouteState, routePreview: RoutePreview | null = null) => {
     setActiveTab(routeState.tab);
     setSelectedPlaceId(routeState.tab === 'map' ? routeState.placeId : null);
     setSelectedFestivalId(routeState.tab === 'map' ? routeState.festivalId : null);
     setDrawerState(routeState.tab === 'map' ? routeState.drawerState : 'closed');
-  }, [setActiveTab, setDrawerState, setSelectedFestivalId, setSelectedPlaceId]);
+    setSelectedRoutePreview(routeState.tab === 'map' ? routePreview : null);
+  }, [setActiveTab, setDrawerState, setSelectedFestivalId, setSelectedPlaceId, setSelectedRoutePreview]);
 
   const commitRouteState = useCallback(
-    (routeState: RouteState, mode: 'push' | 'replace' = 'push') => {
-      applyRouteState(routeState);
+    (routeState: RouteState, mode: 'push' | 'replace' = 'push', options?: RouteStateCommitOptions) => {
+      const requestedRoutePreview = options && Object.prototype.hasOwnProperty.call(options, 'routePreview')
+        ? options.routePreview ?? null
+        : selectedRoutePreview;
+      const nextRoutePreview = routeState.tab === 'map' ? requestedRoutePreview : null;
+      applyRouteState(routeState, nextRoutePreview);
       if (typeof window === 'undefined') {
         return;
       }
 
       const nextUrl = buildRouteUrl(routeState);
+      const nextHistoryState = buildHistoryState(routeState, nextRoutePreview);
       if (mode === 'replace') {
-        window.history.replaceState(routeState, '', nextUrl);
+        window.history.replaceState(nextHistoryState, '', nextUrl);
         return;
       }
 
-      window.history.pushState(routeState, '', nextUrl);
+      window.history.pushState(nextHistoryState, '', nextUrl);
     },
-    [applyRouteState],
+    [applyRouteState, selectedRoutePreview],
   );
 
   const goToTab = useCallback(
@@ -204,6 +251,7 @@ export function useAppRouteState() {
           drawerState: 'closed',
         },
         mode,
+        { routePreview: null },
       );
     },
     [commitRouteState],
@@ -247,8 +295,8 @@ export function useAppRouteState() {
       return undefined;
     }
 
-    const handlePopState = () => {
-      applyRouteState(getInitialRouteState());
+    const handlePopState = (event: PopStateEvent) => {
+      applyRouteState(getInitialRouteState(), getRoutePreviewFromHistoryState(event.state));
     };
 
     window.addEventListener('popstate', handlePopState);

--- a/src/hooks/useAppShellNavigation.ts
+++ b/src/hooks/useAppShellNavigation.ts
@@ -1,5 +1,6 @@
 import type { DrawerState, MyPageTabKey, RoutePreview, Tab } from '../types';
 import type { ReturnViewState } from '../store/app-ui-store';
+import type { RouteStateCommitOptions } from './useAppRouteState';
 
 interface UseAppShellNavigationParams {
   returnView: ReturnViewState | null;
@@ -21,6 +22,7 @@ interface UseAppShellNavigationParams {
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
     historyMode?: 'push' | 'replace',
+    options?: RouteStateCommitOptions,
   ) => void;
 }
 
@@ -54,6 +56,16 @@ export function useAppShellNavigation({
     (typeof window !== 'undefined' && window.history.length > 1);
 
   function handleNavigateBack() {
+    const hasBrowserBackStepOnMap = activeTab === 'map'
+      && (selectedPlaceId !== null || selectedFestivalId !== null || drawerState !== 'closed' || selectedRoutePreview !== null)
+      && typeof window !== 'undefined'
+      && window.history.length > 1;
+
+    if (hasBrowserBackStepOnMap) {
+      window.history.back();
+      return;
+    }
+
     if (returnView) {
       setMyPageTab(returnView.myPageTab);
       setActiveCommentReviewId(returnView.activeCommentReviewId);
@@ -75,13 +87,13 @@ export function useAppShellNavigation({
       return;
     }
 
-    if (selectedRoutePreview) {
-      setSelectedRoutePreview(null);
+    if (activeCommentReviewId !== null) {
+      handleCloseReviewComments();
       return;
     }
 
-    if (activeCommentReviewId !== null) {
-      handleCloseReviewComments();
+    if (selectedRoutePreview) {
+      setSelectedRoutePreview(null);
       return;
     }
 
@@ -112,6 +124,7 @@ export function useAppShellNavigation({
           drawerState,
         },
         'replace',
+        { routePreview: null },
       );
       return;
     }

--- a/src/store/app-ui-store.ts
+++ b/src/store/app-ui-store.ts
@@ -1,5 +1,5 @@
 ﻿import { create } from 'zustand';
-import type { Category, DrawerState, MyPageTabKey, Tab } from '../types';
+import type { Category, DrawerState, MyPageTabKey, RoutePreview, Tab } from '../types';
 
 export type ReturnViewState = {
   tab: Tab;
@@ -30,6 +30,7 @@ type AppUIState = {
   activeCommentReviewId: string | null;
   highlightedCommentId: string | null;
   highlightedReviewId: string | null;
+  selectedRoutePreview: RoutePreview | null;
   returnView: ReturnViewState | null;
   setActiveTab: (value: SetterValue<Tab>) => void;
   setDrawerState: (value: SetterValue<DrawerState>) => void;
@@ -41,6 +42,7 @@ type AppUIState = {
   setActiveCommentReviewId: (value: SetterValue<string | null>) => void;
   setHighlightedCommentId: (value: SetterValue<string | null>) => void;
   setHighlightedReviewId: (value: SetterValue<string | null>) => void;
+  setSelectedRoutePreview: (value: SetterValue<RoutePreview | null>) => void;
   setReturnView: (value: SetterValue<ReturnViewState | null>) => void;
 };
 
@@ -55,6 +57,7 @@ export const useAppUIStore = create<AppUIState>((set) => ({
   activeCommentReviewId: null,
   highlightedCommentId: null,
   highlightedReviewId: null,
+  selectedRoutePreview: null,
   returnView: null,
   setActiveTab: (value) => set((state) => ({ activeTab: resolveValue(value, state.activeTab) })),
   setDrawerState: (value) => set((state) => ({ drawerState: resolveValue(value, state.drawerState) })),
@@ -66,5 +69,6 @@ export const useAppUIStore = create<AppUIState>((set) => ({
   setActiveCommentReviewId: (value) => set((state) => ({ activeCommentReviewId: resolveValue(value, state.activeCommentReviewId) })),
   setHighlightedCommentId: (value) => set((state) => ({ highlightedCommentId: resolveValue(value, state.highlightedCommentId) })),
   setHighlightedReviewId: (value) => set((state) => ({ highlightedReviewId: resolveValue(value, state.highlightedReviewId) })),
+  setSelectedRoutePreview: (value) => set((state) => ({ selectedRoutePreview: resolveValue(value, state.selectedRoutePreview) })),
   setReturnView: (value) => set((state) => ({ returnView: resolveValue(value, state.returnView) })),
 }));

--- a/test/unit/useAppNavigationHelpers.test.ts
+++ b/test/unit/useAppNavigationHelpers.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, vi } from 'vitest';
+import { useAppNavigationHelpers } from '../../src/hooks/useAppNavigationHelpers';
+import type { RoutePreview } from '../../src/types';
+
+const routePreview: RoutePreview = {
+  id: 'route-1',
+  title: '빵집 산책 코스',
+  subtitle: 'tester / 04. 05. 12:00',
+  mood: '데이트',
+  placeIds: ['place-1', 'place-2'],
+  placeNames: ['첫 번째 장소', '두 번째 장소'],
+};
+
+describe('useAppNavigationHelpers', () => {
+  it('pushes map state with route preview metadata when opening preview from the course tab', () => {
+    const setReturnView = vi.fn();
+    const setSelectedRoutePreview = vi.fn();
+    const setActiveCommentReviewId = vi.fn();
+    const setHighlightedCommentId = vi.fn();
+    const setHighlightedReviewId = vi.fn();
+    const setFeedPlaceFilterId = vi.fn();
+    const setNotice = vi.fn();
+    const goToTab = vi.fn();
+    const commitRouteState = vi.fn();
+
+    const helpers = useAppNavigationHelpers({
+      activeTab: 'course',
+      myPageTab: 'stamps',
+      activeCommentReviewId: null,
+      highlightedCommentId: null,
+      highlightedReviewId: null,
+      selectedPlaceId: null,
+      selectedFestivalId: null,
+      drawerState: 'closed',
+      feedPlaceFilterId: null,
+      reviews: [],
+      selectedPlaceReviews: [],
+      myPageReviews: [],
+      setActiveCommentReviewId,
+      setHighlightedCommentId,
+      setHighlightedReviewId,
+      setReturnView,
+      setSelectedRoutePreview,
+      setFeedPlaceFilterId,
+      setNotice,
+      goToTab,
+      commitRouteState,
+      openPlace: vi.fn(),
+      openFestival: vi.fn(),
+      upsertReviewCollections: vi.fn(),
+    });
+
+    helpers.handleOpenRoutePreview(routePreview);
+
+    expect(setReturnView).toHaveBeenCalledWith(expect.objectContaining({ tab: 'course', drawerState: 'closed' }));
+    expect(setSelectedRoutePreview).toHaveBeenCalledWith(routePreview);
+    expect(setActiveCommentReviewId).toHaveBeenCalledWith(null);
+    expect(setHighlightedCommentId).toHaveBeenCalledWith(null);
+    expect(commitRouteState).toHaveBeenCalledWith(
+      { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' },
+      'push',
+      { routePreview },
+    );
+    expect(goToTab).not.toHaveBeenCalled();
+    expect(setFeedPlaceFilterId).not.toHaveBeenCalled();
+    expect(setNotice).not.toHaveBeenCalled();
+    expect(setHighlightedReviewId).not.toHaveBeenCalled();
+  });
+});

--- a/test/unit/useAppRouteState.test.ts
+++ b/test/unit/useAppRouteState.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildHistoryState,
+  getRoutePreviewFromHistoryState,
+  type RouteState,
+} from '../../src/hooks/useAppRouteState';
+import type { RoutePreview } from '../../src/types';
+
+const routeState: RouteState = {
+  tab: 'map',
+  placeId: null,
+  festivalId: null,
+  drawerState: 'closed',
+};
+
+const routePreview: RoutePreview = {
+  id: 'route-1',
+  title: '빵집 산책 코스',
+  subtitle: 'tester / 04. 05. 12:00',
+  mood: '데이트',
+  placeIds: ['place-1', 'place-2'],
+  placeNames: ['첫 번째 장소', '두 번째 장소'],
+};
+
+describe('useAppRouteState helpers', () => {
+  it('builds a history payload that keeps the route preview metadata', () => {
+    expect(buildHistoryState(routeState, routePreview)).toEqual({
+      ...routeState,
+      routePreview,
+    });
+  });
+
+  it('restores only valid route preview data from browser history state', () => {
+    expect(getRoutePreviewFromHistoryState({ routePreview })).toEqual(routePreview);
+    expect(getRoutePreviewFromHistoryState({ routePreview: { id: 'broken' } })).toBeNull();
+    expect(getRoutePreviewFromHistoryState(null)).toBeNull();
+  });
+});

--- a/test/unit/useAppShellNavigation.test.ts
+++ b/test/unit/useAppShellNavigation.test.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useAppShellNavigation } from '../../src/hooks/useAppShellNavigation';
+import type { RoutePreview } from '../../src/types';
+
+const routePreview: RoutePreview = {
+  id: 'route-1',
+  title: '빵집 산책 코스',
+  subtitle: 'tester / 04. 05. 12:00',
+  mood: '데이트',
+  placeIds: ['place-1', 'place-2'],
+  placeNames: ['첫 번째 장소', '두 번째 장소'],
+};
+
+describe('useAppShellNavigation', () => {
+  beforeEach(() => {
+    window.history.pushState({ tab: 'course' }, '', '/?tab=course');
+  });
+
+  it('uses browser back before restoring the return view when a map drawer is open over a route preview', () => {
+    const historyBack = vi.spyOn(window.history, 'back').mockImplementation(() => undefined);
+    const setReturnView = vi.fn();
+
+    const navigation = useAppShellNavigation({
+      returnView: {
+        tab: 'course',
+        myPageTab: 'stamps',
+        activeCommentReviewId: null,
+        highlightedCommentId: null,
+        highlightedReviewId: null,
+        placeId: null,
+        festivalId: null,
+        drawerState: 'closed',
+        feedPlaceFilterId: null,
+      },
+      activeCommentReviewId: null,
+      activeTab: 'map',
+      selectedPlaceId: 'place-1',
+      selectedFestivalId: null,
+      drawerState: 'partial',
+      selectedRoutePreview: routePreview,
+      setMyPageTab: vi.fn(),
+      setActiveCommentReviewId: vi.fn(),
+      setHighlightedCommentId: vi.fn(),
+      setHighlightedReviewId: vi.fn(),
+      setFeedPlaceFilterId: vi.fn(),
+      setSelectedRoutePreview: vi.fn(),
+      setReturnView,
+      handleCloseReviewComments: vi.fn(),
+      goToTab: vi.fn(),
+      commitRouteState: vi.fn(),
+    });
+
+    navigation.handleNavigateBack();
+
+    expect(historyBack).toHaveBeenCalledTimes(1);
+    expect(setReturnView).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
지도 코스 미리보기 뒤로가기 복원

## 요약
- 코스 미리보기를 일시적인 UI 상태가 아니라 내비게이션 상태로 다루도록 수정했습니다.
- route preview 메타데이터를 브라우저 history state에 함께 저장하고 popstate에서 복원하도록 변경했습니다.
- 뒤로가기 순서를 `장소 상세 -> 코스 미리보기 -> 이전 화면`으로 맞췄습니다.
- route preview 상태를 공용 UI store에서 관리해 지도 내 이동 중에도 일관되게 복원되도록 했습니다.

## 테스트
- route preview history state 복원 unit 테스트 추가
- 코스 미리보기 진입 시 history metadata 저장 unit 테스트 추가
- 지도 뒤로가기 순서 unit 테스트 추가

## 검증
- npm run test:all
- npm run build
- backend pytest

## 비고
- 이 PR은 다음 PR인 `codex/issue-route-preview-place-detail-link`의 기반 브랜치입니다.