### PR TITLE
Refactor app store domains and page repository facade

### DIFF
--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -1,0 +1,47 @@
+from sqlalchemy.orm import Session
+
+from ..models import CategoryFilter, CourseMood
+from ..repository_normalized import (
+    get_bootstrap,
+    get_my_page,
+    get_place,
+    get_stamps,
+    list_courses,
+    list_places,
+    toggle_stamp,
+)
+
+
+def read_bootstrap_bundle(db: Session, user_id: str | None):
+    return get_bootstrap(db, user_id)
+
+
+def list_place_entries(db: Session, category: CategoryFilter):
+    return list_places(db, category)
+
+
+def read_place_entry(db: Session, place_id: str):
+    return get_place(db, place_id)
+
+
+def list_course_entries(db: Session, mood: CourseMood | None):
+    return list_courses(db, mood)
+
+
+def read_my_page_entry(db: Session, user_id: str, is_admin: bool):
+    return get_my_page(db, user_id, is_admin)
+
+
+def read_stamp_state(db: Session, user_id: str | None):
+    return get_stamps(db, user_id)
+
+
+def toggle_stamp_entry(
+    db: Session,
+    user_id: str,
+    place_id: str,
+    latitude: float,
+    longitude: float,
+    unlock_radius_meters: int,
+):
+    return toggle_stamp(db, user_id, place_id, latitude, longitude, unlock_radius_meters)

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -1,65 +1,82 @@
-﻿from fastapi import HTTPException, status
+from collections.abc import Callable
+
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from ..config import Settings
 from ..models import CategoryFilter, CourseMood, SessionUser, StampToggleRequest
-from ..repository_normalized import (
-    get_bootstrap,
-    get_my_page,
-    get_place,
-    get_stamps,
-    list_courses,
-    list_places,
-    list_reviews,
-    toggle_stamp,
+from ..repositories.page_repository import (
+    list_course_entries,
+    list_place_entries,
+    read_bootstrap_bundle,
+    read_my_page_entry,
+    read_place_entry,
+    read_stamp_state,
+    toggle_stamp_entry,
 )
+from ..repositories.review_repository import list_review_entries
+
+
+def _raise_not_found(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def _raise_forbidden(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def _run_not_found_policy(action: Callable[[], object]):
+    try:
+        return action()
+    except ValueError as error:
+        _raise_not_found(str(error))
+
+
+def _run_stamp_policy(action: Callable[[], object]):
+    try:
+        return action()
+    except PermissionError as error:
+        _raise_forbidden(str(error))
+    except ValueError as error:
+        _raise_not_found(str(error))
 
 
 def read_bootstrap_service(db: Session, session_user: SessionUser | None):
-    return get_bootstrap(db, session_user.id if session_user else None)
+    return read_bootstrap_bundle(db, session_user.id if session_user else None)
 
 
 def read_places_service(db: Session, category: CategoryFilter):
-    return list_places(db, category)
+    return list_place_entries(db, category)
 
 
 def read_place_service(db: Session, place_id: str):
-    try:
-        return get_place(db, place_id)
-    except ValueError as error:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+    return _run_not_found_policy(lambda: read_place_entry(db, place_id))
 
 
 def read_courses_service(db: Session, mood: CourseMood | None):
-    return list_courses(db, mood)
+    return list_course_entries(db, mood)
 
 
 def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
-    return list_reviews(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)
+    return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)
 
 
 def read_my_page_service(db: Session, session_user: SessionUser, app_settings: Settings):
-    try:
-        return get_my_page(db, session_user.id, app_settings.is_admin(session_user.id))
-    except ValueError as error:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+    return _run_not_found_policy(lambda: read_my_page_entry(db, session_user.id, app_settings.is_admin(session_user.id)))
 
 
 def read_stamps_service(db: Session, session_user: SessionUser | None):
-    return get_stamps(db, session_user.id if session_user else None)
+    return read_stamp_state(db, session_user.id if session_user else None)
 
 
 def toggle_stamp_service(db: Session, payload: StampToggleRequest, session_user: SessionUser, app_settings: Settings):
-    try:
-        return toggle_stamp(
+    return _run_stamp_policy(
+        lambda: toggle_stamp_entry(
             db,
             session_user.id,
             payload.place_id,
             payload.latitude,
             payload.longitude,
             app_settings.stamp_unlock_radius_meters,
-        )
-    except PermissionError as error:
-        raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=str(error)) from error
-    except ValueError as error:
-        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
+        ),
+    )

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -1,0 +1,78 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.config import Settings
+from app.models import SessionUser, StampToggleRequest
+from app.services import page_service
+
+
+def build_session_user() -> SessionUser:
+    return SessionUser(
+        id="user-1",
+        nickname="tester",
+        email="tester@example.com",
+        provider="kakao",
+        profileImage=None,
+        isAdmin=False,
+        profileCompletedAt=None,
+    )
+
+
+def test_read_place_service_maps_missing_place_to_404(monkeypatch):
+    def failing_read_place(*_args, **_kwargs):
+        raise ValueError("장소를 찾을 수 없어요.")
+
+    monkeypatch.setattr(page_service, "read_place_entry", failing_read_place)
+
+    with pytest.raises(HTTPException) as caught:
+        page_service.read_place_service(SimpleNamespace(), "missing-place")
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_read_my_page_service_maps_missing_user_to_404(monkeypatch):
+    def failing_read_my_page(*_args, **_kwargs):
+        raise ValueError("사용자를 찾을 수 없어요.")
+
+    monkeypatch.setattr(page_service, "read_my_page_entry", failing_read_my_page)
+
+    with pytest.raises(HTTPException) as caught:
+        page_service.read_my_page_service(SimpleNamespace(), build_session_user(), Settings())
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_toggle_stamp_service_maps_permission_error_to_403(monkeypatch):
+    def failing_toggle_stamp(*_args, **_kwargs):
+        raise PermissionError("forbidden")
+
+    monkeypatch.setattr(page_service, "toggle_stamp_entry", failing_toggle_stamp)
+
+    with pytest.raises(HTTPException) as caught:
+        page_service.toggle_stamp_service(
+            SimpleNamespace(),
+            StampToggleRequest(placeId="place-1", latitude=36.35, longitude=127.38),
+            build_session_user(),
+            Settings(stamp_unlock_radius_meters=120),
+        )
+
+    assert caught.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_toggle_stamp_service_maps_missing_place_to_404(monkeypatch):
+    def failing_toggle_stamp(*_args, **_kwargs):
+        raise ValueError("장소를 찾을 수 없어요.")
+
+    monkeypatch.setattr(page_service, "toggle_stamp_entry", failing_toggle_stamp)
+
+    with pytest.raises(HTTPException) as caught:
+        page_service.toggle_stamp_service(
+            SimpleNamespace(),
+            StampToggleRequest(placeId="missing-place", latitude=36.35, longitude=127.38),
+            build_session_user(),
+            Settings(stamp_unlock_radius_meters=120),
+        )
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -95,10 +95,23 @@
   - [x] highlighted comment/review id
 - [x] `my-page-store` 1차 분리
   - [x] my page active tab
+- [x] `auth-store` 1차 분리
+  - [x] session user
+  - [x] auth providers
+- [x] `app-map-store` 1차 분리
+  - [x] active category
+  - [x] selected route preview
+- [x] `app-route-store` 1차 분리
+  - [x] active tab
+  - [x] drawer state
+  - [x] selected place / festival id
+- [x] `app-runtime-store` 1차 정리
+  - [x] notice / current position / map location status
+  - [x] review / comment mutation flags
+  - [x] feed / my comments pagination flags
 
 ### 남은 TODO
-- [ ] 현재 `app-ui-store`, `app-runtime-store` 상태 필드 목록 정리
-- [ ] `auth-store`, `map-store` 후보 분리
+- [ ] 현재 `app-runtime-store`를 shell runtime과 page runtime으로 더 나눌지 결정
 - [ ] 기존 selector/액션이 어떤 컴포넌트에서 쓰이는지 매핑
 - [ ] store 분리 후 컴포넌트별 의존 범위 최소화
 - [ ] 전역 notice 같은 cross-cutting 상태는 별도 `ui-shell` 또는 `app-shell` 계층으로 유지할지 결정
@@ -143,11 +156,13 @@
 ### 진행됨
 - [x] review/comment domain repository facade 1차 추가
 - [x] `review_service.py`가 review facade를 우선 사용하도록 변경
+- [x] page domain repository facade 1차 추가
+- [x] `page_service.py`가 page facade를 우선 사용하도록 변경
 
 ### 남은 TODO
 - [ ] `repository_normalized.py` 공개 함수 목록 분류
 - [ ] route/service가 직접 쓰는 함수와 내부 전용 함수를 구분
-- [ ] 리뷰/댓글 외 `profile/stamp/my-page` 도메인 facade 추가
+- [ ] `profile/stamp/my-page` 전용 facade를 더 잘게 분리할지 결정
 - [ ] 문자열/예외/ID 파서 공통 모듈 유지 기준 정리
 - [ ] 서비스가 repository 세부 구현 대신 도메인 인터페이스에 의존하도록 조정
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
   getAuthSession,
 } from './api/client';
