### PR TITLE
Refactor bootstrap status runtime store

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -135,6 +135,8 @@ export default function App() {
   const myCommentsHasMore = useAppRuntimeStore((state) => state.myCommentsHasMore);
   const myCommentsLoadingMore = useAppRuntimeStore((state) => state.myCommentsLoadingMore);
   const myCommentsLoadedOnce = useAppRuntimeStore((state) => state.myCommentsLoadedOnce);
+  const bootstrapStatus = useAppRuntimeStore((state) => state.bootstrapStatus);
+  const bootstrapError = useAppRuntimeStore((state) => state.bootstrapError);
 
   useEffect(() => {
     const initialNotice = getInitialNotice();
@@ -147,10 +149,6 @@ export default function App() {
   const providers = useAuthStore((state) => state.providers);
 
   const {
-    bootstrapStatus,
-    setBootstrapStatus,
-    bootstrapError,
-    setBootstrapError,
     places,
     setPlaces,
     festivals,
@@ -345,8 +343,6 @@ export default function App() {
     communityRouteSort,
     myCommentsLoadedOnce,
     placeReviewsCacheRef,
-    setBootstrapStatus,
-    setBootstrapError,
     setPlaces,
     setFestivals,
     setStampState,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -71,8 +71,6 @@ export default function App() {
     drawerState,
     selectedPlaceId,
     selectedFestivalId,
-    setSelectedPlaceId,
-    setSelectedFestivalId,
     commitRouteState,
     goToTab,
     openPlace,
@@ -132,20 +130,11 @@ export default function App() {
   const setMyPageError = useAppRuntimeStore((state) => state.setMyPageError);
   const isLoggingOut = useAppRuntimeStore((state) => state.isLoggingOut);
   const setIsLoggingOut = useAppRuntimeStore((state) => state.setIsLoggingOut);
-  const feedNextCursor = useAppRuntimeStore((state) => state.feedNextCursor);
-  const setFeedNextCursor = useAppRuntimeStore((state) => state.setFeedNextCursor);
   const feedHasMore = useAppRuntimeStore((state) => state.feedHasMore);
-  const setFeedHasMore = useAppRuntimeStore((state) => state.setFeedHasMore);
   const feedLoadingMore = useAppRuntimeStore((state) => state.feedLoadingMore);
-  const setFeedLoadingMore = useAppRuntimeStore((state) => state.setFeedLoadingMore);
-  const myCommentsNextCursor = useAppRuntimeStore((state) => state.myCommentsNextCursor);
-  const setMyCommentsNextCursor = useAppRuntimeStore((state) => state.setMyCommentsNextCursor);
   const myCommentsHasMore = useAppRuntimeStore((state) => state.myCommentsHasMore);
-  const setMyCommentsHasMore = useAppRuntimeStore((state) => state.setMyCommentsHasMore);
   const myCommentsLoadingMore = useAppRuntimeStore((state) => state.myCommentsLoadingMore);
-  const setMyCommentsLoadingMore = useAppRuntimeStore((state) => state.setMyCommentsLoadingMore);
   const myCommentsLoadedOnce = useAppRuntimeStore((state) => state.myCommentsLoadedOnce);
-  const setMyCommentsLoadedOnce = useAppRuntimeStore((state) => state.setMyCommentsLoadedOnce);
 
   useEffect(() => {
     const initialNotice = getInitialNotice();
@@ -155,9 +144,7 @@ export default function App() {
     setNotice((current) => current ?? initialNotice);
   }, [setNotice]);
   const sessionUser = useAuthStore((state) => state.sessionUser);
-  const setSessionUser = useAuthStore((state) => state.setSessionUser);
   const providers = useAuthStore((state) => state.providers);
-  const setProviders = useAuthStore((state) => state.setProviders);
 
   const {
     bootstrapStatus,
@@ -364,19 +351,7 @@ export default function App() {
     setFestivals,
     setStampState,
     setHasRealData,
-    setSessionUser,
-    setProviders,
-    setSelectedPlaceId,
-    setSelectedFestivalId,
     setSelectedPlaceReviews,
-    setNotice,
-    setFeedNextCursor,
-    setFeedHasMore,
-    setFeedLoadingMore,
-    setMyCommentsNextCursor,
-    setMyCommentsHasMore,
-    setMyCommentsLoadingMore,
-    setMyCommentsLoadedOnce,
     setMyPage,
     resetReviewCaches,
     refreshMyPageForUser,

--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -2,11 +2,13 @@ import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getFestivals, getMapBootstrap, getReviews } from '../api/client';
 import { toReviewSummaryList } from '../lib/reviews';
+import { useAuthStore } from '../store/auth-store';
+import { useAppRuntimeStore } from '../store/app-runtime-store';
+import { useAppRouteStore } from '../store/app-route-store';
 import { clearAuthQueryParams } from './useAppRouteState';
 import type {
   AdminSummaryResponse,
   ApiStatus,
-  AuthProvider,
   FestivalItem,
   MyPageResponse,
   Place,
@@ -32,19 +34,7 @@ interface UseAppBootstrapLifecycleParams {
   setFestivals: Dispatch<SetStateAction<FestivalItem[]>>;
   setStampState: Dispatch<SetStateAction<StampState>>;
   setHasRealData: Dispatch<SetStateAction<boolean>>;
-  setSessionUser: Dispatch<SetStateAction<SessionUser | null>>;
-  setProviders: Dispatch<SetStateAction<AuthProvider[]>>;
-  setSelectedPlaceId: Dispatch<SetStateAction<string | null>>;
-  setSelectedFestivalId: Dispatch<SetStateAction<string | null>>;
   setSelectedPlaceReviews: Dispatch<SetStateAction<Review[]>>;
-  setNotice: (message: string | null) => void;
-  setFeedNextCursor: Dispatch<SetStateAction<string | null>>;
-  setFeedHasMore: Dispatch<SetStateAction<boolean>>;
-  setFeedLoadingMore: Dispatch<SetStateAction<boolean>>;
-  setMyCommentsNextCursor: Dispatch<SetStateAction<string | null>>;
-  setMyCommentsHasMore: Dispatch<SetStateAction<boolean>>;
-  setMyCommentsLoadingMore: Dispatch<SetStateAction<boolean>>;
-  setMyCommentsLoadedOnce: Dispatch<SetStateAction<boolean>>;
   setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
   resetReviewCaches: () => void;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
@@ -74,19 +64,7 @@ export function useAppBootstrapLifecycle({
   setFestivals,
   setStampState,
   setHasRealData,
-  setSessionUser,
-  setProviders,
-  setSelectedPlaceId,
-  setSelectedFestivalId,
   setSelectedPlaceReviews,
-  setNotice,
-  setFeedNextCursor,
-  setFeedHasMore,
-  setFeedLoadingMore,
-  setMyCommentsNextCursor,
-  setMyCommentsHasMore,
-  setMyCommentsLoadingMore,
-  setMyCommentsLoadedOnce,
   setMyPage,
   resetReviewCaches,
   refreshMyPageForUser,
@@ -99,6 +77,19 @@ export function useAppBootstrapLifecycle({
   formatErrorMessage,
   reportBackgroundError,
 }: UseAppBootstrapLifecycleParams) {
+  const setSessionUser = useAuthStore((state) => state.setSessionUser);
+  const setProviders = useAuthStore((state) => state.setProviders);
+  const setSelectedPlaceId = useAppRouteStore((state) => state.setSelectedPlaceId);
+  const setSelectedFestivalId = useAppRouteStore((state) => state.setSelectedFestivalId);
+  const setNotice = useAppRuntimeStore((state) => state.setNotice);
+  const setFeedNextCursor = useAppRuntimeStore((state) => state.setFeedNextCursor);
+  const setFeedHasMore = useAppRuntimeStore((state) => state.setFeedHasMore);
+  const setFeedLoadingMore = useAppRuntimeStore((state) => state.setFeedLoadingMore);
+  const setMyCommentsNextCursor = useAppRuntimeStore((state) => state.setMyCommentsNextCursor);
+  const setMyCommentsHasMore = useAppRuntimeStore((state) => state.setMyCommentsHasMore);
+  const setMyCommentsLoadingMore = useAppRuntimeStore((state) => state.setMyCommentsLoadingMore);
+  const setMyCommentsLoadedOnce = useAppRuntimeStore((state) => state.setMyCommentsLoadedOnce);
+
   const refreshMyPageForUserRef = useRef(refreshMyPageForUser);
   const resetReviewCachesRef = useRef(resetReviewCaches);
   const goToTabRef = useRef(goToTab);

--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -8,7 +8,6 @@ import { useAppRouteStore } from '../store/app-route-store';
 import { clearAuthQueryParams } from './useAppRouteState';
 import type {
   AdminSummaryResponse,
-  ApiStatus,
   FestivalItem,
   MyPageResponse,
   Place,
@@ -28,8 +27,6 @@ interface UseAppBootstrapLifecycleParams {
   communityRouteSort: 'popular' | 'latest';
   myCommentsLoadedOnce: boolean;
   placeReviewsCacheRef: MutableRefObject<Record<string, Review[]>>;
-  setBootstrapStatus: (status: ApiStatus) => void;
-  setBootstrapError: (message: string | null) => void;
   setPlaces: Dispatch<SetStateAction<Place[]>>;
   setFestivals: Dispatch<SetStateAction<FestivalItem[]>>;
   setStampState: Dispatch<SetStateAction<StampState>>;
@@ -58,8 +55,6 @@ export function useAppBootstrapLifecycle({
   communityRouteSort,
   myCommentsLoadedOnce,
   placeReviewsCacheRef,
-  setBootstrapStatus,
-  setBootstrapError,
   setPlaces,
   setFestivals,
   setStampState,
@@ -79,6 +74,8 @@ export function useAppBootstrapLifecycle({
 }: UseAppBootstrapLifecycleParams) {
   const setSessionUser = useAuthStore((state) => state.setSessionUser);
   const setProviders = useAuthStore((state) => state.setProviders);
+  const setBootstrapStatus = useAppRuntimeStore((state) => state.setBootstrapStatus);
+  const setBootstrapError = useAppRuntimeStore((state) => state.setBootstrapError);
   const setSelectedPlaceId = useAppRouteStore((state) => state.setSelectedPlaceId);
   const setSelectedFestivalId = useAppRouteStore((state) => state.setSelectedFestivalId);
   const setNotice = useAppRuntimeStore((state) => state.setNotice);

--- a/src/hooks/useAppDataState.ts
+++ b/src/hooks/useAppDataState.ts
@@ -10,8 +10,6 @@ import type {
 } from '../types';
 
 export function useAppDataState(selectedPlaceId: string | null) {
-  const [bootstrapStatus, setBootstrapStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
-  const [bootstrapError, setBootstrapError] = useState<string | null>(null);
   const [places, setPlaces] = useState<BootstrapResponse['places']>([]);
   const [festivals, setFestivals] = useState<FestivalItem[]>([]);
   const [reviews, setReviews] = useState<BootstrapResponse['reviews']>([]);
@@ -80,10 +78,6 @@ export function useAppDataState(selectedPlaceId: string | null) {
   }
 
   return {
-    bootstrapStatus,
-    setBootstrapStatus,
-    bootstrapError,
-    setBootstrapError,
     places,
     setPlaces,
     festivals,

--- a/src/store/app-runtime-store.ts
+++ b/src/store/app-runtime-store.ts
@@ -5,6 +5,8 @@ import { resolveValue, type SetterValue } from './store-utils';
 type Position = { latitude: number; longitude: number } | null;
 
 type AppRuntimeState = {
+  bootstrapStatus: ApiStatus;
+  bootstrapError: string | null;
   notice: string | null;
   currentPosition: Position;
   mapLocationStatus: ApiStatus;
@@ -32,6 +34,8 @@ type AppRuntimeState = {
   myCommentsHasMore: boolean;
   myCommentsLoadingMore: boolean;
   myCommentsLoadedOnce: boolean;
+  setBootstrapStatus: (value: SetterValue<ApiStatus>) => void;
+  setBootstrapError: (value: SetterValue<string | null>) => void;
   setNotice: (value: SetterValue<string | null>) => void;
   setCurrentPosition: (value: SetterValue<Position>) => void;
   setMapLocationStatus: (value: SetterValue<ApiStatus>) => void;
@@ -62,6 +66,8 @@ type AppRuntimeState = {
 };
 
 export const useAppRuntimeStore = create<AppRuntimeState>((set) => ({
+  bootstrapStatus: 'idle',
+  bootstrapError: null,
   notice: null,
   currentPosition: null,
   mapLocationStatus: 'idle',
@@ -89,6 +95,8 @@ export const useAppRuntimeStore = create<AppRuntimeState>((set) => ({
   myCommentsHasMore: false,
   myCommentsLoadingMore: false,
   myCommentsLoadedOnce: false,
+  setBootstrapStatus: (value) => set((state) => ({ bootstrapStatus: resolveValue(value, state.bootstrapStatus) })),
+  setBootstrapError: (value) => set((state) => ({ bootstrapError: resolveValue(value, state.bootstrapError) })),
   setNotice: (value) => set((state) => ({ notice: resolveValue(value, state.notice) })),
   setCurrentPosition: (value) => set((state) => ({ currentPosition: resolveValue(value, state.currentPosition) })),
   setMapLocationStatus: (value) => set((state) => ({ mapLocationStatus: resolveValue(value, state.mapLocationStatus) })),


### PR DESCRIPTION
## 요약
- bootstrap status/error를 app runtime store로 이동
- useAppDataState에서 bootstrap 상태 소유권 제거
- App/useAppBootstrapLifecycle의 bootstrap setter 전달 제거

## 검증
- npm run typecheck
- npm run build
- npm run test:unit -- useAppReviewActions useAppPagePaginationActions useAppRouteState useAppShellNavigation