### PR TITLE
Keep production smoke workflow name stable

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -1,4 +1,4 @@
-name: production-deploy
+name: production-smoke
 
 on:
   push:
@@ -10,7 +10,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: production-deploy-${{ github.ref }}
+  group: production-smoke-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Summary
- keep the workflow name as `production-smoke`
- keep the unified deploy-plus-smoke pipeline introduced on main
- avoid changing the external workflow name while preserving the internal ordering fix

## Changes
- workflow name: `production-deploy` -> `production-smoke`
- concurrency group name updated to match

## Notes
- `main` already contains the deploy/smoke unification from #70
- this PR only keeps the workflow name stable as a follow-up