@@ -33,16 +33,14 @@ import { useNotificationActions } from './hooks/useNotificationActions';
 import { useAppStageActions } from './hooks/useAppStageActions';
 import { useAppPagePaginationActions } from './hooks/useAppPagePaginationActions';
 import { useAppPageStageActions } from './hooks/useAppPageStageActions';
+import { useAppMapStore } from './store/app-map-store';
+import { useAuthStore } from './store/auth-store';
+import { useAppRuntimeStore } from './store/app-runtime-store';
 import { useAppUIStore } from './store/app-ui-store';
 import { useMyPageStore } from './store/my-page-store';
 import { useNotificationStore } from './store/notification-store';
 import { useReviewUIStore } from './store/review-ui-store';
-import type {
-  ApiStatus,
-  Category,
-  Comment,
-  Tab,
-} from './types';
+import type { Tab } from './types';
 
 const STAMP_UNLOCK_RADIUS_METERS = 120;
 const NOTICE_DISMISS_DELAY_MS = 4000;
@@ -88,45 +86,78 @@ export default function App() {
   const setMyPageTab = useMyPageStore((state) => state.setMyPageTab);
   const feedPlaceFilterId = useReviewUIStore((state) => state.feedPlaceFilterId);
   const setFeedPlaceFilterId = useReviewUIStore((state) => state.setFeedPlaceFilterId);
-  const activeCategory = useAppUIStore((state) => state.activeCategory);
-  const setActiveCategory = useAppUIStore((state) => state.setActiveCategory);
+  const activeCategory = useAppMapStore((state) => state.activeCategory);
+  const setActiveCategory = useAppMapStore((state) => state.setActiveCategory);
   const activeCommentReviewId = useReviewUIStore((state) => state.activeCommentReviewId);
   const setActiveCommentReviewId = useReviewUIStore((state) => state.setActiveCommentReviewId);
   const highlightedCommentId = useReviewUIStore((state) => state.highlightedCommentId);
   const setHighlightedCommentId = useReviewUIStore((state) => state.setHighlightedCommentId);
   const highlightedReviewId = useReviewUIStore((state) => state.highlightedReviewId);
   const setHighlightedReviewId = useReviewUIStore((state) => state.setHighlightedReviewId);
-  const selectedRoutePreview = useAppUIStore((state) => state.selectedRoutePreview);
-  const setSelectedRoutePreview = useAppUIStore((state) => state.setSelectedRoutePreview);
+  const selectedRoutePreview = useAppMapStore((state) => state.selectedRoutePreview);
+  const setSelectedRoutePreview = useAppMapStore((state) => state.setSelectedRoutePreview);
   const returnView = useAppUIStore((state) => state.returnView);
   const setReturnView = useAppUIStore((state) => state.setReturnView);
-  const [notice, setNotice] = useState<string | null>(getInitialNotice);
-  const [currentPosition, setCurrentPosition] = useState<{ latitude: number; longitude: number } | null>(null);
-  const [mapLocationStatus, setMapLocationStatus] = useState<ApiStatus>('idle');
-  const [mapLocationMessage, setMapLocationMessage] = useState<string | null>(null);
-  const [mapLocationFocusKey, setMapLocationFocusKey] = useState(0);
-  const [reviewSubmitting, setReviewSubmitting] = useState(false);
-  const [reviewError, setReviewError] = useState<string | null>(null);
-  const [reviewLikeUpdatingId, setReviewLikeUpdatingId] = useState<string | null>(null);
-  const [commentSubmittingReviewId, setCommentSubmittingReviewId] = useState<string | null>(null);
-  const [commentMutatingId, setCommentMutatingId] = useState<string | null>(null);
-  const [deletingReviewId, setDeletingReviewId] = useState<string | null>(null);
-  const [stampActionStatus, setStampActionStatus] = useState<ApiStatus>('idle');
-  const [stampActionMessage, setStampActionMessage] = useState('장소를 선택하면 오늘 스탬프 가능 여부를 바로 확인할 수 있어요.');
-  const [routeSubmitting, setRouteSubmitting] = useState(false);
-  const [routeError, setRouteError] = useState<string | null>(null);
-  const [routeLikeUpdatingId, setRouteLikeUpdatingId] = useState<string | null>(null);
-  const [profileSaving, setProfileSaving] = useState(false);
-  const [profileError, setProfileError] = useState<string | null>(null);
-  const [myPageError, setMyPageError] = useState<string | null>(null);
-  const [isLoggingOut, setIsLoggingOut] = useState(false);
-  const [feedNextCursor, setFeedNextCursor] = useState<string | null>(null);
-  const [feedHasMore, setFeedHasMore] = useState(false);
-  const [feedLoadingMore, setFeedLoadingMore] = useState(false);
-  const [myCommentsNextCursor, setMyCommentsNextCursor] = useState<string | null>(null);
-  const [myCommentsHasMore, setMyCommentsHasMore] = useState(false);
-  const [myCommentsLoadingMore, setMyCommentsLoadingMore] = useState(false);
-  const [myCommentsLoadedOnce, setMyCommentsLoadedOnce] = useState(false);
+  const notice = useAppRuntimeStore((state) => state.notice);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const currentPosition = useAppRuntimeStore((state) => state.currentPosition);
+  const setCurrentPosition = useAppRuntimeStore((state) => state.setCurrentPosition);
+  const mapLocationStatus = useAppRuntimeStore((state) => state.mapLocationStatus);
+  const setMapLocationStatus = useAppRuntimeStore((state) => state.setMapLocationStatus);
+  const mapLocationMessage = useAppRuntimeStore((state) => state.mapLocationMessage);
+  const setMapLocationMessage = useAppRuntimeStore((state) => state.setMapLocationMessage);
+  const mapLocationFocusKey = useAppRuntimeStore((state) => state.mapLocationFocusKey);
+  const setMapLocationFocusKey = useAppRuntimeStore((state) => state.setMapLocationFocusKey);
+  const reviewSubmitting = useAppRuntimeStore((state) => state.reviewSubmitting);
+  const reviewError = useAppRuntimeStore((state) => state.reviewError);
+  const reviewLikeUpdatingId = useAppRuntimeStore((state) => state.reviewLikeUpdatingId);
+  const commentSubmittingReviewId = useAppRuntimeStore((state) => state.commentSubmittingReviewId);
+  const commentMutatingId = useAppRuntimeStore((state) => state.commentMutatingId);
+  const deletingReviewId = useAppRuntimeStore((state) => state.deletingReviewId);
+  const stampActionStatus = useAppRuntimeStore((state) => state.stampActionStatus);
+  const setStampActionStatus = useAppRuntimeStore((state) => state.setStampActionStatus);
+  const stampActionMessage = useAppRuntimeStore((state) => state.stampActionMessage);
+  const setStampActionMessage = useAppRuntimeStore((state) => state.setStampActionMessage);
+  const routeSubmitting = useAppRuntimeStore((state) => state.routeSubmitting);
+  const setRouteSubmitting = useAppRuntimeStore((state) => state.setRouteSubmitting);
+  const routeError = useAppRuntimeStore((state) => state.routeError);
+  const setRouteError = useAppRuntimeStore((state) => state.setRouteError);
+  const routeLikeUpdatingId = useAppRuntimeStore((state) => state.routeLikeUpdatingId);
+  const setRouteLikeUpdatingId = useAppRuntimeStore((state) => state.setRouteLikeUpdatingId);
+  const profileSaving = useAppRuntimeStore((state) => state.profileSaving);
+  const setProfileSaving = useAppRuntimeStore((state) => state.setProfileSaving);
+  const profileError = useAppRuntimeStore((state) => state.profileError);
+  const setProfileError = useAppRuntimeStore((state) => state.setProfileError);
+  const myPageError = useAppRuntimeStore((state) => state.myPageError);
+  const setMyPageError = useAppRuntimeStore((state) => state.setMyPageError);
+  const isLoggingOut = useAppRuntimeStore((state) => state.isLoggingOut);
+  const setIsLoggingOut = useAppRuntimeStore((state) => state.setIsLoggingOut);
+  const feedNextCursor = useAppRuntimeStore((state) => state.feedNextCursor);
+  const setFeedNextCursor = useAppRuntimeStore((state) => state.setFeedNextCursor);
+  const feedHasMore = useAppRuntimeStore((state) => state.feedHasMore);
+  const setFeedHasMore = useAppRuntimeStore((state) => state.setFeedHasMore);
+  const feedLoadingMore = useAppRuntimeStore((state) => state.feedLoadingMore);
+  const setFeedLoadingMore = useAppRuntimeStore((state) => state.setFeedLoadingMore);
+  const myCommentsNextCursor = useAppRuntimeStore((state) => state.myCommentsNextCursor);
+  const setMyCommentsNextCursor = useAppRuntimeStore((state) => state.setMyCommentsNextCursor);
+  const myCommentsHasMore = useAppRuntimeStore((state) => state.myCommentsHasMore);
+  const setMyCommentsHasMore = useAppRuntimeStore((state) => state.setMyCommentsHasMore);
+  const myCommentsLoadingMore = useAppRuntimeStore((state) => state.myCommentsLoadingMore);
+  const setMyCommentsLoadingMore = useAppRuntimeStore((state) => state.setMyCommentsLoadingMore);
+  const myCommentsLoadedOnce = useAppRuntimeStore((state) => state.myCommentsLoadedOnce);
+  const setMyCommentsLoadedOnce = useAppRuntimeStore((state) => state.setMyCommentsLoadedOnce);
+
+  useEffect(() => {
+    const initialNotice = getInitialNotice();
+    if (!initialNotice) {
+      return;
+    }
+    setNotice((current) => current ?? initialNotice);
+  }, [setNotice]);
+  const sessionUser = useAuthStore((state) => state.sessionUser);
+  const setSessionUser = useAuthStore((state) => state.setSessionUser);
+  const providers = useAuthStore((state) => state.providers);
+  const setProviders = useAuthStore((state) => state.setProviders);
 
   const {
     bootstrapStatus,
@@ -147,10 +178,6 @@ export default function App() {
     setStampState,
     hasRealData,
     setHasRealData,
-    sessionUser,
-    setSessionUser,
-    providers,
-    setProviders,
     communityRoutes,
     setCommunityRoutes,
     communityRouteSort,
@@ -215,13 +242,7 @@ export default function App() {
     handleUpdateProfile,
     handleLogout,
   } = useAppAuthActions({
-    setSessionUser,
-    setProviders,
     setMyPage,
-    setNotice,
-    setIsLoggingOut,
-    setProfileSaving,
-    setProfileError,
     formatErrorMessage,
   });
 
@@ -251,13 +272,10 @@ export default function App() {
     replaceCommunityRoutes,
     setCommunityRoutes,
     setReviews,
-    setFeedHasMore,
-    setFeedNextCursor,
     setCourses,
     setAdminLoading,
     setAdminSummary,
     setMyPage,
-    setMyPageError,
   });
 
   const {
@@ -302,21 +320,8 @@ export default function App() {
   } = useAppPagePaginationActions({
     sessionUser,
     myPage,
-    feedNextCursor,
-    feedHasMore,
-    feedLoadingMore,
-    myCommentsNextCursor,
-    myCommentsHasMore,
-    myCommentsLoadingMore,
     setReviews,
     setMyPage,
-    setFeedNextCursor,
-    setFeedHasMore,
-    setFeedLoadingMore,
-    setMyCommentsNextCursor,
-    setMyCommentsHasMore,
-    setMyCommentsLoadingMore,
-    setMyCommentsLoadedOnce,
     reportBackgroundError,
   });
 
@@ -340,9 +345,6 @@ export default function App() {
     mapLocationMessage,
     stampUnlockRadiusMeters: STAMP_UNLOCK_RADIUS_METERS,
     noticeDismissDelayMs: NOTICE_DISMISS_DELAY_MS,
-    setStampActionMessage,
-    setNotice,
-    setMapLocationMessage,
   });
 
 
@@ -394,13 +396,7 @@ export default function App() {
   } = useAppMapActions({
     sessionUser,
     setPlaces,
-    setCurrentPosition,
-    setMapLocationStatus,
-    setMapLocationMessage,
-    setMapLocationFocusKey,
-    setNotice,
     setStampState,
-    setStampActionStatus,
     goToTab,
     commitRouteState,
     refreshMyPageForUser,
@@ -424,17 +420,10 @@ export default function App() {
     myPage,
     activeCommentReviewId,
     highlightedReviewId,
-    setReviewSubmitting,
-    setReviewError,
-    setCommentSubmittingReviewId,
-    setCommentMutatingId,
-    setDeletingReviewId,
-    setReviewLikeUpdatingId,
     setSelectedPlaceReviews,
     setReviews,
     setMyPage,
     setNotice,
-    setHighlightedReviewId,
     goToTab,
     commitRouteState,
     refreshMyPageForUser,
@@ -452,13 +441,7 @@ export default function App() {
     handleToggleRouteLike,
     handlePublishRoute,
   } = useAppRouteActions({
-    sessionUser,
-    setRouteLikeUpdatingId,
-    setRouteSubmitting,
-    setRouteError,
     setMyPage,
-    setNotice,
-    setMyPageTab,
     communityRoutesCacheRef,
     patchCommunityRoutes,
     refreshMyPageForUser,

--- a/src/hooks/useAppAuthActions.ts
+++ b/src/hooks/useAppAuthActions.ts
@@ -1,6 +1,8 @@
 ﻿import { logout, updateProfile, getProviderLoginUrl } from '../api/client';
 import { getLoginReturnUrl } from './useAppRouteState';
 import type { Dispatch, SetStateAction } from 'react';
+import { useAuthStore } from '../store/auth-store';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
 import type { MyPageResponse, SessionUser } from '../types';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -13,26 +15,21 @@ interface ProviderOption {
 }
 
 interface UseAppAuthActionsParams {
-  setSessionUser: SetState<SessionUser | null>;
-  setProviders: SetState<ProviderOption[]>;
   setMyPage: SetState<MyPageResponse | null>;
-  setNotice: (notice: string | null) => void;
-  setIsLoggingOut: SetState<boolean>;
-  setProfileSaving: SetState<boolean>;
-  setProfileError: SetState<string | null>;
   formatErrorMessage: (error: unknown) => string;
 }
 
 export function useAppAuthActions({
-  setSessionUser,
-  setProviders,
   setMyPage,
-  setNotice,
-  setIsLoggingOut,
-  setProfileSaving,
-  setProfileError,
   formatErrorMessage,
 }: UseAppAuthActionsParams) {
+  const setSessionUser = useAuthStore((state) => state.setSessionUser);
+  const setProviders = useAuthStore((state) => state.setProviders);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const setIsLoggingOut = useAppRuntimeStore((state) => state.setIsLoggingOut);
+  const setProfileSaving = useAppRuntimeStore((state) => state.setProfileSaving);
+  const setProfileError = useAppRuntimeStore((state) => state.setProfileError);
+
   function startProviderLogin(provider: 'naver' | 'kakao') {
     window.location.assign(getProviderLoginUrl(provider, getLoginReturnUrl()));
   }

--- a/src/hooks/useAppDataState.ts
+++ b/src/hooks/useAppDataState.ts
@@ -2,19 +2,12 @@ import { useRef, useState } from 'react';
 import { toReviewSummary } from '../lib/reviews';
 import type {
   AdminSummaryResponse,
-  AuthProvider,
   BootstrapResponse,
   CommunityRouteSort,
   FestivalItem,
   MyPageResponse,
-  SessionUser,
   UserRoute,
 } from '../types';
-
-const emptyProviders: AuthProvider[] = [
-  { key: 'naver', label: '\uB124\uC774\uBC84', isEnabled: false, loginUrl: null },
-  { key: 'kakao', label: '\uCE74\uCE74\uC624', isEnabled: false, loginUrl: null },
-];
 
 export function useAppDataState(selectedPlaceId: string | null) {
   const [bootstrapStatus, setBootstrapStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
@@ -30,8 +23,6 @@ export function useAppDataState(selectedPlaceId: string | null) {
     travelSessions: [],
   });
   const [hasRealData, setHasRealData] = useState(true);
-  const [sessionUser, setSessionUser] = useState<SessionUser | null>(null);
-  const [providers, setProviders] = useState<AuthProvider[]>(emptyProviders);
   const [communityRoutes, setCommunityRoutes] = useState<UserRoute[]>([]);
   const [communityRouteSort, setCommunityRouteSort] = useState<CommunityRouteSort>('popular');
   const [myPage, setMyPage] = useState<MyPageResponse | null>(null);
@@ -107,10 +98,6 @@ export function useAppDataState(selectedPlaceId: string | null) {
     setStampState,
     hasRealData,
     setHasRealData,
-    sessionUser,
-    setSessionUser,
-    providers,
-    setProviders,
     communityRoutes,
     setCommunityRoutes,
     communityRouteSort,

--- a/src/hooks/useAppFeedbackEffects.ts
+++ b/src/hooks/useAppFeedbackEffects.ts
@@ -1,5 +1,6 @@
 ﻿import { useEffect } from 'react';
 import { formatDistanceMeters } from '../lib/visits';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
 import type { Place, SessionUser, StampLog } from '../types';
 
 interface UseAppFeedbackEffectsParams {
@@ -11,9 +12,6 @@ interface UseAppFeedbackEffectsParams {
   mapLocationMessage: string | null;
   stampUnlockRadiusMeters: number;
   noticeDismissDelayMs: number;
-  setStampActionMessage: (message: string) => void;
-  setNotice: (notice: string | null) => void;
-  setMapLocationMessage: (message: string | null) => void;
 }
 
 export function useAppFeedbackEffects({
@@ -25,10 +23,11 @@ export function useAppFeedbackEffects({
   mapLocationMessage,
   stampUnlockRadiusMeters,
   noticeDismissDelayMs,
-  setStampActionMessage,
-  setNotice,
-  setMapLocationMessage,
 }: UseAppFeedbackEffectsParams) {
+  const setStampActionMessage = useAppRuntimeStore((state) => state.setStampActionMessage);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const setMapLocationMessage = useAppRuntimeStore((state) => state.setMapLocationMessage);
+
   useEffect(() => {
     if (!selectedPlace) {
       setStampActionMessage('\uC7A5\uC18C\uB97C \uC120\uD0DD\uD558\uBA74 \uC624\uB298 \uC2A4\uD0EC\uD504 \uAC00\uB2A5 \uC5EC\uBD80\uB97C \uBC14\uB85C \uD655\uC778\uD560 \uC218 \uC788\uC5B4\uC694.');

--- a/src/hooks/useAppMapActions.ts
+++ b/src/hooks/useAppMapActions.ts
@@ -2,6 +2,7 @@
 import { claimStamp } from '../api/client';
 import { getCurrentDevicePosition } from '../lib/geolocation';
 import { formatDistanceMeters } from '../lib/visits';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
 import type { ApiStatus, DrawerState, Place, SessionUser, StampState, Tab } from '../types';
 import type { RouteStateCommitOptions } from './useAppRouteState';
 
@@ -11,13 +12,7 @@ type SetState<T> = Dispatch<SetStateAction<T>>;
 interface UseAppMapActionsParams {
   sessionUser: SessionUser | null;
   setPlaces: SetState<Place[]>;
-  setCurrentPosition: SetState<{ latitude: number; longitude: number } | null>;
-  setMapLocationStatus: SetState<ApiStatus>;
-  setMapLocationMessage: SetState<string | null>;
-  setMapLocationFocusKey: SetState<number>;
-  setNotice: (notice: string | null) => void;
   setStampState: SetState<StampState>;
-  setStampActionStatus: SetState<ApiStatus>;
   goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
@@ -31,18 +26,19 @@ interface UseAppMapActionsParams {
 export function useAppMapActions({
   sessionUser,
   setPlaces,
-  setCurrentPosition,
-  setMapLocationStatus,
-  setMapLocationMessage,
-  setMapLocationFocusKey,
-  setNotice,
   setStampState,
-  setStampActionStatus,
   goToTab,
   commitRouteState,
   refreshMyPageForUser,
   formatErrorMessage,
 }: UseAppMapActionsParams) {
+  const setCurrentPosition = useAppRuntimeStore((state) => state.setCurrentPosition);
+  const setMapLocationStatus = useAppRuntimeStore((state) => state.setMapLocationStatus);
+  const setMapLocationMessage = useAppRuntimeStore((state) => state.setMapLocationMessage);
+  const setMapLocationFocusKey = useAppRuntimeStore((state) => state.setMapLocationFocusKey);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const setStampActionStatus = useAppRuntimeStore((state) => state.setStampActionStatus);
+
   async function refreshCurrentPosition(shouldFocusMap: boolean) {
     setMapLocationStatus('loading');
     setMapLocationMessage('현재 위치를 확인하고 있어요.');

--- a/src/hooks/useAppPagePaginationActions.ts
+++ b/src/hooks/useAppPagePaginationActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react';
 import { getMyCommentsPage, getReviewFeedPage } from '../api/client';
 import { toReviewSummaryList } from '../lib/reviews';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
 import type { MyPageResponse, Review, SessionUser } from '../types';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -8,44 +9,32 @@ type SetState<T> = Dispatch<SetStateAction<T>>;
 interface UseAppPagePaginationActionsParams {
   sessionUser: SessionUser | null;
   myPage: MyPageResponse | null;
-  feedNextCursor: string | null;
-  feedHasMore: boolean;
-  feedLoadingMore: boolean;
-  myCommentsNextCursor: string | null;
-  myCommentsHasMore: boolean;
-  myCommentsLoadingMore: boolean;
   setReviews: SetState<Review[]>;
   setMyPage: SetState<MyPageResponse | null>;
-  setFeedNextCursor: SetState<string | null>;
-  setFeedHasMore: SetState<boolean>;
-  setFeedLoadingMore: SetState<boolean>;
-  setMyCommentsNextCursor: SetState<string | null>;
-  setMyCommentsHasMore: SetState<boolean>;
-  setMyCommentsLoadingMore: SetState<boolean>;
-  setMyCommentsLoadedOnce: SetState<boolean>;
   reportBackgroundError: (error: unknown) => void;
 }
 
 export function useAppPagePaginationActions({
   sessionUser,
   myPage,
-  feedNextCursor,
-  feedHasMore,
-  feedLoadingMore,
-  myCommentsNextCursor,
-  myCommentsHasMore,
-  myCommentsLoadingMore,
   setReviews,
   setMyPage,
-  setFeedNextCursor,
-  setFeedHasMore,
-  setFeedLoadingMore,
-  setMyCommentsNextCursor,
-  setMyCommentsHasMore,
-  setMyCommentsLoadingMore,
-  setMyCommentsLoadedOnce,
   reportBackgroundError,
 }: UseAppPagePaginationActionsParams) {
+  const feedNextCursor = useAppRuntimeStore((state) => state.feedNextCursor);
+  const feedHasMore = useAppRuntimeStore((state) => state.feedHasMore);
+  const feedLoadingMore = useAppRuntimeStore((state) => state.feedLoadingMore);
+  const myCommentsNextCursor = useAppRuntimeStore((state) => state.myCommentsNextCursor);
+  const myCommentsHasMore = useAppRuntimeStore((state) => state.myCommentsHasMore);
+  const myCommentsLoadingMore = useAppRuntimeStore((state) => state.myCommentsLoadingMore);
+  const setFeedNextCursor = useAppRuntimeStore((state) => state.setFeedNextCursor);
+  const setFeedHasMore = useAppRuntimeStore((state) => state.setFeedHasMore);
+  const setFeedLoadingMore = useAppRuntimeStore((state) => state.setFeedLoadingMore);
+  const setMyCommentsNextCursor = useAppRuntimeStore((state) => state.setMyCommentsNextCursor);
+  const setMyCommentsHasMore = useAppRuntimeStore((state) => state.setMyCommentsHasMore);
+  const setMyCommentsLoadingMore = useAppRuntimeStore((state) => state.setMyCommentsLoadingMore);
+  const setMyCommentsLoadedOnce = useAppRuntimeStore((state) => state.setMyCommentsLoadedOnce);
+
   const loadMoreFeedReviews = useCallback(async () => {
     if (feedLoadingMore || !feedHasMore) {
       return;

--- a/src/hooks/useAppReviewActions.ts
+++ b/src/hooks/useAppReviewActions.ts
@@ -10,6 +10,8 @@ import {
   uploadReviewImage,
 } from '../api/client';
 import { countCommentsInThread, toReviewSummary } from '../lib/reviews';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
+import { useReviewUIStore } from '../store/review-ui-store';
 import type { RouteStateCommitOptions } from './useAppRouteState';
 import type {
   Comment,
@@ -34,17 +36,10 @@ interface UseAppReviewActionsParams {
   myPage: MyPageResponse | null;
   activeCommentReviewId: string | null;
   highlightedReviewId: string | null;
-  setReviewSubmitting: SetState<boolean>;
-  setReviewError: SetState<string | null>;
-  setCommentSubmittingReviewId: SetState<string | null>;
-  setCommentMutatingId: SetState<string | null>;
-  setDeletingReviewId: SetState<string | null>;
-  setReviewLikeUpdatingId: SetState<string | null>;
   setSelectedPlaceReviews: SetState<Review[]>;
   setReviews: SetState<Review[]>;
   setMyPage: SetState<MyPageResponse | null>;
   setNotice: (notice: string | null) => void;
-  setHighlightedReviewId: (reviewId: string | null) => void;
   goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
   commitRouteState: (
     nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
@@ -70,17 +65,10 @@ export function useAppReviewActions({
   myPage,
   activeCommentReviewId,
   highlightedReviewId,
-  setReviewSubmitting,
-  setReviewError,
-  setCommentSubmittingReviewId,
-  setCommentMutatingId,
-  setDeletingReviewId,
-  setReviewLikeUpdatingId,
   setSelectedPlaceReviews,
   setReviews,
   setMyPage,
   setNotice,
-  setHighlightedReviewId,
   goToTab,
   commitRouteState,
   refreshMyPageForUser,
@@ -92,6 +80,14 @@ export function useAppReviewActions({
   clearReviewComments,
   formatErrorMessage,
 }: UseAppReviewActionsParams) {
+  const setReviewSubmitting = useAppRuntimeStore((state) => state.setReviewSubmitting);
+  const setReviewError = useAppRuntimeStore((state) => state.setReviewError);
+  const setCommentSubmittingReviewId = useAppRuntimeStore((state) => state.setCommentSubmittingReviewId);
+  const setCommentMutatingId = useAppRuntimeStore((state) => state.setCommentMutatingId);
+  const setDeletingReviewId = useAppRuntimeStore((state) => state.setDeletingReviewId);
+  const setReviewLikeUpdatingId = useAppRuntimeStore((state) => state.setReviewLikeUpdatingId);
+  const setHighlightedReviewId = useReviewUIStore((state) => state.setHighlightedReviewId);
+
   async function handleCreateReview(payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) {
     if (!sessionUser || !selectedPlace) {
       goToTab('my');

--- a/src/hooks/useAppRouteActions.ts
+++ b/src/hooks/useAppRouteActions.ts
@@ -1,19 +1,16 @@
 ﻿import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { createUserRoute, toggleCommunityRouteLike } from '../api/client';
-import type { MyPageResponse, MyPageTabKey, SessionUser, Tab, UserRoute } from '../types';
+import { useAuthStore } from '../store/auth-store';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
+import { useMyPageStore } from '../store/my-page-store';
+import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../types';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
 type HistoryMode = 'push' | 'replace';
 
 interface UseAppRouteActionsParams {
-  sessionUser: SessionUser | null;
-  setRouteLikeUpdatingId: SetState<string | null>;
-  setRouteSubmitting: SetState<boolean>;
-  setRouteError: SetState<string | null>;
   setMyPage: SetState<MyPageResponse | null>;
-  setNotice: (notice: string | null) => void;
-  setMyPageTab: (nextTab: MyPageTabKey) => void;
   communityRoutesCacheRef: MutableRefObject<CommunityRoutesCache>;
   patchCommunityRoutes: (routeId: string, updater: (route: UserRoute) => UserRoute) => void;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
@@ -22,19 +19,20 @@ interface UseAppRouteActionsParams {
 }
 
 export function useAppRouteActions({
-  sessionUser,
-  setRouteLikeUpdatingId,
-  setRouteSubmitting,
-  setRouteError,
   setMyPage,
-  setNotice,
-  setMyPageTab,
   communityRoutesCacheRef,
   patchCommunityRoutes,
   refreshMyPageForUser,
   formatErrorMessage,
   goToTab,
 }: UseAppRouteActionsParams) {
+  const sessionUser = useAuthStore((state) => state.sessionUser);
+  const setRouteLikeUpdatingId = useAppRuntimeStore((state) => state.setRouteLikeUpdatingId);
+  const setRouteSubmitting = useAppRuntimeStore((state) => state.setRouteSubmitting);
+  const setRouteError = useAppRuntimeStore((state) => state.setRouteError);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const setMyPageTab = useMyPageStore((state) => state.setMyPageTab);
+
   async function handleToggleRouteLike(routeId: string) {
     if (!sessionUser) {
       goToTab('my');

--- a/src/hooks/useAppRouteState.ts
+++ b/src/hooks/useAppRouteState.ts
@@ -1,5 +1,6 @@
-﻿import { useCallback, useEffect } from 'react';
-import { useAppUIStore } from '../store/app-ui-store';
+import { useCallback, useEffect } from 'react';
+import { useAppMapStore } from '../store/app-map-store';
+import { useAppRouteStore } from '../store/app-route-store';
 import type { DrawerState, RoutePreview, Tab } from '../types';
 
 export type RouteState = {
@@ -186,29 +187,29 @@ function initializeRouteStore() {
     return;
   }
   const routeState = getInitialRouteState();
-  useAppUIStore.setState({
+  useAppRouteStore.setState({
     activeTab: routeState.tab,
     selectedPlaceId: routeState.tab === 'map' ? routeState.placeId : null,
     selectedFestivalId: routeState.tab === 'map' ? routeState.festivalId : null,
     drawerState: routeState.tab === 'map' ? routeState.drawerState : 'closed',
-    selectedRoutePreview: getRoutePreviewFromHistoryState(window.history.state),
   });
+  useAppMapStore.setState({ selectedRoutePreview: getRoutePreviewFromHistoryState(window.history.state) });
   routeStoreInitialized = true;
 }
 
 export function useAppRouteState() {
   initializeRouteStore();
 
-  const activeTab = useAppUIStore((state) => state.activeTab);
-  const drawerState = useAppUIStore((state) => state.drawerState);
-  const selectedPlaceId = useAppUIStore((state) => state.selectedPlaceId);
-  const selectedFestivalId = useAppUIStore((state) => state.selectedFestivalId);
-  const selectedRoutePreview = useAppUIStore((state) => state.selectedRoutePreview);
-  const setActiveTab = useAppUIStore((state) => state.setActiveTab);
-  const setDrawerState = useAppUIStore((state) => state.setDrawerState);
-  const setSelectedPlaceId = useAppUIStore((state) => state.setSelectedPlaceId);
-  const setSelectedFestivalId = useAppUIStore((state) => state.setSelectedFestivalId);
-  const setSelectedRoutePreview = useAppUIStore((state) => state.setSelectedRoutePreview);
+  const activeTab = useAppRouteStore((state) => state.activeTab);
+  const drawerState = useAppRouteStore((state) => state.drawerState);
+  const selectedPlaceId = useAppRouteStore((state) => state.selectedPlaceId);
+  const selectedFestivalId = useAppRouteStore((state) => state.selectedFestivalId);
+  const setActiveTab = useAppRouteStore((state) => state.setActiveTab);
+  const setDrawerState = useAppRouteStore((state) => state.setDrawerState);
+  const setSelectedPlaceId = useAppRouteStore((state) => state.setSelectedPlaceId);
+  const setSelectedFestivalId = useAppRouteStore((state) => state.setSelectedFestivalId);
+  const selectedRoutePreview = useAppMapStore((state) => state.selectedRoutePreview);
+  const setSelectedRoutePreview = useAppMapStore((state) => state.setSelectedRoutePreview);
 
   const applyRouteState = useCallback((routeState: RouteState, routePreview: RoutePreview | null = null) => {
     setActiveTab(routeState.tab);

--- a/src/hooks/useAppTabDataLoaders.ts
+++ b/src/hooks/useAppTabDataLoaders.ts
@@ -2,6 +2,7 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getAdminSummary, getCommunityRoutes, getMySummary, getReviewFeedPage } from '../api/client';
 import { toReviewSummaryList } from '../lib/reviews';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
 import type {
   AdminSummaryResponse,
   CommunityRouteSort,
@@ -26,13 +27,10 @@ interface UseAppTabDataLoadersParams {
   replaceCommunityRoutes: (nextRoutes: UserRoute[], sort?: CommunityRouteSort) => void;
   setCommunityRoutes: Dispatch<SetStateAction<UserRoute[]>>;
   setReviews: Dispatch<SetStateAction<Review[]>>;
-  setFeedHasMore: Dispatch<SetStateAction<boolean>>;
-  setFeedNextCursor: Dispatch<SetStateAction<string | null>>;
   setCourses: Dispatch<SetStateAction<Course[]>>;
   setAdminLoading: Dispatch<SetStateAction<boolean>>;
   setAdminSummary: Dispatch<SetStateAction<AdminSummaryResponse | null>>;
   setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
-  setMyPageError: Dispatch<SetStateAction<string | null>>;
 }
 
 export function useAppTabDataLoaders({
@@ -46,14 +44,15 @@ export function useAppTabDataLoaders({
   replaceCommunityRoutes,
   setCommunityRoutes,
   setReviews,
-  setFeedHasMore,
-  setFeedNextCursor,
   setCourses,
   setAdminLoading,
   setAdminSummary,
   setMyPage,
-  setMyPageError,
 }: UseAppTabDataLoadersParams) {
+  const setFeedHasMore = useAppRuntimeStore((state) => state.setFeedHasMore);
+  const setFeedNextCursor = useAppRuntimeStore((state) => state.setFeedNextCursor);
+  const setMyPageError = useAppRuntimeStore((state) => state.setMyPageError);
+
   const fetchCommunityRoutes = useCallback(async (sort: CommunityRouteSort, force = false) => {
     const cached = communityRoutesCacheRef.current[sort];
     if (!force && cached) {

--- a/src/store/app-map-store.ts
+++ b/src/store/app-map-store.ts
@@ -1,0 +1,17 @@
+import { create } from 'zustand';
+import type { Category, RoutePreview } from '../types';
+import { resolveValue, type SetterValue } from './store-utils';
+
+type AppMapStoreState = {
+  activeCategory: Category;
+  selectedRoutePreview: RoutePreview | null;
+  setActiveCategory: (value: SetterValue<Category>) => void;
+  setSelectedRoutePreview: (value: SetterValue<RoutePreview | null>) => void;
+};
+
+export const useAppMapStore = create<AppMapStoreState>((set) => ({
+  activeCategory: 'all',
+  selectedRoutePreview: null,
+  setActiveCategory: (value) => set((state) => ({ activeCategory: resolveValue(value, state.activeCategory) })),
+  setSelectedRoutePreview: (value) => set((state) => ({ selectedRoutePreview: resolveValue(value, state.selectedRoutePreview) })),
+}));

--- a/src/store/app-route-store.ts
+++ b/src/store/app-route-store.ts
@@ -1,0 +1,25 @@
+import { create } from 'zustand';
+import type { DrawerState, Tab } from '../types';
+import { resolveValue, type SetterValue } from './store-utils';
+
+type AppRouteStoreState = {
+  activeTab: Tab;
+  drawerState: DrawerState;
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  setActiveTab: (value: SetterValue<Tab>) => void;
+  setDrawerState: (value: SetterValue<DrawerState>) => void;
+  setSelectedPlaceId: (value: SetterValue<string | null>) => void;
+  setSelectedFestivalId: (value: SetterValue<string | null>) => void;
+};
+
+export const useAppRouteStore = create<AppRouteStoreState>((set) => ({
+  activeTab: 'map',
+  drawerState: 'closed',
+  selectedPlaceId: null,
+  selectedFestivalId: null,
+  setActiveTab: (value) => set((state) => ({ activeTab: resolveValue(value, state.activeTab) })),
+  setDrawerState: (value) => set((state) => ({ drawerState: resolveValue(value, state.drawerState) })),
+  setSelectedPlaceId: (value) => set((state) => ({ selectedPlaceId: resolveValue(value, state.selectedPlaceId) })),
+  setSelectedFestivalId: (value) => set((state) => ({ selectedFestivalId: resolveValue(value, state.selectedFestivalId) })),
+}));

--- a/src/store/app-runtime-store.ts
+++ b/src/store/app-runtime-store.ts
@@ -1,11 +1,6 @@
-﻿import { create } from 'zustand';
+import { create } from 'zustand';
 import type { ApiStatus } from '../types';
-
-type SetterValue<T> = T | ((current: T) => T);
-
-function resolveValue<T>(value: SetterValue<T>, current: T): T {
-  return typeof value === 'function' ? (value as (current: T) => T)(current) : value;
-}
+import { resolveValue, type SetterValue } from './store-utils';
 
 type Position = { latitude: number; longitude: number } | null;
 

--- a/src/store/app-ui-store.ts
+++ b/src/store/app-ui-store.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Category, DrawerState, MyPageTabKey, RoutePreview, Tab } from '../types';
+import type { DrawerState, MyPageTabKey, Tab } from '../types';
 import { resolveValue, type SetterValue } from './store-utils';
 
 export type ReturnViewState = {
@@ -15,35 +15,11 @@ export type ReturnViewState = {
 };
 
 type AppUIState = {
-  activeTab: Tab;
-  drawerState: DrawerState;
-  selectedPlaceId: string | null;
-  selectedFestivalId: string | null;
-  activeCategory: Category;
-  selectedRoutePreview: RoutePreview | null;
   returnView: ReturnViewState | null;
-  setActiveTab: (value: SetterValue<Tab>) => void;
-  setDrawerState: (value: SetterValue<DrawerState>) => void;
-  setSelectedPlaceId: (value: SetterValue<string | null>) => void;
-  setSelectedFestivalId: (value: SetterValue<string | null>) => void;
-  setActiveCategory: (value: SetterValue<Category>) => void;
-  setSelectedRoutePreview: (value: SetterValue<RoutePreview | null>) => void;
   setReturnView: (value: SetterValue<ReturnViewState | null>) => void;
 };
 
 export const useAppUIStore = create<AppUIState>((set) => ({
-  activeTab: 'map',
-  drawerState: 'closed',
-  selectedPlaceId: null,
-  selectedFestivalId: null,
-  activeCategory: 'all',
-  selectedRoutePreview: null,
   returnView: null,
-  setActiveTab: (value) => set((state) => ({ activeTab: resolveValue(value, state.activeTab) })),
-  setDrawerState: (value) => set((state) => ({ drawerState: resolveValue(value, state.drawerState) })),
-  setSelectedPlaceId: (value) => set((state) => ({ selectedPlaceId: resolveValue(value, state.selectedPlaceId) })),
-  setSelectedFestivalId: (value) => set((state) => ({ selectedFestivalId: resolveValue(value, state.selectedFestivalId) })),
-  setActiveCategory: (value) => set((state) => ({ activeCategory: resolveValue(value, state.activeCategory) })),
-  setSelectedRoutePreview: (value) => set((state) => ({ selectedRoutePreview: resolveValue(value, state.selectedRoutePreview) })),
   setReturnView: (value) => set((state) => ({ returnView: resolveValue(value, state.returnView) })),
 }));

--- a/src/store/auth-store.ts
+++ b/src/store/auth-store.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand';
+import type { AuthProvider, SessionUser } from '../types';
+import { resolveValue, type SetterValue } from './store-utils';
+
+const emptyProviders: AuthProvider[] = [
+  { key: 'naver', label: '네이버', isEnabled: false, loginUrl: null },
+  { key: 'kakao', label: '카카오', isEnabled: false, loginUrl: null },
+];
+
+type AuthStoreState = {
+  sessionUser: SessionUser | null;
+  providers: AuthProvider[];
+  setSessionUser: (value: SetterValue<SessionUser | null>) => void;
+  setProviders: (value: SetterValue<AuthProvider[]>) => void;
+};
+
+export const useAuthStore = create<AuthStoreState>((set) => ({
+  sessionUser: null,
+  providers: emptyProviders,
+  setSessionUser: (value) => set((state) => ({ sessionUser: resolveValue(value, state.sessionUser) })),
+  setProviders: (value) => set((state) => ({ providers: resolveValue(value, state.providers) })),
+}));

--- a/test/unit/useAppPagePaginationActions.test.tsx
+++ b/test/unit/useAppPagePaginationActions.test.tsx
@@ -1,6 +1,7 @@
 import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useAppPagePaginationActions } from '../../src/hooks/useAppPagePaginationActions';
+import { useAppRuntimeStore } from '../../src/store/app-runtime-store';
 import { createReviewFixture, myCommentFixture, myPageFixture, sessionUserFixture } from '../fixtures/app-fixtures';
 import type { MyPageResponse, Review } from '../../src/types';
 
@@ -14,13 +15,24 @@ import { getMyCommentsPage, getReviewFeedPage } from '../../src/api/client';
 describe('useAppPagePaginationActions', () => {
   beforeEach(() => {
     vi.resetAllMocks();
+    useAppRuntimeStore.setState({
+      feedNextCursor: null,
+      feedHasMore: false,
+      feedLoadingMore: false,
+      myCommentsNextCursor: null,
+      myCommentsHasMore: false,
+      myCommentsLoadingMore: false,
+      myCommentsLoadedOnce: false,
+    });
   });
 
   it('appends deduped summarized reviews when loading more feed items', async () => {
     let reviews: Review[] = [createReviewFixture({ id: 'review-1', comments: [] })];
-    let feedNextCursor: string | null = 'cursor-1';
-    let feedHasMore = true;
-    let feedLoadingMore = false;
+    useAppRuntimeStore.setState({
+      feedNextCursor: 'cursor-1',
+      feedHasMore: true,
+      feedLoadingMore: false,
+    });
 
     vi.mocked(getReviewFeedPage).mockResolvedValue({
       items: [
@@ -33,29 +45,10 @@ describe('useAppPagePaginationActions', () => {
     const { result } = renderHook(() => useAppPagePaginationActions({
       sessionUser: sessionUserFixture,
       myPage: myPageFixture,
-      feedNextCursor,
-      feedHasMore,
-      feedLoadingMore,
-      myCommentsNextCursor: null,
-      myCommentsHasMore: false,
-      myCommentsLoadingMore: false,
       setReviews: (nextValue) => {
         reviews = typeof nextValue === 'function' ? nextValue(reviews) : nextValue;
       },
       setMyPage: vi.fn(),
-      setFeedNextCursor: (nextValue) => {
-        feedNextCursor = typeof nextValue === 'function' ? nextValue(feedNextCursor) : nextValue;
-      },
-      setFeedHasMore: (nextValue) => {
-        feedHasMore = typeof nextValue === 'function' ? nextValue(feedHasMore) : nextValue;
-      },
-      setFeedLoadingMore: (nextValue) => {
-        feedLoadingMore = typeof nextValue === 'function' ? nextValue(feedLoadingMore) : nextValue;
-      },
-      setMyCommentsNextCursor: vi.fn(),
-      setMyCommentsHasMore: vi.fn(),
-      setMyCommentsLoadingMore: vi.fn(),
-      setMyCommentsLoadedOnce: vi.fn(),
       reportBackgroundError: vi.fn(),
     }));
 
@@ -69,9 +62,9 @@ describe('useAppPagePaginationActions', () => {
       ...createReviewFixture({ id: 'review-2', comments: [myPageFixture.reviews[0].comments[0]], commentCount: 1 }),
       comments: [],
     });
-    expect(feedNextCursor).toBe('cursor-2');
-    expect(feedHasMore).toBe(true);
-    expect(feedLoadingMore).toBe(false);
+    expect(useAppRuntimeStore.getState().feedNextCursor).toBe('cursor-2');
+    expect(useAppRuntimeStore.getState().feedHasMore).toBe(true);
+    expect(useAppRuntimeStore.getState().feedLoadingMore).toBe(false);
   });
 
   it('replaces my comments on initial load and appends deduped items otherwise', async () => {
@@ -79,10 +72,12 @@ describe('useAppPagePaginationActions', () => {
       ...myPageFixture,
       comments: [myCommentFixture],
     };
-    let myCommentsNextCursor: string | null = 'cursor-1';
-    let myCommentsHasMore = true;
-    let myCommentsLoadingMore = false;
-    let myCommentsLoadedOnce = false;
+    useAppRuntimeStore.setState({
+      myCommentsNextCursor: 'cursor-1',
+      myCommentsHasMore: true,
+      myCommentsLoadingMore: false,
+      myCommentsLoadedOnce: false,
+    });
 
     vi.mocked(getMyCommentsPage)
       .mockResolvedValueOnce({
@@ -97,30 +92,9 @@ describe('useAppPagePaginationActions', () => {
     const { result, rerender } = renderHook(() => useAppPagePaginationActions({
       sessionUser: sessionUserFixture,
       myPage,
-      feedNextCursor: null,
-      feedHasMore: false,
-      feedLoadingMore: false,
-      myCommentsNextCursor,
-      myCommentsHasMore,
-      myCommentsLoadingMore,
       setReviews: vi.fn(),
       setMyPage: (nextValue) => {
         myPage = typeof nextValue === 'function' ? nextValue(myPage) : nextValue;
-      },
-      setFeedNextCursor: vi.fn(),
-      setFeedHasMore: vi.fn(),
-      setFeedLoadingMore: vi.fn(),
-      setMyCommentsNextCursor: (nextValue) => {
-        myCommentsNextCursor = typeof nextValue === 'function' ? nextValue(myCommentsNextCursor) : nextValue;
-      },
-      setMyCommentsHasMore: (nextValue) => {
-        myCommentsHasMore = typeof nextValue === 'function' ? nextValue(myCommentsHasMore) : nextValue;
-      },
-      setMyCommentsLoadingMore: (nextValue) => {
-        myCommentsLoadingMore = typeof nextValue === 'function' ? nextValue(myCommentsLoadingMore) : nextValue;
-      },
-      setMyCommentsLoadedOnce: (nextValue) => {
-        myCommentsLoadedOnce = typeof nextValue === 'function' ? nextValue(myCommentsLoadedOnce) : nextValue;
       },
       reportBackgroundError: vi.fn(),
     }));
@@ -130,9 +104,9 @@ describe('useAppPagePaginationActions', () => {
     });
     expect(getMyCommentsPage).toHaveBeenNthCalledWith(1, { cursor: null, limit: 10 });
     expect(myPage?.comments.map((comment) => comment.id)).toEqual(['comment-2']);
-    expect(myCommentsNextCursor).toBe('cursor-2');
-    expect(myCommentsHasMore).toBe(true);
-    expect(myCommentsLoadedOnce).toBe(true);
+    expect(useAppRuntimeStore.getState().myCommentsNextCursor).toBe('cursor-2');
+    expect(useAppRuntimeStore.getState().myCommentsHasMore).toBe(true);
+    expect(useAppRuntimeStore.getState().myCommentsLoadedOnce).toBe(true);
     rerender();
 
     await act(async () => {
@@ -140,8 +114,8 @@ describe('useAppPagePaginationActions', () => {
     });
     expect(getMyCommentsPage).toHaveBeenNthCalledWith(2, { cursor: 'cursor-2', limit: 10 });
     expect(myPage?.comments.map((comment) => comment.id)).toEqual(['comment-2', 'comment-3']);
-    expect(myCommentsNextCursor).toBeNull();
-    expect(myCommentsHasMore).toBe(false);
-    expect(myCommentsLoadingMore).toBe(false);
+    expect(useAppRuntimeStore.getState().myCommentsNextCursor).toBeNull();
+    expect(useAppRuntimeStore.getState().myCommentsHasMore).toBe(false);
+    expect(useAppRuntimeStore.getState().myCommentsLoadingMore).toBe(false);
   });
 });

--- a/test/unit/useAppReviewActions.test.tsx
+++ b/test/unit/useAppReviewActions.test.tsx
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { MyPageResponse, Review } from '../../src/types';
 import { useActiveReviewComments } from '../../src/hooks/useActiveReviewComments';
 import { useAppReviewActions } from '../../src/hooks/useAppReviewActions';
+import { useAppRuntimeStore } from '../../src/store/app-runtime-store';
+import { useReviewUIStore } from '../../src/store/review-ui-store';
 import { createReviewFixture, myPageFixture, placeFixture, sessionUserFixture } from '../fixtures/app-fixtures';
 
 vi.mock('../../src/api/client', () => ({
@@ -23,6 +25,17 @@ describe('useAppReviewActions', () => {
   beforeEach(() => {
     vi.resetAllMocks();
     vi.mocked(getReviewComments).mockResolvedValue([]);
+    useAppRuntimeStore.setState({
+      reviewSubmitting: false,
+      reviewError: null,
+      reviewLikeUpdatingId: null,
+      commentSubmittingReviewId: null,
+      commentMutatingId: null,
+      deletingReviewId: null,
+    });
+    useReviewUIStore.setState({
+      highlightedReviewId: null,
+    });
   });
 
   it('keeps my-page reviews summarized after editing a review', async () => {
@@ -80,17 +93,10 @@ describe('useAppReviewActions', () => {
       myPage: myPageState,
       activeCommentReviewId: null,
       highlightedReviewId: null,
-      setReviewSubmitting: vi.fn(),
-      setReviewError: vi.fn(),
-      setCommentSubmittingReviewId: vi.fn(),
-      setCommentMutatingId: vi.fn(),
-      setDeletingReviewId: vi.fn(),
-      setReviewLikeUpdatingId: vi.fn(),
       setSelectedPlaceReviews: vi.fn(),
       setReviews: vi.fn(),
       setMyPage,
       setNotice: vi.fn(),
-      setHighlightedReviewId: vi.fn(),
       goToTab: vi.fn(),
       commitRouteState: vi.fn(),
       refreshMyPageForUser: vi.fn(),


### PR DESCRIPTION
## ����
- App shell ���¸� auth/map/route/runtime/review/my ������ store�� 2�� �и��߽��ϴ�.
- `App.tsx`���� ������ �ѱ��� setter prop drilling�� ���̰�, �� ���� �ʿ��� store�� ���� �е��� �����߽��ϴ�.
- `page_repository` facade�� �߰��ϰ� `page_service`�� �ش� ���踦 �����ϵ��� �ٲ����ϴ�.
- ���� unit/backend �׽�Ʈ�� � �ε��� ������ ���� ������ �°� �����߽��ϴ�.

## ����
- npm run typecheck
- npm run build
- npm run test:unit -- useAppReviewActions useAppPagePaginationActions useAppRouteState useAppShellNavigation
- backend tests/test_page_service.py tests/test_review_service.py
