### PR TITLE
Test review state contracts

### DIFF
--- a/test/unit/useAppDataState.test.tsx
+++ b/test/unit/useAppDataState.test.tsx
@@ -1,0 +1,92 @@
+import { act, renderHook } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { useAppDataState } from '../../src/hooks/useAppDataState';
+import { createReviewFixture } from '../fixtures/app-fixtures';
+
+describe('useAppDataState', () => {
+  it('keeps patched review collections summary-only across selected-place caches', () => {
+    const review = createReviewFixture({
+      id: 'review-1',
+      placeId: 'place-1',
+      commentCount: 1,
+      comments: [],
+    });
+    const detailedReview = {
+      ...review,
+      commentCount: 2,
+      comments: [
+        {
+          id: 'comment-1',
+          userId: 'user-2',
+          author: 'tester-2',
+          body: 'embedded',
+          parentId: null,
+          isDeleted: false,
+          createdAt: '04. 08. 10:15',
+          replies: [],
+        },
+      ],
+    };
+
+    const { result } = renderHook(() => useAppDataState('place-1'));
+
+    act(() => {
+      result.current.setReviews([review]);
+      result.current.setSelectedPlaceReviews([review]);
+      result.current.placeReviewsCacheRef.current['place-1'] = [review];
+    });
+
+    act(() => {
+      result.current.patchReviewCollections('review-1', () => detailedReview);
+    });
+
+    expect(result.current.reviews[0]).toEqual({
+      ...detailedReview,
+      comments: [],
+    });
+    expect(result.current.selectedPlaceReviews[0]).toEqual({
+      ...detailedReview,
+      comments: [],
+    });
+    expect(result.current.placeReviewsCacheRef.current['place-1']?.[0]).toEqual({
+      ...detailedReview,
+      comments: [],
+    });
+  });
+
+  it('only upserts selected-place reviews for the active place while keeping cache entries summarized', () => {
+    const review = createReviewFixture({
+      id: 'review-2',
+      placeId: 'place-2',
+      commentCount: 2,
+      comments: [
+        {
+          id: 'comment-2',
+          userId: 'user-3',
+          author: 'tester-3',
+          body: 'embedded',
+          parentId: null,
+          isDeleted: false,
+          createdAt: '04. 08. 11:15',
+          replies: [],
+        },
+      ],
+    });
+
+    const { result } = renderHook(() => useAppDataState('place-1'));
+
+    act(() => {
+      result.current.upsertReviewCollections(review);
+    });
+
+    expect(result.current.reviews[0]).toEqual({
+      ...review,
+      comments: [],
+    });
+    expect(result.current.selectedPlaceReviews).toEqual([]);
+    expect(result.current.placeReviewsCacheRef.current['place-2']?.[0]).toEqual({
+      ...review,
+      comments: [],
+    });
+  });
+});

--- a/test/unit/useAppShellNavigation.test.ts
+++ b/test/unit/useAppShellNavigation.test.ts
@@ -104,4 +104,65 @@ describe('useAppShellNavigation', () => {
     expect(setReturnView).toHaveBeenCalledWith(null);
     expect(goToTab).toHaveBeenCalledWith('map', 'replace');
   });
+
+  it('restores the saved return view when there is no map history step to consume first', () => {
+    const setMyPageTab = vi.fn();
+    const setActiveCommentReviewId = vi.fn();
+    const setHighlightedCommentId = vi.fn();
+    const setHighlightedReviewId = vi.fn();
+    const setFeedPlaceFilterId = vi.fn();
+    const setSelectedRoutePreview = vi.fn();
+    const setReturnView = vi.fn();
+    const commitRouteState = vi.fn();
+
+    const navigation = useAppShellNavigation({
+      sessionUser: sessionUser,
+      returnView: {
+        tab: 'feed',
+        myPageTab: 'comments',
+        activeCommentReviewId: 'review-1',
+        highlightedCommentId: 'comment-1',
+        highlightedReviewId: 'review-1',
+        placeId: null,
+        festivalId: null,
+        drawerState: 'closed',
+        feedPlaceFilterId: 'place-1',
+      },
+      activeCommentReviewId: null,
+      activeTab: 'feed',
+      selectedPlaceId: null,
+      selectedFestivalId: null,
+      drawerState: 'closed',
+      selectedRoutePreview: null,
+      setMyPageTab,
+      setActiveCommentReviewId,
+      setHighlightedCommentId,
+      setHighlightedReviewId,
+      setFeedPlaceFilterId,
+      setSelectedRoutePreview,
+      setReturnView,
+      handleCloseReviewComments: vi.fn(),
+      goToTab: vi.fn(),
+      commitRouteState,
+    });
+
+    navigation.handleNavigateBack();
+
+    expect(setMyPageTab).toHaveBeenCalledWith('comments');
+    expect(setActiveCommentReviewId).toHaveBeenCalledWith('review-1');
+    expect(setHighlightedCommentId).toHaveBeenCalledWith('comment-1');
+    expect(setHighlightedReviewId).toHaveBeenCalledWith('review-1');
+    expect(setFeedPlaceFilterId).toHaveBeenCalledWith('place-1');
+    expect(setSelectedRoutePreview).toHaveBeenCalledWith(null);
+    expect(setReturnView).toHaveBeenCalledWith(null);
+    expect(commitRouteState).toHaveBeenCalledWith(
+      {
+        tab: 'feed',
+        placeId: null,
+        festivalId: null,
+        drawerState: 'closed',
+      },
+      'replace',
+    );
+  });
 });


### PR DESCRIPTION
## 요약
- review collection patch/upsert 경로가 summary-only를 유지하는지 useAppDataState 단위 테스트를 추가했습니다.
- returnView가 있을 때 app shell back navigation이 저장된 상태를 우선 복원하는지 unit 테스트를 추가했습니다.
- 구현 변경 없이 회귀 안전망을 강화하는 테스트 전용 PR입니다.

## 검증
- npm run test:unit
- npm run build

## 비고
- Windows/Vitest worker 환경에서 불안정한 케이스는 제외하고, 실제로 안정적으로 통과하는 상태 계약 테스트만 포함했습니다.