### PR TITLE
Refactor map stage prop contracts

### DIFF
--- a/src/components/AppMapStageView.tsx
+++ b/src/components/AppMapStageView.tsx
@@ -65,11 +65,61 @@ export const AppMapStageView = memo(function AppMapStageView({
 }: AppMapStageViewProps) {
   return (
     <MapTabStage
-      {...mapData}
-      {...mapActions}
-      onOpenFeedReview={mapActions.onOpenPlaceFeed}
-      initialMapCenter={{ lat: mapData.initialMapViewport.lat, lng: mapData.initialMapViewport.lng }}
-      initialMapZoom={mapData.initialMapViewport.zoom}
+      mapData={{
+        activeCategory: mapData.activeCategory,
+        filteredPlaces: mapData.filteredPlaces,
+        festivals: mapData.festivals,
+        currentPosition: mapData.currentPosition,
+        mapLocationStatus: mapData.mapLocationStatus,
+        mapLocationFocusKey: mapData.mapLocationFocusKey,
+        routePreviewPlaces: mapData.routePreviewPlaces,
+      }}
+      routePreviewData={{
+        routePreview: mapData.routePreview,
+        onClearRoutePreview: mapActions.onClearRoutePreview,
+        onOpenRoutePreviewPlace: mapActions.onOpenRoutePreviewPlace,
+      }}
+      viewportData={{
+        initialMapCenter: { lat: mapData.initialMapViewport.lat, lng: mapData.initialMapViewport.lng },
+        initialMapZoom: mapData.initialMapViewport.zoom,
+        onLocateCurrentPosition: mapActions.onLocateCurrentPosition,
+        onMapViewportChange: mapActions.onMapViewportChange,
+      }}
+      placeSheet={{
+        selectedPlace: mapData.selectedPlace,
+        drawerState: mapData.drawerState,
+        sessionUser: mapData.sessionUser,
+        selectedPlaceReviews: mapData.selectedPlaceReviews,
+        visitCount: mapData.visitCount,
+        latestStamp: mapData.latestStamp,
+        todayStamp: mapData.todayStamp,
+        stampActionStatus: mapData.stampActionStatus,
+        stampActionMessage: mapData.stampActionMessage,
+        reviewProofMessage: mapData.reviewProofMessage,
+        reviewError: mapData.reviewError,
+        reviewSubmitting: mapData.reviewSubmitting,
+        canCreateReview: mapData.canCreateReview,
+        hasCreatedReviewToday: mapData.hasCreatedReviewToday,
+        onOpenPlace: mapActions.onOpenPlace,
+        onOpenFeedReview: mapActions.onOpenPlaceFeed,
+        onCloseDrawer: mapActions.onCloseDrawer,
+        onExpandPlaceDrawer: mapActions.onExpandPlaceDrawer,
+        onCollapsePlaceDrawer: mapActions.onCollapsePlaceDrawer,
+        onRequestLogin: mapActions.onRequestLogin,
+        onClaimStamp: mapActions.onClaimStamp,
+        onCreateReview: mapActions.onCreateReview,
+      }}
+      festivalSheet={{
+        selectedFestival: mapData.selectedFestival,
+        drawerState: mapData.drawerState,
+        onOpenFestival: mapActions.onOpenFestival,
+        onCloseDrawer: mapActions.onCloseDrawer,
+        onExpandFestivalDrawer: mapActions.onExpandFestivalDrawer,
+        onCollapseFestivalDrawer: mapActions.onCollapseFestivalDrawer,
+      }}
+      mapActions={{
+        setActiveCategory: mapActions.setActiveCategory,
+      }}
     />
   );
 });

