### PR TITLE
Bypass Cloudflare challenge in production smoke

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -90,7 +90,9 @@ jobs:
       - deploy-worker
     runs-on: ubuntu-latest
     env:
-      SMOKE_BASE_URL: https://daejeon.jamissue.com
+      SMOKE_BASE_URL: https://daejeon-jamissue-pages.pages.dev
+      SMOKE_API_BASE_URL: https://daejeon-jamissue-api.yhh4433.workers.dev
+      SMOKE_FORCE_API_BASE_URL: 1
       SMOKE_DEPLOY_WAIT_MS: 0
       SMOKE_RETRY_ATTEMPTS: 5
       SMOKE_RETRY_DELAY_MS: 15000

--- a/scripts/run-smoke-checks.mjs
+++ b/scripts/run-smoke-checks.mjs
@@ -91,6 +91,9 @@ function normalizeUrl(url) {
 export function resolveApiBaseUrl({ runtimeConfig, configuredApiBaseUrl: configuredUrl, defaultApiBaseUrl = DEFAULT_API_BASE_URL }) {
   const runtimeApiBaseUrl = normalizeUrl(runtimeConfig?.apiBaseUrl);
   const overrideApiBaseUrl = normalizeUrl(configuredUrl);
+  if (process.env.SMOKE_FORCE_API_BASE_URL === "1" && overrideApiBaseUrl) {
+    return overrideApiBaseUrl;
+  }
   if (runtimeApiBaseUrl) {
     return runtimeApiBaseUrl;
   }

--- a/test/unit/smoke-checks.test.ts
+++ b/test/unit/smoke-checks.test.ts
@@ -37,6 +37,19 @@ describe('run-smoke-checks helpers', () => {
     ).toBe('https://api.workflow.example');
   });
 
+  it('can force the configured apiBaseUrl over runtime config for smoke-only origins', () => {
+    process.env.SMOKE_FORCE_API_BASE_URL = '1';
+
+    expect(
+      resolveApiBaseUrl({
+        runtimeConfig: { apiBaseUrl: 'https://api.runtime.example/' },
+        configuredApiBaseUrl: 'https://api.workflow.example/',
+      }),
+    ).toBe('https://api.workflow.example');
+
+    delete process.env.SMOKE_FORCE_API_BASE_URL;
+  });
+
   it('builds browser-like headers for smoke requests', () => {
     const headers = buildRequestHeaders('application/json,text/plain,*/*');
 


### PR DESCRIPTION
## Summary
- point production smoke at the Pages and Workers origin URLs instead of the protected custom domains
- allow the smoke script to force a smoke-only API origin override when runtime config still points at the public custom domain
- keep coverage on the same deployed frontend and worker code while avoiding Cloudflare challenge pages in GitHub Actions

## Changes
- `SMOKE_BASE_URL`: `https://daejeon-jamissue-pages.pages.dev`
- `SMOKE_API_BASE_URL`: `https://daejeon-jamissue-api.yhh4433.workers.dev`
- `SMOKE_FORCE_API_BASE_URL=1`
- added unit coverage for forced smoke API override

## Validation
- `npm run test:unit`
- `npm run build`