### PR TITLE
Run production smoke after deployments finish

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,24 +1,121 @@
 name: production-smoke
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows:
+      - cloudflare-pages
+      - cloudflare-worker
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
   contents: read
+  actions: read
 
 jobs:
   smoke:
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (
+        github.event.workflow_run.event == 'push' &&
+        github.event.workflow_run.head_branch == 'main' &&
+        github.event.workflow_run.conclusion == 'success'
+      )
     runs-on: ubuntu-latest
     env:
       SMOKE_BASE_URL: https://daejeon.jamissue.com
-      SMOKE_DEPLOY_WAIT_MS: 60000
+      SMOKE_DEPLOY_WAIT_MS: 0
       SMOKE_RETRY_ATTEMPTS: 5
       SMOKE_RETRY_DELAY_MS: 15000
+      REQUIRED_WORKFLOWS: cloudflare-pages,cloudflare-worker
+      WORKFLOW_RUN_SHA: ${{ github.event_name == 'workflow_dispatch' && github.sha || github.event.workflow_run.head_sha }}
+      WORKFLOW_RUN_BRANCH: ${{ github.event_name == 'workflow_dispatch' && github.ref_name || github.event.workflow_run.head_branch }}
     steps:
+      - uses: actions/github-script@v7
+        id: await-deployments
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const sha = process.env.WORKFLOW_RUN_SHA;
+            const branch = process.env.WORKFLOW_RUN_BRANCH;
+            const workflowNames = process.env.REQUIRED_WORKFLOWS.split(',').map((name) => name.trim()).filter(Boolean);
+            const maxAttempts = 30;
+            const delayMs = 15000;
+
+            if (!sha) {
+              core.setFailed('Missing workflow head SHA for smoke run.');
+              return;
+            }
+
+            const workflowIds = new Map();
+            const { data: workflowData } = await github.rest.actions.listRepoWorkflows({
+              owner,
+              repo,
+              per_page: 100,
+            });
+
+            for (const workflow of workflowData.workflows) {
+              workflowIds.set(workflow.name, workflow.id);
+            }
+
+            for (const name of workflowNames) {
+              if (!workflowIds.has(name)) {
+                core.setFailed(`Required workflow "${name}" was not found.`);
+                return;
+              }
+            }
+
+            async function getLatestRun(name) {
+              const workflow_id = workflowIds.get(name);
+              const { data } = await github.rest.actions.listWorkflowRuns({
+                owner,
+                repo,
+                workflow_id,
+                branch,
+                event: 'push',
+                per_page: 20,
+              });
+              return data.workflow_runs.find((run) => run.head_sha === sha) || null;
+            }
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+              const states = [];
+
+              for (const name of workflowNames) {
+                const run = await getLatestRun(name);
+                states.push({
+                  name,
+                  status: run?.status || 'missing',
+                  conclusion: run?.conclusion || 'missing',
+                  url: run?.html_url || null,
+                });
+              }
+
+              core.info(`Deployment workflow states for ${sha}: ${JSON.stringify(states)}`);
+
+              const failed = states.find((state) => state.conclusion && state.conclusion !== 'success' && state.conclusion !== 'missing');
+              if (failed) {
+                core.setFailed(`Required workflow "${failed.name}" finished with conclusion "${failed.conclusion}". ${failed.url || ''}`.trim());
+                return;
+              }
+
+              const pending = states.filter((state) => state.status !== 'completed' || state.conclusion === 'missing');
+              if (pending.length === 0) {
+                return;
+              }
+
+              if (attempt === maxAttempts) {
+                core.setFailed(`Timed out waiting for deployment workflows for ${sha}: ${JSON.stringify(pending)}`);
+                return;
+              }
+
+              await new Promise((resolve) => setTimeout(resolve, delayMs));
+            }
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.WORKFLOW_RUN_SHA }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
## 요약
- production-smoke를 `push` 직후 바로 실행하지 않고, `cloudflare-pages`와 `cloudflare-worker` 배포 workflow가 같은 SHA로 모두 성공 완료된 뒤에만 실행되도록 변경했습니다.
- 고정 60초 대기를 제거하고, GitHub Actions API로 실제 배포 workflow 완료 상태를 확인한 다음 smoke를 시작하도록 수정했습니다.
- smoke는 배포가 끝난 정확한 commit SHA를 checkout해서 검사합니다.

## 배경
- 기존에는 `main` push 후 `production-smoke`, `cloudflare-pages`, `cloudflare-worker`가 서로 독립적으로 동시에 시작했습니다.
- 그 결과 worker/pages 배포가 아직 끝나지 않았는데 smoke가 먼저 실행되어 실패할 수 있었습니다.
- 이번 변경은 시간 기반 대기가 아니라 배포 완료 자체를 기준으로 순서를 보장합니다.

## 변경 사항
- `production-smoke` 트리거를 `push`에서 `workflow_run`으로 변경
- `cloudflare-pages`, `cloudflare-worker` 완료 이벤트를 기준으로 smoke 시작
- 같은 `head_sha` 기준으로 두 workflow가 모두 성공했는지 polling 후 확인
- 완료 전에는 대기, 실패 시 즉시 실패 처리
- smoke 실행 시 해당 SHA를 checkout해서 검사

## 비고
- 기존 `Make production smoke follow runtime config (#67)` 이후, 실제 실패 원인이 배포 완료 전 smoke 실행 순서 문제로 확인되어 추가 보완한 PR입니다.