--- a/src/components/MapTabStage.tsx
+++ b/src/components/MapTabStage.tsx
@@ -16,91 +16,70 @@ import type {
 } from '../types';
 
 interface MapTabStageProps {
-  activeCategory: Category;
-  setActiveCategory: (category: Category) => void;
-  filteredPlaces: Place[];
-  festivals: FestivalItem[];
-  selectedPlace: Place | null;
-  selectedFestival: FestivalItem | null;
-  currentPosition: { latitude: number; longitude: number } | null;
-  mapLocationStatus: ApiStatus;
-  mapLocationFocusKey: number;
-  drawerState: DrawerState;
-  sessionUser: SessionUser | null;
-  selectedPlaceReviews: BootstrapResponse['reviews'];
-  routePreview: RoutePreview | null;
-  routePreviewPlaces: Place[];
-  visitCount: number;
-  latestStamp: BootstrapResponse['stamps']['logs'][number] | null;
-  todayStamp: BootstrapResponse['stamps']['logs'][number] | null;
-  stampActionStatus: ApiStatus;
-  stampActionMessage: string;
-  reviewProofMessage: string;
-  reviewError: string | null;
-  reviewSubmitting: boolean;
-  canCreateReview: boolean;
-  hasCreatedReviewToday: boolean;
-  onOpenFeedReview: () => void;
-  onClearRoutePreview: () => void;
-  initialMapCenter?: { lat: number; lng: number };
-  initialMapZoom?: number;
-  onOpenPlace: (placeId: string) => void;
-  onOpenRoutePreviewPlace: (placeId: string) => void;
-  onOpenFestival: (festivalId: string) => void;
-  onCloseDrawer: () => void;
-  onExpandPlaceDrawer: () => void;
-  onCollapsePlaceDrawer: () => void;
-  onExpandFestivalDrawer: () => void;
-  onCollapseFestivalDrawer: () => void;
-  onRequestLogin: () => void;
-  onClaimStamp: (place: Place) => Promise<void>;
-  onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
-  onLocateCurrentPosition: () => void;
-  onMapViewportChange: (lat: number, lng: number, zoom: number) => void;
+  mapData: {
+    activeCategory: Category;
+    filteredPlaces: Place[];
+    festivals: FestivalItem[];
+    currentPosition: { latitude: number; longitude: number } | null;
+    mapLocationStatus: ApiStatus;
+    mapLocationFocusKey: number;
+    routePreviewPlaces: Place[];
+  };
+  routePreviewData: {
+    routePreview: RoutePreview | null;
+    onClearRoutePreview: () => void;
+    onOpenRoutePreviewPlace: (placeId: string) => void;
+  };
+  viewportData: {
+    initialMapCenter?: { lat: number; lng: number };
+    initialMapZoom?: number;
+    onLocateCurrentPosition: () => void;
+    onMapViewportChange: (lat: number, lng: number, zoom: number) => void;
+  };
+  placeSheet: {
+    selectedPlace: Place | null;
+    drawerState: DrawerState;
+    sessionUser: SessionUser | null;
+    selectedPlaceReviews: BootstrapResponse['reviews'];
+    visitCount: number;
+    latestStamp: BootstrapResponse['stamps']['logs'][number] | null;
+    todayStamp: BootstrapResponse['stamps']['logs'][number] | null;
+    stampActionStatus: ApiStatus;
+    stampActionMessage: string;
+    reviewProofMessage: string;
+    reviewError: string | null;
+    reviewSubmitting: boolean;
+    canCreateReview: boolean;
+    hasCreatedReviewToday: boolean;
+    onOpenPlace: (placeId: string) => void;
+    onOpenFeedReview: () => void;
+    onCloseDrawer: () => void;
+    onExpandPlaceDrawer: () => void;
+    onCollapsePlaceDrawer: () => void;
+    onRequestLogin: () => void;
+    onClaimStamp: (place: Place) => Promise<void>;
+    onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
+  };
+  festivalSheet: {
+    selectedFestival: FestivalItem | null;
+    drawerState: DrawerState;
+    onOpenFestival: (festivalId: string) => void;
+    onCloseDrawer: () => void;
+    onExpandFestivalDrawer: () => void;
+    onCollapseFestivalDrawer: () => void;
+  };
+  mapActions: {
+    setActiveCategory: (category: Category) => void;
+  };
 }
 
 export function MapTabStage({
-  activeCategory,
-  setActiveCategory,
-  filteredPlaces,
-  festivals,
-  selectedPlace,
-  selectedFestival,
-  currentPosition,
-  mapLocationStatus,
-  mapLocationFocusKey,
-  drawerState,
-  sessionUser,
-  selectedPlaceReviews,
-  routePreview,
-  routePreviewPlaces,
-  visitCount,
-  latestStamp,
-  todayStamp,
-  stampActionStatus,
-  stampActionMessage,
-  reviewProofMessage,
-  reviewError,
-  reviewSubmitting,
-  canCreateReview,
-  hasCreatedReviewToday,
-  onOpenFeedReview,
-  onClearRoutePreview,
-  initialMapCenter,
-  initialMapZoom,
-  onOpenPlace,
-  onOpenRoutePreviewPlace,
-  onOpenFestival,
-  onCloseDrawer,
-  onExpandPlaceDrawer,
-  onCollapsePlaceDrawer,
-  onExpandFestivalDrawer,
-  onCollapseFestivalDrawer,
-  onRequestLogin,
-  onClaimStamp,
-  onCreateReview,
-  onLocateCurrentPosition,
-  onMapViewportChange,
+  mapData,
+  routePreviewData,
+  viewportData,
+  placeSheet,
+  festivalSheet,
+  mapActions,
 }: MapTabStageProps) {
   return (
     <div className="map-stage">
@@ -119,14 +98,14 @@ export function MapTabStage({
       <div className="map-filter-strip">
         <div className="chip-row compact-gap">
           {categoryItems.map((item) => {
-            const isActive = item.key === activeCategory;
+            const isActive = item.key === mapData.activeCategory;
             const info = item.key === 'all' ? null : categoryInfo[item.key];
             return (
               <button
                 key={item.key}
                 type="button"
                 className={isActive ? 'chip is-active map-filter-chip' : 'chip map-filter-chip'}
-                onClick={() => setActiveCategory(item.key)}
+                onClick={() => mapActions.setActiveCategory(item.key)}
                 style={
                   info
                     ? {
@@ -145,52 +124,57 @@ export function MapTabStage({
       </div>
 
       <NaverMap
-        places={filteredPlaces}
-        festivals={festivals}
-        selectedPlaceId={selectedPlace?.id ?? null}
-        selectedFestivalId={selectedFestival?.id ?? null}
-        onSelectPlace={onOpenPlace}
-        onSelectFestival={onOpenFestival}
-        currentPosition={currentPosition}
-        currentLocationStatus={mapLocationStatus}
+        places={mapData.filteredPlaces}
+        festivals={mapData.festivals}
+        selectedPlaceId={placeSheet.selectedPlace?.id ?? null}
+        selectedFestivalId={festivalSheet.selectedFestival?.id ?? null}
+        onSelectPlace={placeSheet.onOpenPlace}
+        onSelectFestival={festivalSheet.onOpenFestival}
+        currentPosition={mapData.currentPosition}
+        currentLocationStatus={mapData.mapLocationStatus}
         currentLocationMessage={null}
-        focusCurrentLocationKey={mapLocationFocusKey}
-        onLocateCurrentPosition={onLocateCurrentPosition}
-        initialCenter={initialMapCenter}
-        initialZoom={initialMapZoom}
-        onViewportChange={onMapViewportChange}
-        routePreviewPlaces={routePreviewPlaces}
+        focusCurrentLocationKey={mapData.mapLocationFocusKey}
+        onLocateCurrentPosition={viewportData.onLocateCurrentPosition}
+        initialCenter={viewportData.initialMapCenter}
+        initialZoom={viewportData.initialMapZoom}
+        onViewportChange={viewportData.onMapViewportChange}
+        routePreviewPlaces={mapData.routePreviewPlaces}
         height="100%"
       />
 
-      {!selectedPlace && !selectedFestival && routePreview && (
+      {!placeSheet.selectedPlace && !festivalSheet.selectedFestival && routePreviewData.routePreview && (
         <section className="map-route-preview-card">
           <div className="map-route-preview-card__top">
             <div>
               <p className="eyebrow">ROUTE PREVIEW</p>
-              <h3>{routePreview.title}</h3>
-              <p className="section-copy">{routePreview.subtitle}</p>
+              <h3>{routePreviewData.routePreview.title}</h3>
+              <p className="section-copy">{routePreviewData.routePreview.subtitle}</p>
             </div>
-            <button type="button" className="map-route-preview-card__close" onClick={onClearRoutePreview} aria-label="경로 미리보기 닫기">
+            <button
+              type="button"
+              className="map-route-preview-card__close"
+              onClick={routePreviewData.onClearRoutePreview}
+              aria-label="경로 미리보기 닫기"
+            >
               <span aria-hidden="true">{'\u00D7'}</span>
             </button>
           </div>
           <div className="course-card__places community-route-places map-route-preview-card__places">
-            {routePreview.placeIds.map((placeId, index) => (
+            {routePreviewData.routePreview.placeIds.map((placeId, index) => (
               <button
-                key={routePreview.id + '-' + placeId}
+                key={routePreviewData.routePreview!.id + '-' + placeId}
                 type="button"
                 className="soft-tag soft-tag--button course-card__place"
-                onClick={() => onOpenRoutePreviewPlace(placeId)}
+                onClick={() => routePreviewData.onOpenRoutePreviewPlace(placeId)}
               >
-                {index + 1}. {routePreview.placeNames[index] ?? placeId}
+                {index + 1}. {routePreviewData.routePreview!.placeNames[index] ?? placeId}
               </button>
             ))}
           </div>
         </section>
       )}
 
-      {!selectedPlace && !selectedFestival && (
+      {!placeSheet.selectedPlace && !festivalSheet.selectedFestival && (
         <section className="map-drawer-teaser">
           <span className="map-drawer-teaser__handle" aria-hidden="true" />
           <div className="map-drawer-teaser__peek" aria-hidden="true">
@@ -206,37 +190,37 @@ export function MapTabStage({
       )}
 
       <PlaceDetailSheet
-        place={selectedPlace}
-        reviews={selectedPlaceReviews}
-        isOpen={Boolean(selectedPlace) && drawerState !== 'closed'}
-        drawerState={drawerState}
-        loggedIn={Boolean(sessionUser)}
-        visitCount={visitCount}
-        latestStamp={latestStamp}
-        todayStamp={todayStamp}
-        hasCreatedReviewToday={hasCreatedReviewToday}
-        stampActionStatus={stampActionStatus}
-        stampActionMessage={stampActionMessage}
-        reviewProofMessage={reviewProofMessage}
-        reviewError={reviewError}
-        reviewSubmitting={reviewSubmitting}
-        canCreateReview={canCreateReview}
-        onOpenFeedReview={onOpenFeedReview}
-        onClose={onCloseDrawer}
-        onExpand={onExpandPlaceDrawer}
-        onCollapse={onCollapsePlaceDrawer}
-        onRequestLogin={onRequestLogin}
-        onClaimStamp={onClaimStamp}
-        onCreateReview={onCreateReview}
+        place={placeSheet.selectedPlace}
+        reviews={placeSheet.selectedPlaceReviews}
+        isOpen={Boolean(placeSheet.selectedPlace) && placeSheet.drawerState !== 'closed'}
+        drawerState={placeSheet.drawerState}
+        loggedIn={Boolean(placeSheet.sessionUser)}
+        visitCount={placeSheet.visitCount}
+        latestStamp={placeSheet.latestStamp}
+        todayStamp={placeSheet.todayStamp}
+        hasCreatedReviewToday={placeSheet.hasCreatedReviewToday}
+        stampActionStatus={placeSheet.stampActionStatus}
+        stampActionMessage={placeSheet.stampActionMessage}
+        reviewProofMessage={placeSheet.reviewProofMessage}
+        reviewError={placeSheet.reviewError}
+        reviewSubmitting={placeSheet.reviewSubmitting}
+        canCreateReview={placeSheet.canCreateReview}
+        onOpenFeedReview={placeSheet.onOpenFeedReview}
+        onClose={placeSheet.onCloseDrawer}
+        onExpand={placeSheet.onExpandPlaceDrawer}
+        onCollapse={placeSheet.onCollapsePlaceDrawer}
+        onRequestLogin={placeSheet.onRequestLogin}
+        onClaimStamp={placeSheet.onClaimStamp}
+        onCreateReview={placeSheet.onCreateReview}
       />
 
       <FestivalDetailSheet
-        festival={selectedFestival}
-        isOpen={Boolean(selectedFestival) && drawerState !== 'closed'}
-        drawerState={drawerState}
-        onClose={onCloseDrawer}
-        onExpand={onExpandFestivalDrawer}
-        onCollapse={onCollapseFestivalDrawer}
+        festival={festivalSheet.selectedFestival}
+        isOpen={Boolean(festivalSheet.selectedFestival) && festivalSheet.drawerState !== 'closed'}
+        drawerState={festivalSheet.drawerState}
+        onClose={festivalSheet.onCloseDrawer}
+        onExpand={festivalSheet.onExpandFestivalDrawer}
+        onCollapse={festivalSheet.onCollapseFestivalDrawer}
       />
     </div>
   );

--- a/test/integration/map-route-preview-card.test.tsx
+++ b/test/integration/map-route-preview-card.test.tsx
@@ -20,63 +20,77 @@ describe('MapTabStage route preview card', () => {
   it('opens the selected place detail directly from the route preview list', () => {
     const onOpenRoutePreviewPlace = vi.fn();
     const places = [
-      { ...placeFixture, id: 'place-1', name: '첫 번째 장소' },
-      { ...placeFixture, id: 'place-2', positionId: 'position-2', name: '두 번째 장소', latitude: 36.351, longitude: 127.385 },
+      { ...placeFixture, id: 'place-1', name: '첫번째 장소' },
+      { ...placeFixture, id: 'place-2', positionId: 'position-2', name: '두번째 장소', latitude: 36.351, longitude: 127.385 },
     ];
     const routePreview: RoutePreview = {
       id: 'route-1',
-      title: '빵집 산책 코스',
+      title: '맛집 탐방 코스',
       subtitle: 'tester / 04. 05. 12:00',
-      mood: '데이트',
+      mood: 'exciting',
       placeIds: places.map((place) => place.id),
       placeNames: places.map((place) => place.name),
     };
 
     render(
       <MapTabStage
-        activeCategory="all"
-        setActiveCategory={vi.fn()}
-        filteredPlaces={places}
-        festivals={[]}
-        selectedPlace={null}
-        selectedFestival={null}
-        currentPosition={null}
-        mapLocationStatus="idle"
-        mapLocationFocusKey={0}
-        drawerState="closed"
-        sessionUser={sessionUserFixture}
-        selectedPlaceReviews={[createReviewFixture()]}
-        routePreview={routePreview}
-        routePreviewPlaces={places}
-        visitCount={0}
-        latestStamp={null}
-        todayStamp={null}
-        stampActionStatus="idle"
-        stampActionMessage="스탬프 안내"
-        reviewProofMessage="리뷰 안내"
-        reviewError={null}
-        reviewSubmitting={false}
-        canCreateReview={false}
-        hasCreatedReviewToday={false}
-        onOpenFeedReview={vi.fn()}
-        onClearRoutePreview={vi.fn()}
-        onOpenPlace={vi.fn()}
-        onOpenRoutePreviewPlace={onOpenRoutePreviewPlace}
-        onOpenFestival={vi.fn()}
-        onCloseDrawer={vi.fn()}
-        onExpandPlaceDrawer={vi.fn()}
-        onCollapsePlaceDrawer={vi.fn()}
-        onExpandFestivalDrawer={vi.fn()}
-        onCollapseFestivalDrawer={vi.fn()}
-        onRequestLogin={vi.fn()}
-        onClaimStamp={vi.fn()}
-        onCreateReview={vi.fn()}
-        onLocateCurrentPosition={vi.fn()}
-        onMapViewportChange={vi.fn()}
+        mapData={{
+          activeCategory: 'all',
+          filteredPlaces: places,
+          festivals: [],
+          currentPosition: null,
+          mapLocationStatus: 'idle',
+          mapLocationFocusKey: 0,
+          routePreviewPlaces: places,
+        }}
+        routePreviewData={{
+          routePreview,
+          onClearRoutePreview: vi.fn(),
+          onOpenRoutePreviewPlace,
+        }}
+        viewportData={{
+          onLocateCurrentPosition: vi.fn(),
+          onMapViewportChange: vi.fn(),
+        }}
+        placeSheet={{
+          selectedPlace: null,
+          drawerState: 'closed',
+          sessionUser: sessionUserFixture,
+          selectedPlaceReviews: [createReviewFixture()],
+          visitCount: 0,
+          latestStamp: null,
+          todayStamp: null,
+          stampActionStatus: 'idle',
+          stampActionMessage: '스탬프 안내',
+          reviewProofMessage: '리뷰 안내',
+          reviewError: null,
+          reviewSubmitting: false,
+          canCreateReview: false,
+          hasCreatedReviewToday: false,
+          onOpenPlace: vi.fn(),
+          onOpenFeedReview: vi.fn(),
+          onCloseDrawer: vi.fn(),
+          onExpandPlaceDrawer: vi.fn(),
+          onCollapsePlaceDrawer: vi.fn(),
+          onRequestLogin: vi.fn(),
+          onClaimStamp: vi.fn(),
+          onCreateReview: vi.fn(),
+        }}
+        festivalSheet={{
+          selectedFestival: null,
+          drawerState: 'closed',
+          onOpenFestival: vi.fn(),
+          onCloseDrawer: vi.fn(),
+          onExpandFestivalDrawer: vi.fn(),
+          onCollapseFestivalDrawer: vi.fn(),
+        }}
+        mapActions={{
+          setActiveCategory: vi.fn(),
+        }}
       />,
     );
 
-    fireEvent.click(screen.getByRole('button', { name: '2. 두 번째 장소' }));
+    fireEvent.click(screen.getByRole('button', { name: '2. 두번째 장소' }));
 
     expect(onOpenRoutePreviewPlace).toHaveBeenCalledWith('place-2');
   });


### PR DESCRIPTION
## 요약
- MapTabStage prop 계약을 mapData, routePreviewData, viewportData, placeSheet, festivalSheet, mapActions로 분리했습니다.
- AppMapStageView에서 지도 스테이지로 넘기는 데이터를 의미 단위로 묶어 상위 wiring을 단순화했습니다.
- route preview 카드에서 장소 상세를 여는 동선이 새 계약에서도 유지되도록 integration 테스트를 갱신했습니다.

## 검증
- npm run typecheck
- npm run test:integration -- map-route-preview-card
- npm run build

## 비고
- 지도 스테이지 prop surface 축소에만 집중한 PR입니다.