### PR TITLE
Fix my-page route tab scroll jump

### DIFF
--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -129,7 +129,7 @@ export function MyPagePanel({
   const [notificationBusyId, setNotificationBusyId] = useState<string | null>(null);
   const [notificationsBusy, setNotificationsBusy] = useState(false);
   const [notificationError, setNotificationError] = useState<string | null>(null);
-  const scrollRef = useScrollRestoration<HTMLElement>(`my:${activeTab}`);
+  const scrollRef = useScrollRestoration<HTMLElement>('my');
   const commentsLoadMoreRef = useAutoLoadMore({
     enabled: activeTab === 'comments' && commentsHasMore,
     loading: commentsLoadingMore,


### PR DESCRIPTION
## 요약
- 마이페이지 내부 탭 전환에서 코스 탭만 위로 튀던 스크롤 복원 키를 정리했습니다.
- 내부 탭별 스크롤 복원을 제거하고, 마이페이지 전체를 하나의 스크롤 컨텍스트로 유지합니다.

## 검증
- npm run typecheck
- npm run test:all
- npm run build