### PR TITLE
Refactor bootstrap fetch responsibilities

### DIFF
--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -1,10 +1,11 @@
 import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import { getFestivals, getMapBootstrap, getReviews } from '../api/client';
-import { toReviewSummaryList } from '../lib/reviews';
+import { getFestivals, getMapBootstrap } from '../api/client';
 import { useAuthStore } from '../store/auth-store';
 import { useAppRuntimeStore } from '../store/app-runtime-store';
 import { useAppRouteStore } from '../store/app-route-store';
+import { useAppTabWarmup } from './useAppTabWarmup';
+import { useSelectedPlaceReviewSync } from './useSelectedPlaceReviewSync';
 import { clearAuthQueryParams } from './useAppRouteState';
 import type {
   AdminSummaryResponse,
@@ -113,65 +114,29 @@ export function useAppBootstrapLifecycle({
     reportBackgroundErrorRef.current = reportBackgroundError;
   }, [reportBackgroundError]);
 
-  useEffect(() => {
-    if (!selectedPlaceId || activeTab !== 'map') {
-      setSelectedPlaceReviews([]);
-      return;
-    }
-
-    const cachedReviews = placeReviewsCacheRef.current[selectedPlaceId];
-    if (cachedReviews) {
-      setSelectedPlaceReviews(cachedReviews);
-      return;
-    }
-
-    void getReviews({ placeId: selectedPlaceId })
-      .then((nextReviews) => {
-        const nextReviewSummaries = toReviewSummaryList(nextReviews);
-        placeReviewsCacheRef.current[selectedPlaceId] = nextReviewSummaries;
-        setSelectedPlaceReviews(nextReviewSummaries);
-      })
-      .catch(reportBackgroundError);
-  }, [activeTab, placeReviewsCacheRef, reportBackgroundError, selectedPlaceId, setSelectedPlaceReviews]);
-
-  useEffect(() => {
-    if (activeTab === 'feed') {
-      void ensureFeedReviews().catch(reportBackgroundError);
-      return;
-    }
-
-    if (activeTab === 'course') {
-      void fetchCommunityRoutes(communityRouteSort).catch(reportBackgroundError);
-      return;
-    }
-
-    if (activeTab === 'my') {
-      if (sessionUser && myPage === null) {
-        void refreshMyPageForUser(sessionUser, true).catch(reportBackgroundError);
-      }
-      if (sessionUser?.isAdmin && myPageTab === 'admin' && adminSummary === null) {
-        void refreshAdminSummary().catch(reportBackgroundError);
-      }
-      if (sessionUser && myPage && myPageTab === 'comments' && !myCommentsLoadedOnce) {
-        void loadMoreMyComments(true);
-      }
-    }
-  }, [
+  useSelectedPlaceReviewSync({
     activeTab,
-    adminSummary,
-    communityRouteSort,
-    ensureCuratedCourses,
-    ensureFeedReviews,
-    fetchCommunityRoutes,
-    loadMoreMyComments,
-    myCommentsLoadedOnce,
+    selectedPlaceId,
+    placeReviewsCacheRef,
+    setSelectedPlaceReviews,
+    reportBackgroundError,
+  });
+
+  useAppTabWarmup({
+    activeTab,
+    sessionUser,
     myPage,
     myPageTab,
-    refreshAdminSummary,
+    adminSummary,
+    communityRouteSort,
+    myCommentsLoadedOnce,
+    ensureFeedReviews,
+    fetchCommunityRoutes,
     refreshMyPageForUser,
+    refreshAdminSummary,
+    loadMoreMyComments,
     reportBackgroundError,
-    sessionUser,
-  ]);
+  });
 
   useEffect(() => {
     let active = true;

--- a/src/hooks/useAppTabWarmup.ts
+++ b/src/hooks/useAppTabWarmup.ts
@@ -1,0 +1,72 @@
+import { useEffect } from 'react';
+import type { AdminSummaryResponse, MyPageResponse, SessionUser, Tab } from '../types';
+
+interface UseAppTabWarmupParams {
+  activeTab: Tab;
+  sessionUser: SessionUser | null;
+  myPage: MyPageResponse | null;
+  myPageTab: string;
+  adminSummary: AdminSummaryResponse | null;
+  communityRouteSort: 'popular' | 'latest';
+  myCommentsLoadedOnce: boolean;
+  ensureFeedReviews: (force?: boolean) => Promise<void>;
+  fetchCommunityRoutes: (sort: 'popular' | 'latest', force?: boolean) => Promise<unknown>;
+  refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
+  refreshAdminSummary: (force?: boolean) => Promise<AdminSummaryResponse | null>;
+  loadMoreMyComments: (initial?: boolean) => Promise<void>;
+  reportBackgroundError: (error: unknown) => void;
+}
+
+export function useAppTabWarmup({
+  activeTab,
+  sessionUser,
+  myPage,
+  myPageTab,
+  adminSummary,
+  communityRouteSort,
+  myCommentsLoadedOnce,
+  ensureFeedReviews,
+  fetchCommunityRoutes,
+  refreshMyPageForUser,
+  refreshAdminSummary,
+  loadMoreMyComments,
+  reportBackgroundError,
+}: UseAppTabWarmupParams) {
+  useEffect(() => {
+    if (activeTab === 'feed') {
+      void ensureFeedReviews().catch(reportBackgroundError);
+      return;
+    }
+
+    if (activeTab === 'course') {
+      void fetchCommunityRoutes(communityRouteSort).catch(reportBackgroundError);
+      return;
+    }
+
+    if (activeTab === 'my') {
+      if (sessionUser && myPage === null) {
+        void refreshMyPageForUser(sessionUser, true).catch(reportBackgroundError);
+      }
+      if (sessionUser?.isAdmin && myPageTab === 'admin' && adminSummary === null) {
+        void refreshAdminSummary().catch(reportBackgroundError);
+      }
+      if (sessionUser && myPage && myPageTab === 'comments' && !myCommentsLoadedOnce) {
+        void loadMoreMyComments(true);
+      }
+    }
+  }, [
+    activeTab,
+    adminSummary,
+    communityRouteSort,
+    ensureFeedReviews,
+    fetchCommunityRoutes,
+    loadMoreMyComments,
+    myCommentsLoadedOnce,
+    myPage,
+    myPageTab,
+    refreshAdminSummary,
+    refreshMyPageForUser,
+    reportBackgroundError,
+    sessionUser,
+  ]);
+}

--- a/src/hooks/useSelectedPlaceReviewSync.ts
+++ b/src/hooks/useSelectedPlaceReviewSync.ts
@@ -1,0 +1,42 @@
+import { useEffect } from 'react';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { getReviews } from '../api/client';
+import { toReviewSummaryList } from '../lib/reviews';
+import type { Review, Tab } from '../types';
+
+interface UseSelectedPlaceReviewSyncParams {
+  activeTab: Tab;
+  selectedPlaceId: string | null;
+  placeReviewsCacheRef: MutableRefObject<Record<string, Review[]>>;
+  setSelectedPlaceReviews: Dispatch<SetStateAction<Review[]>>;
+  reportBackgroundError: (error: unknown) => void;
+}
+
+export function useSelectedPlaceReviewSync({
+  activeTab,
+  selectedPlaceId,
+  placeReviewsCacheRef,
+  setSelectedPlaceReviews,
+  reportBackgroundError,
+}: UseSelectedPlaceReviewSyncParams) {
+  useEffect(() => {
+    if (!selectedPlaceId || activeTab !== 'map') {
+      setSelectedPlaceReviews([]);
+      return;
+    }
+
+    const cachedReviews = placeReviewsCacheRef.current[selectedPlaceId];
+    if (cachedReviews) {
+      setSelectedPlaceReviews(cachedReviews);
+      return;
+    }
+
+    void getReviews({ placeId: selectedPlaceId })
+      .then((nextReviews) => {
+        const nextReviewSummaries = toReviewSummaryList(nextReviews);
+        placeReviewsCacheRef.current[selectedPlaceId] = nextReviewSummaries;
+        setSelectedPlaceReviews(nextReviewSummaries);
+      })
+      .catch(reportBackgroundError);
+  }, [activeTab, placeReviewsCacheRef, reportBackgroundError, selectedPlaceId, setSelectedPlaceReviews]);
+}


### PR DESCRIPTION
## 요약
- bootstrap lifecycle에서 선택 장소 리뷰 동기화 책임 분리
- bootstrap lifecycle에서 탭별 warmup 책임 분리
- 초기 bootstrap 로드 흐름은 유지하고 보조 fetch 책임만 별도 훅으로 분리

## 검증
- npm run typecheck
- npm run build
- npm run test:unit -- useAppReviewActions useAppPagePaginationActions useAppRouteState useAppShellNavigation