### PR TITLE
Refactor feed and my-page panel contracts

### DIFF
--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -121,32 +121,42 @@ export const AppPageStage = memo(function AppPageStage({
     <div className="page-stage">
       {activeTab === 'feed' && (
         <FeedTab
-          reviews={feedData.reviews}
-          sessionUser={sharedData.sessionUser}
-          reviewLikeUpdatingId={feedData.reviewLikeUpdatingId}
-          placeFilterId={feedData.feedPlaceFilterId}
-          placeFilterName={feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null}
-          commentSubmittingReviewId={feedData.commentSubmittingReviewId}
-          commentMutatingId={feedData.commentMutatingId}
-          deletingReviewId={feedData.deletingReviewId}
-          activeCommentReviewId={feedData.activeCommentReviewId}
-          activeCommentReviewComments={feedData.activeCommentReviewComments}
-          activeCommentReviewStatus={feedData.activeCommentReviewStatus}
-          highlightedCommentId={feedData.highlightedCommentId}
-          highlightedReviewId={feedData.highlightedReviewId}
-          hasMore={feedData.feedHasMore && !feedData.feedPlaceFilterId}
-          loadingMore={feedData.feedLoadingMore}
-          onLoadMore={feedActions.onLoadMoreFeed}
-          onToggleReviewLike={feedActions.onToggleReviewLike}
-          onCreateComment={feedActions.onCreateComment}
-          onUpdateComment={feedActions.onUpdateComment}
-          onDeleteComment={feedActions.onDeleteComment}
-          onDeleteReview={feedActions.onDeleteReview}
-          onRequestLogin={sharedActions.onRequestLogin}
-          onClearPlaceFilter={feedActions.onClearPlaceFilter}
-          onOpenPlace={sharedActions.onOpenPlace}
-          onOpenComments={feedActions.onOpenComments}
-          onCloseComments={feedActions.onCloseComments}
+          feedData={{
+            reviews: feedData.reviews,
+            placeFilterId: feedData.feedPlaceFilterId,
+            placeFilterName: feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null,
+            highlightedReviewId: feedData.highlightedReviewId,
+            reviewLikeUpdatingId: feedData.reviewLikeUpdatingId,
+            hasMore: feedData.feedHasMore && !feedData.feedPlaceFilterId,
+            loadingMore: feedData.feedLoadingMore,
+          }}
+          commentSheetData={{
+            activeCommentReviewId: feedData.activeCommentReviewId,
+            activeCommentReviewComments: feedData.activeCommentReviewComments,
+            activeCommentReviewStatus: feedData.activeCommentReviewStatus,
+            highlightedCommentId: feedData.highlightedCommentId,
+            commentSubmittingReviewId: feedData.commentSubmittingReviewId,
+            commentMutatingId: feedData.commentMutatingId,
+            deletingReviewId: feedData.deletingReviewId,
+          }}
+          sharedData={{
+            sessionUser: sharedData.sessionUser,
+          }}
+          feedActions={{
+            onLoadMore: feedActions.onLoadMoreFeed,
+            onToggleReviewLike: feedActions.onToggleReviewLike,
+            onCreateComment: feedActions.onCreateComment,
+            onUpdateComment: feedActions.onUpdateComment,
+            onDeleteComment: feedActions.onDeleteComment,
+            onDeleteReview: feedActions.onDeleteReview,
+            onClearPlaceFilter: feedActions.onClearPlaceFilter,
+            onOpenComments: feedActions.onOpenComments,
+            onCloseComments: feedActions.onCloseComments,
+          }}
+          sharedActions={{
+            onRequestLogin: sharedActions.onRequestLogin,
+            onOpenPlace: sharedActions.onOpenPlace,
+          }}
         />
       )}
 
@@ -170,39 +180,53 @@ export const AppPageStage = memo(function AppPageStage({
 
       {activeTab === 'my' && (
         <MyPagePanel
-          sessionUser={sharedData.sessionUser}
-          myPage={myPageData.myPage}
-          providers={myPageData.providers}
-          myPageError={myPageData.myPageError}
-          activeTab={myPageData.myPageTab}
-          isLoggingOut={myPageData.isLoggingOut}
-          profileSaving={myPageData.profileSaving}
-          profileError={myPageData.profileError}
-          routeSubmitting={myPageData.routeSubmitting}
-          routeError={myPageData.routeError}
-          adminSummary={myPageData.adminSummary}
-          adminBusyPlaceId={myPageData.adminBusyPlaceId}
-          adminLoading={myPageData.adminLoading}
-          onChangeTab={myPageActions.onChangeMyPageTab}
-          onLogin={myPageActions.onLogin}
-          onRetry={myPageActions.onRetryMyPage}
-          onLogout={myPageActions.onLogout}
-          onSaveNickname={myPageActions.onSaveNickname}
-          onPublishRoute={myPageActions.onPublishRoute}
-          onOpenPlace={sharedActions.onOpenPlace}
-          onOpenComment={myPageActions.onOpenCommentFromMyPage}
-          onOpenReview={myPageActions.onOpenReview}
-          onUpdateReview={myPageActions.onUpdateReview}
-          onDeleteReview={myPageActions.onDeleteReview}
-          onMarkNotificationRead={myPageActions.onMarkNotificationRead}
-          onMarkAllNotificationsRead={myPageActions.onMarkAllNotificationsRead}
-          onDeleteNotification={myPageActions.onDeleteNotification}
-          commentsHasMore={myPageData.commentsHasMore}
-          commentsLoadingMore={myPageData.commentsLoadingMore}
-          onLoadMoreComments={myPageActions.onLoadMoreComments}
-          onRefreshAdmin={myPageActions.onRefreshAdmin}
-          onToggleAdminPlace={myPageActions.onToggleAdminPlace}
-          onToggleAdminManualOverride={myPageActions.onToggleAdminManualOverride}
+          sessionData={{
+            sessionUser: sharedData.sessionUser,
+            myPage: myPageData.myPage,
+            providers: myPageData.providers,
+            myPageError: myPageData.myPageError,
+          }}
+          panelState={{
+            activeTab: myPageData.myPageTab,
+            isLoggingOut: myPageData.isLoggingOut,
+            profileSaving: myPageData.profileSaving,
+            profileError: myPageData.profileError,
+            routeSubmitting: myPageData.routeSubmitting,
+            routeError: myPageData.routeError,
+            commentsHasMore: myPageData.commentsHasMore,
+            commentsLoadingMore: myPageData.commentsLoadingMore,
+          }}
+          reviewActions={{
+            onOpenPlace: sharedActions.onOpenPlace,
+            onOpenComment: myPageActions.onOpenCommentFromMyPage,
+            onOpenReview: myPageActions.onOpenReview,
+            onUpdateReview: myPageActions.onUpdateReview,
+            onDeleteReview: myPageActions.onDeleteReview,
+            onLoadMoreComments: myPageActions.onLoadMoreComments,
+          }}
+          panelActions={{
+            onChangeTab: myPageActions.onChangeMyPageTab,
+            onLogin: myPageActions.onLogin,
+            onRetry: myPageActions.onRetryMyPage,
+            onLogout: myPageActions.onLogout,
+            onSaveNickname: myPageActions.onSaveNickname,
+            onPublishRoute: myPageActions.onPublishRoute,
+          }}
+          notificationActions={{
+            onMarkNotificationRead: myPageActions.onMarkNotificationRead,
+            onMarkAllNotificationsRead: myPageActions.onMarkAllNotificationsRead,
+            onDeleteNotification: myPageActions.onDeleteNotification,
+          }}
+          adminData={{
+            adminSummary: myPageData.adminSummary,
+            adminBusyPlaceId: myPageData.adminBusyPlaceId,
+            adminLoading: myPageData.adminLoading,
+          }}
+          adminActions={{
+            onRefreshAdmin: myPageActions.onRefreshAdmin,
+            onToggleAdminPlace: myPageActions.onToggleAdminPlace,
+            onToggleAdminManualOverride: myPageActions.onToggleAdminManualOverride,
+          }}
         />
       )}
     </div>

--- a/src/components/FeedTab.tsx
+++ b/src/components/FeedTab.tsx
@@ -1,4 +1,4 @@
-﻿import { useMemo } from 'react';
+import { useMemo } from 'react';
 import { useAutoLoadMore } from '../hooks/useAutoLoadMore';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { FeedCommentSheet } from './FeedCommentSheet';
@@ -6,62 +6,83 @@ import { ReviewList } from './ReviewList';
 import type { ApiStatus, Comment, Review, SessionUser } from '../types';
 
 interface FeedTabProps {
-  reviews: Review[];
-  sessionUser: SessionUser | null;
-  reviewLikeUpdatingId: string | null;
-  placeFilterId: string | null;
-  placeFilterName: string | null;
-  commentSubmittingReviewId: string | null;
-  commentMutatingId: string | null;
-  deletingReviewId: string | null;
-  activeCommentReviewId: string | null;
-  activeCommentReviewComments: Comment[];
-  activeCommentReviewStatus: ApiStatus;
-  highlightedCommentId: string | null;
-  highlightedReviewId: string | null;
-  hasMore: boolean;
-  loadingMore: boolean;
-  onLoadMore: () => Promise<void>;
-  onToggleReviewLike: (reviewId: string) => Promise<void>;
-  onCreateComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
-  onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
-  onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
-  onDeleteReview: (reviewId: string) => Promise<void>;
-  onRequestLogin: () => void;
-  onClearPlaceFilter: () => void;
-  onOpenPlace: (placeId: string) => void;
-  onOpenComments: (reviewId: string, commentId?: string | null) => void;
-  onCloseComments: () => void;
+  feedData: {
+    reviews: Review[];
+    placeFilterId: string | null;
+    placeFilterName: string | null;
+    highlightedReviewId: string | null;
+    reviewLikeUpdatingId: string | null;
+    hasMore: boolean;
+    loadingMore: boolean;
+  };
+  commentSheetData: {
+    activeCommentReviewId: string | null;
+    activeCommentReviewComments: Comment[];
+    activeCommentReviewStatus: ApiStatus;
+    highlightedCommentId: string | null;
+    commentSubmittingReviewId: string | null;
+    commentMutatingId: string | null;
+    deletingReviewId: string | null;
+  };
+  sharedData: {
+    sessionUser: SessionUser | null;
+  };
+  feedActions: {
+    onLoadMore: () => Promise<void>;
+    onToggleReviewLike: (reviewId: string) => Promise<void>;
+    onCreateComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
+    onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
+    onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
+    onDeleteReview: (reviewId: string) => Promise<void>;
+    onClearPlaceFilter: () => void;
+    onOpenComments: (reviewId: string, commentId?: string | null) => void;
+    onCloseComments: () => void;
+  };
+  sharedActions: {
+    onRequestLogin: () => void;
+    onOpenPlace: (placeId: string) => void;
+  };
 }
 
 export function FeedTab({
-  reviews,
-  sessionUser,
-  reviewLikeUpdatingId,
-  placeFilterId,
-  placeFilterName,
-  commentSubmittingReviewId,
-  commentMutatingId,
-  deletingReviewId,
-  activeCommentReviewId,
-  activeCommentReviewComments,
-  activeCommentReviewStatus,
-  highlightedCommentId,
-  highlightedReviewId,
-  hasMore,
-  loadingMore,
-  onLoadMore,
-  onToggleReviewLike,
-  onCreateComment,
-  onUpdateComment,
-  onDeleteComment,
-  onDeleteReview,
-  onRequestLogin,
-  onClearPlaceFilter,
-  onOpenPlace,
-  onOpenComments,
-  onCloseComments,
+  feedData,
+  commentSheetData,
+  sharedData,
+  feedActions,
+  sharedActions,
 }: FeedTabProps) {
+  const {
+    reviews,
+    placeFilterId,
+    placeFilterName,
+    highlightedReviewId,
+    reviewLikeUpdatingId,
+    hasMore,
+    loadingMore,
+  } = feedData;
+  const {
+    activeCommentReviewId,
+    activeCommentReviewComments,
+    activeCommentReviewStatus,
+    highlightedCommentId,
+    commentSubmittingReviewId,
+    commentMutatingId,
+    deletingReviewId,
+  } = commentSheetData;
+  const { sessionUser } = sharedData;
+  const {
+    onLoadMore,
+    onToggleReviewLike,
+    onCreateComment,
+    onUpdateComment,
+    onDeleteComment,
+    onDeleteReview,
+    onClearPlaceFilter,
+    onOpenComments,
+    onCloseComments,
+  } = feedActions;
+  const { onRequestLogin, onOpenPlace } = sharedActions;
+
   const skipFeedScrollRestore = Boolean(highlightedReviewId || activeCommentReviewId || highlightedCommentId);
   const scrollRef = useScrollRestoration<HTMLElement>(`feed:${placeFilterId ?? 'all'}`, { skipRestore: skipFeedScrollRestore });
   const loadMoreRef = useAutoLoadMore({

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -9,39 +9,53 @@ import { ProviderButtons } from './ProviderButtons';
 import type { AdminSummaryResponse, AuthProvider, MyPageResponse, MyPageTabKey, ReviewMood, SessionUser } from '../types';
 
 interface MyPagePanelProps {
-  sessionUser: SessionUser | null;
-  myPage: MyPageResponse | null;
-  providers: AuthProvider[];
-  myPageError: string | null;
-  activeTab: MyPageTabKey;
-  isLoggingOut: boolean;
-  profileSaving: boolean;
-  profileError: string | null;
-  routeSubmitting: boolean;
-  routeError: string | null;
-  adminSummary: AdminSummaryResponse | null;
-  adminBusyPlaceId: string | null;
-  adminLoading: boolean;
-  onChangeTab: (nextTab: MyPageTabKey) => void;
-  onLogin: (provider: 'naver' | 'kakao') => void;
-  onRetry: () => Promise<void>;
-  onLogout: () => Promise<void>;
-  onSaveNickname: (nickname: string) => Promise<void>;
-  onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
-  onOpenPlace: (placeId: string) => void;
-  onOpenComment: (reviewId: string, commentId: string) => void;
-  onOpenReview: (reviewId: string) => void;
-  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
-  onDeleteReview: (reviewId: string) => Promise<void>;
-  onMarkNotificationRead: (notificationId: string) => Promise<void>;
-  onMarkAllNotificationsRead: () => Promise<void>;
-  onDeleteNotification: (notificationId: string) => Promise<void>;
-  commentsHasMore: boolean;
-  commentsLoadingMore: boolean;
-  onLoadMoreComments: (initial?: boolean) => Promise<void>;
-  onRefreshAdmin: () => Promise<void>;
-  onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
-  onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
+  sessionData: {
+    sessionUser: SessionUser | null;
+    myPage: MyPageResponse | null;
+    providers: AuthProvider[];
+    myPageError: string | null;
+  };
+  panelState: {
+    activeTab: MyPageTabKey;
+    isLoggingOut: boolean;
+    profileSaving: boolean;
+    profileError: string | null;
+    routeSubmitting: boolean;
+    routeError: string | null;
+    commentsHasMore: boolean;
+    commentsLoadingMore: boolean;
+  };
+  reviewActions: {
+    onOpenPlace: (placeId: string) => void;
+    onOpenComment: (reviewId: string, commentId: string) => void;
+    onOpenReview: (reviewId: string) => void;
+    onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
+    onDeleteReview: (reviewId: string) => Promise<void>;
+    onLoadMoreComments: (initial?: boolean) => Promise<void>;
+  };
+  panelActions: {
+    onChangeTab: (nextTab: MyPageTabKey) => void;
+    onLogin: (provider: 'naver' | 'kakao') => void;
+    onRetry: () => Promise<void>;
+    onLogout: () => Promise<void>;
+    onSaveNickname: (nickname: string) => Promise<void>;
+    onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
+  };
+  notificationActions: {
+    onMarkNotificationRead: (notificationId: string) => Promise<void>;
+    onMarkAllNotificationsRead: () => Promise<void>;
+    onDeleteNotification: (notificationId: string) => Promise<void>;
+  };
+  adminData: {
+    adminSummary: AdminSummaryResponse | null;
+    adminBusyPlaceId: string | null;
+    adminLoading: boolean;
+  };
+  adminActions: {
+    onRefreshAdmin: () => Promise<void>;
+    onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
+    onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
+  };
 }
 
 const AdminPanel = lazy(() => import('./AdminPanel').then((module) => ({ default: module.AdminPanel })));
@@ -64,40 +78,48 @@ function getNotificationLabel(notification: NotificationItem) {
 }
 
 export function MyPagePanel({
-  sessionUser,
-  myPage,
-  providers,
-  myPageError,
-  activeTab,
-  isLoggingOut,
-  profileSaving,
-  profileError,
-  routeSubmitting,
-  routeError,
-  adminSummary,
-  adminBusyPlaceId,
-  adminLoading,
-  onChangeTab,
-  onLogin,
-  onRetry,
-  onLogout,
-  onSaveNickname,
-  onPublishRoute,
-  onOpenPlace,
-  onOpenComment,
-  onOpenReview,
-  onUpdateReview,
-  onDeleteReview,
-  onMarkNotificationRead,
-  onMarkAllNotificationsRead,
-  onDeleteNotification,
-  commentsHasMore,
-  commentsLoadingMore,
-  onLoadMoreComments,
-  onRefreshAdmin,
-  onToggleAdminPlace,
-  onToggleAdminManualOverride,
+  sessionData,
+  panelState,
+  reviewActions,
+  panelActions,
+  notificationActions,
+  adminData,
+  adminActions,
 }: MyPagePanelProps) {
+  const { sessionUser, myPage, providers, myPageError } = sessionData;
+  const {
+    activeTab,
+    isLoggingOut,
+    profileSaving,
+    profileError,
+    routeSubmitting,
+    routeError,
+    commentsHasMore,
+    commentsLoadingMore,
+  } = panelState;
+  const {
+    onOpenPlace,
+    onOpenComment,
+    onOpenReview,
+    onUpdateReview,
+    onDeleteReview,
+    onLoadMoreComments,
+  } = reviewActions;
+  const {
+    onChangeTab,
+    onLogin,
+    onRetry,
+    onLogout,
+    onSaveNickname,
+    onPublishRoute,
+  } = panelActions;
+  const {
+    onMarkNotificationRead,
+    onMarkAllNotificationsRead,
+    onDeleteNotification,
+  } = notificationActions;
+  const { adminSummary, adminBusyPlaceId, adminLoading } = adminData;
+  const { onRefreshAdmin, onToggleAdminPlace, onToggleAdminManualOverride } = adminActions;
   const [nickname, setNickname] = useState(sessionUser?.nickname ?? '');
   const [showVisitedDetail, setShowVisitedDetail] = useState(false);
   const [showSettings, setShowSettings] = useState(false);

--- a/test/regression/my-page-panel.test.tsx
+++ b/test/regression/my-page-panel.test.tsx
@@ -4,127 +4,67 @@ import { MyPagePanel } from '../../src/components/MyPagePanel';
 import { myPageFixture, sessionUserFixture } from '../fixtures/app-fixtures';
 import type { MyPageTabKey } from '../../src/types';
 
-function renderPanel(activeTab: MyPageTabKey) {
-  return render(
-    <MyPagePanel
-      sessionUser={sessionUserFixture}
-      myPage={myPageFixture}
-      providers={[]}
-      myPageError={null}
-      activeTab={activeTab}
-      isLoggingOut={false}
-      profileSaving={false}
-      profileError={null}
-      routeSubmitting={false}
-      routeError={null}
-      adminSummary={null}
-      adminBusyPlaceId={null}
-      adminLoading={false}
-      onChangeTab={vi.fn()}
-      onLogin={vi.fn()}
-      onRetry={vi.fn().mockResolvedValue(undefined)}
-      onLogout={vi.fn().mockResolvedValue(undefined)}
-      onSaveNickname={vi.fn().mockResolvedValue(undefined)}
-      onPublishRoute={vi.fn().mockResolvedValue(undefined)}
-      onOpenPlace={vi.fn()}
-      onOpenComment={vi.fn()}
-      onOpenReview={vi.fn()}
-      onUpdateReview={vi.fn().mockResolvedValue(undefined)}
-      onDeleteReview={vi.fn().mockResolvedValue(undefined)}
-      onMarkNotificationRead={vi.fn().mockResolvedValue(undefined)}
-      onMarkAllNotificationsRead={vi.fn().mockResolvedValue(undefined)}
-      onDeleteNotification={vi.fn().mockResolvedValue(undefined)}
-      commentsHasMore={false}
-      commentsLoadingMore={false}
-      onLoadMoreComments={vi.fn().mockResolvedValue(undefined)}
-      onRefreshAdmin={vi.fn().mockResolvedValue(undefined)}
-      onToggleAdminPlace={vi.fn().mockResolvedValue(undefined)}
-      onToggleAdminManualOverride={vi.fn().mockResolvedValue(undefined)}
-    />,
-  );
+function createPanelProps(activeTab: MyPageTabKey) {
+  return {
+    sessionData: {
+      sessionUser: sessionUserFixture,
+      myPage: myPageFixture,
+      providers: [],
+      myPageError: null,
+    },
+    panelState: {
+      activeTab,
+      isLoggingOut: false,
+      profileSaving: false,
+      profileError: null,
+      routeSubmitting: false,
+      routeError: null,
+      commentsHasMore: false,
+      commentsLoadingMore: false,
+    },
+    reviewActions: {
+      onOpenPlace: vi.fn(),
+      onOpenComment: vi.fn(),
+      onOpenReview: vi.fn(),
+      onUpdateReview: vi.fn().mockResolvedValue(undefined),
+      onDeleteReview: vi.fn().mockResolvedValue(undefined),
+      onLoadMoreComments: vi.fn().mockResolvedValue(undefined),
+    },
+    panelActions: {
+      onChangeTab: vi.fn(),
+      onLogin: vi.fn(),
+      onRetry: vi.fn().mockResolvedValue(undefined),
+      onLogout: vi.fn().mockResolvedValue(undefined),
+      onSaveNickname: vi.fn().mockResolvedValue(undefined),
+      onPublishRoute: vi.fn().mockResolvedValue(undefined),
+    },
+    notificationActions: {
+      onMarkNotificationRead: vi.fn().mockResolvedValue(undefined),
+      onMarkAllNotificationsRead: vi.fn().mockResolvedValue(undefined),
+      onDeleteNotification: vi.fn().mockResolvedValue(undefined),
+    },
+    adminData: {
+      adminSummary: null,
+      adminBusyPlaceId: null,
+      adminLoading: false,
+    },
+    adminActions: {
+      onRefreshAdmin: vi.fn().mockResolvedValue(undefined),
+      onToggleAdminPlace: vi.fn().mockResolvedValue(undefined),
+      onToggleAdminManualOverride: vi.fn().mockResolvedValue(undefined),
+    },
+  } as const;
 }
 
 describe('MyPagePanel regression', () => {
   it('renders the extracted tab sections without losing their representative content', () => {
-    const { rerender } = renderPanel('stamps');
+    const { rerender } = render(<MyPagePanel {...createPanelProps('stamps')} />);
     expect(screen.getByText('STAMP LOG')).toBeInTheDocument();
 
-    rerender(
-      <MyPagePanel
-        sessionUser={sessionUserFixture}
-        myPage={myPageFixture}
-        providers={[]}
-        myPageError={null}
-        activeTab="comments"
-        isLoggingOut={false}
-        profileSaving={false}
-        profileError={null}
-        routeSubmitting={false}
-        routeError={null}
-        adminSummary={null}
-        adminBusyPlaceId={null}
-        adminLoading={false}
-        onChangeTab={vi.fn()}
-        onLogin={vi.fn()}
-        onRetry={vi.fn().mockResolvedValue(undefined)}
-        onLogout={vi.fn().mockResolvedValue(undefined)}
-        onSaveNickname={vi.fn().mockResolvedValue(undefined)}
-        onPublishRoute={vi.fn().mockResolvedValue(undefined)}
-        onOpenPlace={vi.fn()}
-        onOpenComment={vi.fn()}
-        onOpenReview={vi.fn()}
-        onUpdateReview={vi.fn().mockResolvedValue(undefined)}
-        onDeleteReview={vi.fn().mockResolvedValue(undefined)}
-        onMarkNotificationRead={vi.fn().mockResolvedValue(undefined)}
-        onMarkAllNotificationsRead={vi.fn().mockResolvedValue(undefined)}
-        onDeleteNotification={vi.fn().mockResolvedValue(undefined)}
-        commentsHasMore={false}
-        commentsLoadingMore={false}
-        onLoadMoreComments={vi.fn().mockResolvedValue(undefined)}
-        onRefreshAdmin={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminPlace={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminManualOverride={vi.fn().mockResolvedValue(undefined)}
-      />,
-    );
-    expect(screen.getByText('내 댓글')).toBeInTheDocument();
+    rerender(<MyPagePanel {...createPanelProps('comments')} />);
+    expect(screen.getByText('내 댓글 보기')).toBeInTheDocument();
 
-    rerender(
-      <MyPagePanel
-        sessionUser={sessionUserFixture}
-        myPage={myPageFixture}
-        providers={[]}
-        myPageError={null}
-        activeTab="routes"
-        isLoggingOut={false}
-        profileSaving={false}
-        profileError={null}
-        routeSubmitting={false}
-        routeError={null}
-        adminSummary={null}
-        adminBusyPlaceId={null}
-        adminLoading={false}
-        onChangeTab={vi.fn()}
-        onLogin={vi.fn()}
-        onRetry={vi.fn().mockResolvedValue(undefined)}
-        onLogout={vi.fn().mockResolvedValue(undefined)}
-        onSaveNickname={vi.fn().mockResolvedValue(undefined)}
-        onPublishRoute={vi.fn().mockResolvedValue(undefined)}
-        onOpenPlace={vi.fn()}
-        onOpenComment={vi.fn()}
-        onOpenReview={vi.fn()}
-        onUpdateReview={vi.fn().mockResolvedValue(undefined)}
-        onDeleteReview={vi.fn().mockResolvedValue(undefined)}
-        onMarkNotificationRead={vi.fn().mockResolvedValue(undefined)}
-        onMarkAllNotificationsRead={vi.fn().mockResolvedValue(undefined)}
-        onDeleteNotification={vi.fn().mockResolvedValue(undefined)}
-        commentsHasMore={false}
-        commentsLoadingMore={false}
-        onLoadMoreComments={vi.fn().mockResolvedValue(undefined)}
-        onRefreshAdmin={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminPlace={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminManualOverride={vi.fn().mockResolvedValue(undefined)}
-      />,
-    );
+    rerender(<MyPagePanel {...createPanelProps('routes')} />);
     expect(screen.getByText(myPageFixture.routes[0].title)).toBeInTheDocument();
   });
 });

--- a/test/smoke/component-smoke.test.tsx
+++ b/test/smoke/component-smoke.test.tsx
@@ -63,39 +63,53 @@ describe('component smoke', () => {
 
     const myPage = render(
       <MyPagePanel
-        sessionUser={sessionUserFixture}
-        myPage={myPageFixture}
-        providers={[]}
-        myPageError={null}
-        activeTab="feeds"
-        isLoggingOut={false}
-        profileSaving={false}
-        profileError={null}
-        routeSubmitting={false}
-        routeError={null}
-        adminSummary={null}
-        adminBusyPlaceId={null}
-        adminLoading={false}
-        onChangeTab={vi.fn()}
-        onLogin={vi.fn()}
-        onRetry={vi.fn().mockResolvedValue(undefined)}
-        onLogout={vi.fn().mockResolvedValue(undefined)}
-        onSaveNickname={vi.fn().mockResolvedValue(undefined)}
-        onPublishRoute={vi.fn().mockResolvedValue(undefined)}
-        onOpenPlace={vi.fn()}
-        onOpenComment={vi.fn()}
-        onOpenReview={vi.fn()}
-        onUpdateReview={vi.fn().mockResolvedValue(undefined)}
-        onDeleteReview={vi.fn().mockResolvedValue(undefined)}
-        onMarkNotificationRead={vi.fn().mockResolvedValue(undefined)}
-        onMarkAllNotificationsRead={vi.fn().mockResolvedValue(undefined)}
-        onDeleteNotification={vi.fn().mockResolvedValue(undefined)}
-        commentsHasMore={false}
-        commentsLoadingMore={false}
-        onLoadMoreComments={vi.fn().mockResolvedValue(undefined)}
-        onRefreshAdmin={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminPlace={vi.fn().mockResolvedValue(undefined)}
-        onToggleAdminManualOverride={vi.fn().mockResolvedValue(undefined)}
+        sessionData={{
+          sessionUser: sessionUserFixture,
+          myPage: myPageFixture,
+          providers: [],
+          myPageError: null,
+        }}
+        panelState={{
+          activeTab: 'feeds',
+          isLoggingOut: false,
+          profileSaving: false,
+          profileError: null,
+          routeSubmitting: false,
+          routeError: null,
+          commentsHasMore: false,
+          commentsLoadingMore: false,
+        }}
+        reviewActions={{
+          onOpenPlace: vi.fn(),
+          onOpenComment: vi.fn(),
+          onOpenReview: vi.fn(),
+          onUpdateReview: vi.fn().mockResolvedValue(undefined),
+          onDeleteReview: vi.fn().mockResolvedValue(undefined),
+          onLoadMoreComments: vi.fn().mockResolvedValue(undefined),
+        }}
+        panelActions={{
+          onChangeTab: vi.fn(),
+          onLogin: vi.fn(),
+          onRetry: vi.fn().mockResolvedValue(undefined),
+          onLogout: vi.fn().mockResolvedValue(undefined),
+          onSaveNickname: vi.fn().mockResolvedValue(undefined),
+          onPublishRoute: vi.fn().mockResolvedValue(undefined),
+        }}
+        notificationActions={{
+          onMarkNotificationRead: vi.fn().mockResolvedValue(undefined),
+          onMarkAllNotificationsRead: vi.fn().mockResolvedValue(undefined),
+          onDeleteNotification: vi.fn().mockResolvedValue(undefined),
+        }}
+        adminData={{
+          adminSummary: null,
+          adminBusyPlaceId: null,
+          adminLoading: false,
+        }}
+        adminActions={{
+          onRefreshAdmin: vi.fn().mockResolvedValue(undefined),
+          onToggleAdminPlace: vi.fn().mockResolvedValue(undefined),
+          onToggleAdminManualOverride: vi.fn().mockResolvedValue(undefined),
+        }}
       />,
     );
 


### PR DESCRIPTION
## 요약
- FeedTab 계약을 eedData, commentSheetData, sharedData, eedActions, sharedActions로 분리했습니다.
- MyPagePanel 계약을 sessionData, panelState, eviewActions, panelActions, 
otificationActions, dminData, dminActions로 분리했습니다.
- AppPageStage에서 feed/my-page로 내려가는 긴 prop 나열을 그룹 객체로 정리했습니다.
- 회귀 테스트와 컴포넌트 스모크 테스트를 새 계약 기준으로 갱신했습니다.

## 검증
- npm run typecheck
- npm run build
- npm run test:regression -- my-page-panel
- npm run test:smoke:ui

## 비고
- feed/my-page 페이지 패널 계약 정리에만 집중한 PR입니다.