### PR TITLE
Add my-page route navigation into course tab

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,8 @@ export default function App() {
   const setHighlightedCommentId = useReviewUIStore((state) => state.setHighlightedCommentId);
   const highlightedReviewId = useReviewUIStore((state) => state.highlightedReviewId);
   const setHighlightedReviewId = useReviewUIStore((state) => state.setHighlightedReviewId);
+  const highlightedRouteId = useReviewUIStore((state) => state.highlightedRouteId);
+  const setHighlightedRouteId = useReviewUIStore((state) => state.setHighlightedRouteId);
   const selectedRoutePreview = useAppMapStore((state) => state.selectedRoutePreview);
   const setSelectedRoutePreview = useAppMapStore((state) => state.setSelectedRoutePreview);
   const returnView = useAppUIStore((state) => state.returnView);
@@ -272,6 +274,7 @@ export default function App() {
     handleOpenReviewWithReturn,
     handleOpenPlaceFeedWithReturn,
     handleOpenCommentWithReturn,
+    handleOpenCommunityRouteWithReturn,
   } = useAppNavigationHelpers({
     activeTab,
     myPageTab,
@@ -288,6 +291,7 @@ export default function App() {
     setActiveCommentReviewId,
     setHighlightedCommentId,
     setHighlightedReviewId,
+    setHighlightedRouteId,
     setReturnView,
     setSelectedRoutePreview,
     setFeedPlaceFilterId,
@@ -505,11 +509,13 @@ export default function App() {
     handleChangeRouteSort,
     handleRetryMyPage,
     handleOpenCommentFromMyPage,
+    handleOpenRouteFromMyPage,
   } = useAppPageStageActions({
     sessionUser,
     setFeedPlaceFilterId,
     setCommunityRouteSort,
     handleOpenCommentWithReturn,
+    handleOpenCommunityRouteWithReturn,
     fetchCommunityRoutes,
     refreshMyPageForUser,
     reportBackgroundError,
@@ -614,6 +620,7 @@ export default function App() {
                 communityRoutes,
                 communityRouteSort,
                 routeLikeUpdatingId,
+                highlightedRouteId,
               }}
               myPageData={{
                 myPage: hydratedMyPage,
@@ -659,6 +666,7 @@ export default function App() {
                 onSaveNickname: handleUpdateProfile,
                 onPublishRoute: handlePublishRoute,
                 onOpenCommentFromMyPage: handleOpenCommentFromMyPage,
+                onOpenRouteFromMyPage: handleOpenRouteFromMyPage,
                 onOpenReview: handleOpenReviewWithReturn,
                 onUpdateReview: handleUpdateReview,
                 onDeleteReview: handleDeleteReview,

--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -48,6 +48,7 @@ interface AppPageStageProps {
     communityRoutes: UserRoute[];
     communityRouteSort: CommunityRouteSort;
     routeLikeUpdatingId: string | null;
+    highlightedRouteId: string | null;
   };
   myPageData: {
     myPage: MyPageResponse | null;
@@ -93,6 +94,7 @@ interface AppPageStageProps {
     onSaveNickname: (nickname: string) => Promise<void>;
     onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
     onOpenCommentFromMyPage: (reviewId: string, commentId: string) => void;
+    onOpenRouteFromMyPage: (routeId: string) => Promise<void>;
     onOpenReview: (reviewId: string) => Promise<void>;
     onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
     onDeleteReview: (reviewId: string) => Promise<void>;
@@ -169,6 +171,7 @@ export const AppPageStage = memo(function AppPageStage({
           sort={courseData.communityRouteSort}
           sessionUser={sharedData.sessionUser}
           routeLikeUpdatingId={courseData.routeLikeUpdatingId}
+          highlightedRouteId={courseData.highlightedRouteId}
           placeNameById={sharedData.placeNameById}
           onChangeSort={courseActions.onChangeRouteSort}
           onToggleLike={courseActions.onToggleRouteLike}
@@ -199,6 +202,7 @@ export const AppPageStage = memo(function AppPageStage({
           reviewActions={{
             onOpenPlace: sharedActions.onOpenPlace,
             onOpenComment: myPageActions.onOpenCommentFromMyPage,
+            onOpenRoute: myPageActions.onOpenRouteFromMyPage,
             onOpenReview: myPageActions.onOpenReview,
             onUpdateReview: myPageActions.onUpdateReview,
             onDeleteReview: myPageActions.onDeleteReview,

--- a/src/components/CourseTab.tsx
+++ b/src/components/CourseTab.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useRef } from 'react';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { HeartIcon } from './review/ReviewActionIcons';
 import type { CommunityRouteSort, Course, SessionUser, UserRoute } from '../types';
@@ -8,6 +9,7 @@ interface CourseTabProps {
   sort: CommunityRouteSort;
   sessionUser: SessionUser | null;
   routeLikeUpdatingId: string | null;
+  highlightedRouteId: string | null;
   placeNameById: Record<string, string>;
   onChangeSort: (sort: CommunityRouteSort) => void;
   onToggleLike: (routeId: string) => Promise<void>;
@@ -22,6 +24,7 @@ export function CourseTab({
   sort,
   sessionUser,
   routeLikeUpdatingId,
+  highlightedRouteId,
   placeNameById,
   onChangeSort,
   onToggleLike,
@@ -30,8 +33,20 @@ export function CourseTab({
   onRequestLogin,
 }: CourseTabProps) {
   const scrollRef = useScrollRestoration<HTMLElement>('course');
+  const routeRefs = useRef<Record<string, HTMLElement | null>>({});
   void courses;
   void placeNameById;
+
+  useEffect(() => {
+    if (!highlightedRouteId) {
+      return;
+    }
+    const target = routeRefs.current[highlightedRouteId];
+    if (!target) {
+      return;
+    }
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  }, [highlightedRouteId]);
 
   return (
     <section ref={scrollRef} className="page-panel page-panel--scrollable">
@@ -62,7 +77,13 @@ export function CourseTab({
         </div>
         <div className="community-route-list">
           {communityRoutes.map((route) => (
-            <article key={route.id} className="community-route-card">
+            <article
+              key={route.id}
+              ref={(node) => {
+                routeRefs.current[route.id] = node;
+              }}
+              className={route.id === highlightedRouteId ? 'community-route-card community-route-card--highlighted' : 'community-route-card'}
+            >
               <div className="community-route-card__header community-route-card__header--feedlike">
                 <div className="community-route-card__title-block">
                   <div className="community-route-card__tag-row">

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -28,6 +28,7 @@ interface MyPagePanelProps {
   reviewActions: {
     onOpenPlace: (placeId: string) => void;
     onOpenComment: (reviewId: string, commentId: string) => void;
+    onOpenRoute: (routeId: string) => Promise<void>;
     onOpenReview: (reviewId: string) => void;
     onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
     onDeleteReview: (reviewId: string) => Promise<void>;
@@ -100,6 +101,7 @@ export function MyPagePanel({
   const {
     onOpenPlace,
     onOpenComment,
+    onOpenRoute,
     onOpenReview,
     onUpdateReview,
     onDeleteReview,
@@ -415,6 +417,7 @@ export function MyPagePanel({
                 routeSubmitting={routeSubmitting}
                 routeError={routeError}
                 onOpenPlace={onOpenPlace}
+                onOpenRoute={onOpenRoute}
                 onPublishRoute={onPublishRoute}
               />
             )}

--- a/src/components/my-page/MyRoutesTabSection.tsx
+++ b/src/components/my-page/MyRoutesTabSection.tsx
@@ -19,6 +19,7 @@ interface MyRoutesTabSectionProps {
   routeSubmitting: boolean;
   routeError: string | null;
   onOpenPlace: (placeId: string) => void;
+  onOpenRoute: (routeId: string) => Promise<void>;
   onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
 }
 
@@ -38,6 +39,7 @@ export function MyRoutesTabSection({
   routeSubmitting,
   routeError,
   onOpenPlace,
+  onOpenRoute,
   onPublishRoute,
 }: MyRoutesTabSectionProps) {
   const [drafts, setDrafts] = useState<Record<string, DraftState>>({});
@@ -145,6 +147,11 @@ export function MyRoutesTabSection({
                   {index + 1}. {route.placeNames[index] ?? placeId}
                 </button>
               ))}
+            </div>
+            <div className="review-card__actions review-card__actions--course">
+              <button type="button" className="review-link-button" onClick={() => void onOpenRoute(route.id)}>
+                코스 탭에서 보기
+              </button>
             </div>
           </article>
         ))}

--- a/src/hooks/useAppNavigationHelpers.ts
+++ b/src/hooks/useAppNavigationHelpers.ts
@@ -25,6 +25,7 @@ interface UseAppNavigationHelpersParams {
   setActiveCommentReviewId: (reviewId: string | null) => void;
   setHighlightedCommentId: (commentId: string | null) => void;
   setHighlightedReviewId: (reviewId: string | null) => void;
+  setHighlightedRouteId: (routeId: string | null) => void;
   setReturnView: (value: ReturnViewState | null) => void;
   setSelectedRoutePreview: (route: RoutePreview | null) => void;
   setFeedPlaceFilterId: (placeId: string | null) => void;
@@ -67,6 +68,7 @@ export function useAppNavigationHelpers({
   setActiveCommentReviewId,
   setHighlightedCommentId,
   setHighlightedReviewId,
+  setHighlightedRouteId,
   setReturnView,
   setSelectedRoutePreview,
   setFeedPlaceFilterId,
@@ -191,6 +193,18 @@ export function useAppNavigationHelpers({
     handleOpenReviewComments(reviewId, commentId);
   }
 
+  function handleOpenCommunityRouteWithReturn(routeId: string) {
+    if (activeTab !== 'course') {
+      setReturnView(snapshotReturnView());
+    }
+    setHighlightedRouteId(routeId);
+    setSelectedRoutePreview(null);
+    setHighlightedReviewId(null);
+    setHighlightedCommentId(null);
+    setActiveCommentReviewId(null);
+    goToTab('course');
+  }
+
   return {
     handleOpenReviewComments,
     handleCloseReviewComments,
@@ -200,5 +214,6 @@ export function useAppNavigationHelpers({
     handleOpenReviewWithReturn,
     handleOpenPlaceFeedWithReturn,
     handleOpenCommentWithReturn,
+    handleOpenCommunityRouteWithReturn,
   };
 }

--- a/src/hooks/useAppPageStageActions.ts
+++ b/src/hooks/useAppPageStageActions.ts
@@ -6,6 +6,7 @@ interface UseAppPageStageActionsParams {
   setFeedPlaceFilterId: (placeId: string | null) => void;
   setCommunityRouteSort: (sort: 'popular' | 'latest') => void;
   handleOpenCommentWithReturn: (reviewId: string, commentId: string) => void;
+  handleOpenCommunityRouteWithReturn: (routeId: string) => void;
   fetchCommunityRoutes: (sort: 'popular' | 'latest') => Promise<unknown>;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<unknown>;
   reportBackgroundError: (error: unknown) => void;
@@ -16,6 +17,7 @@ export function useAppPageStageActions({
   setFeedPlaceFilterId,
   setCommunityRouteSort,
   handleOpenCommentWithReturn,
+  handleOpenCommunityRouteWithReturn,
   fetchCommunityRoutes,
   refreshMyPageForUser,
   reportBackgroundError,
@@ -40,10 +42,17 @@ export function useAppPageStageActions({
     handleOpenCommentWithReturn(reviewId, commentId);
   }, [handleOpenCommentWithReturn]);
 
+  const handleOpenRouteFromMyPage = useCallback(async (routeId: string) => {
+    setCommunityRouteSort('latest');
+    await fetchCommunityRoutes('latest');
+    handleOpenCommunityRouteWithReturn(routeId);
+  }, [fetchCommunityRoutes, handleOpenCommunityRouteWithReturn, setCommunityRouteSort]);
+
   return {
     handleClearPlaceFilter,
     handleChangeRouteSort,
     handleRetryMyPage,
     handleOpenCommentFromMyPage,
+    handleOpenRouteFromMyPage,
   };
 }

--- a/src/store/review-ui-store.ts
+++ b/src/store/review-ui-store.ts
@@ -6,10 +6,12 @@ type ReviewUIState = {
   activeCommentReviewId: string | null;
   highlightedCommentId: string | null;
   highlightedReviewId: string | null;
+  highlightedRouteId: string | null;
   setFeedPlaceFilterId: (value: SetterValue<string | null>) => void;
   setActiveCommentReviewId: (value: SetterValue<string | null>) => void;
   setHighlightedCommentId: (value: SetterValue<string | null>) => void;
   setHighlightedReviewId: (value: SetterValue<string | null>) => void;
+  setHighlightedRouteId: (value: SetterValue<string | null>) => void;
 };
 
 export const useReviewUIStore = create<ReviewUIState>((set) => ({
@@ -17,8 +19,10 @@ export const useReviewUIStore = create<ReviewUIState>((set) => ({
   activeCommentReviewId: null,
   highlightedCommentId: null,
   highlightedReviewId: null,
+  highlightedRouteId: null,
   setFeedPlaceFilterId: (value) => set((state) => ({ feedPlaceFilterId: resolveValue(value, state.feedPlaceFilterId) })),
   setActiveCommentReviewId: (value) => set((state) => ({ activeCommentReviewId: resolveValue(value, state.activeCommentReviewId) })),
   setHighlightedCommentId: (value) => set((state) => ({ highlightedCommentId: resolveValue(value, state.highlightedCommentId) })),
   setHighlightedReviewId: (value) => set((state) => ({ highlightedReviewId: resolveValue(value, state.highlightedReviewId) })),
+  setHighlightedRouteId: (value) => set((state) => ({ highlightedRouteId: resolveValue(value, state.highlightedRouteId) })),
 }));

--- a/src/styles/refinements.css
+++ b/src/styles/refinements.css
@@ -1087,6 +1087,12 @@ body {
   margin: 0 !important;
 }
 
+.community-route-card--highlighted {
+  border-color: rgba(255, 127, 168, 0.34) !important;
+  background: rgba(255, 248, 251, 0.98) !important;
+  box-shadow: 0 0 0 4px rgba(255, 206, 222, 0.28) !important;
+}
+
 /* 2026-03-21 my feed highlight */
 .review-card--highlighted {
   border-color: rgba(255, 127, 168, 0.34) !important;

--- a/test/regression/my-page-panel.test.tsx
+++ b/test/regression/my-page-panel.test.tsx
@@ -25,6 +25,7 @@ function createPanelProps(activeTab: MyPageTabKey) {
     reviewActions: {
       onOpenPlace: vi.fn(),
       onOpenComment: vi.fn(),
+      onOpenRoute: vi.fn().mockResolvedValue(undefined),
       onOpenReview: vi.fn(),
       onUpdateReview: vi.fn().mockResolvedValue(undefined),
       onDeleteReview: vi.fn().mockResolvedValue(undefined),
@@ -66,5 +67,6 @@ describe('MyPagePanel regression', () => {
 
     rerender(<MyPagePanel {...createPanelProps('routes')} />);
     expect(screen.getByText(myPageFixture.routes[0].title)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '코스 탭에서 보기' })).toBeInTheDocument();
   });
 });

--- a/test/unit/useAppPageStageActions.test.tsx
+++ b/test/unit/useAppPageStageActions.test.tsx
@@ -12,6 +12,7 @@ describe('useAppPageStageActions', () => {
       setFeedPlaceFilterId,
       setCommunityRouteSort: vi.fn(),
       handleOpenCommentWithReturn: vi.fn(),
+      handleOpenCommunityRouteWithReturn: vi.fn(),
       fetchCommunityRoutes: vi.fn().mockResolvedValue(undefined),
       refreshMyPageForUser: vi.fn().mockResolvedValue(undefined),
       reportBackgroundError: vi.fn(),
@@ -33,6 +34,7 @@ describe('useAppPageStageActions', () => {
         setFeedPlaceFilterId: vi.fn(),
         setCommunityRouteSort: vi.fn(),
         handleOpenCommentWithReturn: vi.fn(),
+        handleOpenCommunityRouteWithReturn: vi.fn(),
         fetchCommunityRoutes: vi.fn().mockResolvedValue(undefined),
         refreshMyPageForUser,
         reportBackgroundError: vi.fn(),
@@ -62,6 +64,7 @@ describe('useAppPageStageActions', () => {
       setFeedPlaceFilterId: vi.fn(),
       setCommunityRouteSort,
       handleOpenCommentWithReturn: vi.fn(),
+      handleOpenCommunityRouteWithReturn: vi.fn(),
       fetchCommunityRoutes,
       refreshMyPageForUser: vi.fn().mockResolvedValue(undefined),
       reportBackgroundError,
@@ -84,6 +87,7 @@ describe('useAppPageStageActions', () => {
       setFeedPlaceFilterId: vi.fn(),
       setCommunityRouteSort: vi.fn(),
       handleOpenCommentWithReturn,
+      handleOpenCommunityRouteWithReturn: vi.fn(),
       fetchCommunityRoutes: vi.fn().mockResolvedValue(undefined),
       refreshMyPageForUser: vi.fn().mockResolvedValue(undefined),
       reportBackgroundError: vi.fn(),
@@ -94,5 +98,30 @@ describe('useAppPageStageActions', () => {
     });
 
     expect(handleOpenCommentWithReturn).toHaveBeenCalledWith('review-1', 'comment-1');
+  });
+
+  it('opens a published route from my-page through the course navigation helper', async () => {
+    const setCommunityRouteSort = vi.fn();
+    const fetchCommunityRoutes = vi.fn().mockResolvedValue(undefined);
+    const handleOpenCommunityRouteWithReturn = vi.fn();
+
+    const { result } = renderHook(() => useAppPageStageActions({
+      sessionUser: sessionUserFixture,
+      setFeedPlaceFilterId: vi.fn(),
+      setCommunityRouteSort,
+      handleOpenCommentWithReturn: vi.fn(),
+      handleOpenCommunityRouteWithReturn,
+      fetchCommunityRoutes,
+      refreshMyPageForUser: vi.fn().mockResolvedValue(undefined),
+      reportBackgroundError: vi.fn(),
+    }));
+
+    await act(async () => {
+      await result.current.handleOpenRouteFromMyPage('route-1');
+    });
+
+    expect(setCommunityRouteSort).toHaveBeenCalledWith('latest');
+    expect(fetchCommunityRoutes).toHaveBeenCalledWith('latest');
+    expect(handleOpenCommunityRouteWithReturn).toHaveBeenCalledWith('route-1');
   });
 });


### PR DESCRIPTION
## 요약
- 마이페이지의 발행 코스 카드에서 공개 코스 탭으로 바로 이동하는 버튼을 추가했습니다.
- 이동 시 최신순 공개 코스를 먼저 불러오고, 해당 코스 카드로 스크롤/하이라이트되도록 연결했습니다.
- 관련 unit/regression 테스트를 보강했습니다.

## 검증
- npm run test:all
- npm run build