### PR TITLE
Refactor my-page service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -79,10 +79,10 @@ from .services.auth_service import (
     get_redirect_target,
     update_profile_session_payload,
 )
+from .services.my_page_service import read_my_page_service
 from .services.page_service import (
     read_bootstrap_service,
     read_courses_service,
-    read_my_page_service,
     read_place_service,
     read_places_service,
     read_reviews_service,

--- a/backend/app/repositories/my_page_repository.py
+++ b/backend/app/repositories/my_page_repository.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import Session
+
+from ..repository_normalized import get_my_page
+
+
+def read_my_page_entry(db: Session, user_id: str, is_admin: bool):
+    return get_my_page(db, user_id, is_admin)

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -3,7 +3,6 @@ from sqlalchemy.orm import Session
 from ..models import CategoryFilter, CourseMood
 from ..repository_normalized import (
     get_bootstrap,
-    get_my_page,
     get_place,
     get_stamps,
     list_courses,
@@ -26,10 +25,6 @@ def read_place_entry(db: Session, place_id: str):
 
 def list_course_entries(db: Session, mood: CourseMood | None):
     return list_courses(db, mood)
-
-
-def read_my_page_entry(db: Session, user_id: str, is_admin: bool):
-    return get_my_page(db, user_id, is_admin)
 
 
 def read_stamp_state(db: Session, user_id: str | None):

--- a/backend/app/services/my_page_service.py
+++ b/backend/app/services/my_page_service.py
@@ -1,0 +1,23 @@
+from collections.abc import Callable
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..config import Settings
+from ..models import SessionUser
+from ..repositories.my_page_repository import read_my_page_entry
+
+
+def _raise_not_found(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def _run_not_found_policy(action: Callable[[], object]):
+    try:
+        return action()
+    except ValueError as error:
+        _raise_not_found(str(error))
+
+
+def read_my_page_service(db: Session, session_user: SessionUser, app_settings: Settings):
+    return _run_not_found_policy(lambda: read_my_page_entry(db, session_user.id, app_settings.is_admin(session_user.id)))

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -9,7 +9,6 @@ from ..repositories.page_repository import (
     list_course_entries,
     list_place_entries,
     read_bootstrap_bundle,
-    read_my_page_entry,
     read_place_entry,
     read_stamp_state,
     toggle_stamp_entry,
@@ -59,10 +58,6 @@ def read_courses_service(db: Session, mood: CourseMood | None):
 
 def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
     return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)
-
-
-def read_my_page_service(db: Session, session_user: SessionUser, app_settings: Settings):
-    return _run_not_found_policy(lambda: read_my_page_entry(db, session_user.id, app_settings.is_admin(session_user.id)))
 
 
 def read_stamps_service(db: Session, session_user: SessionUser | None):

--- a/backend/tests/test_my_page_service.py
+++ b/backend/tests/test_my_page_service.py
@@ -1,0 +1,32 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.config import Settings
+from app.models import SessionUser
+from app.services import my_page_service
+
+
+def build_session_user() -> SessionUser:
+    return SessionUser(
+        id="user-1",
+        nickname="tester",
+        email="tester@example.com",
+        provider="kakao",
+        profileImage=None,
+        isAdmin=False,
+        profileCompletedAt=None,
+    )
+
+
+def test_read_my_page_service_maps_missing_user_to_404(monkeypatch):
+    def failing_read_my_page(*_args, **_kwargs):
+        raise ValueError("사용자를 찾을 수 없어요.")
+
+    monkeypatch.setattr(my_page_service, "read_my_page_entry", failing_read_my_page)
+
+    with pytest.raises(HTTPException) as caught:
+        my_page_service.read_my_page_service(SimpleNamespace(), build_session_user(), Settings())
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -3,7 +3,6 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException, status
 
-from app.config import Settings
 from app.models import SessionUser, StampToggleRequest
 from app.services import page_service
 
@@ -32,18 +31,6 @@ def test_read_place_service_maps_missing_place_to_404(monkeypatch):
     assert caught.value.status_code == status.HTTP_404_NOT_FOUND
 
 
-def test_read_my_page_service_maps_missing_user_to_404(monkeypatch):
-    def failing_read_my_page(*_args, **_kwargs):
-        raise ValueError("사용자를 찾을 수 없어요.")
-
-    monkeypatch.setattr(page_service, "read_my_page_entry", failing_read_my_page)
-
-    with pytest.raises(HTTPException) as caught:
-        page_service.read_my_page_service(SimpleNamespace(), build_session_user(), Settings())
-
-    assert caught.value.status_code == status.HTTP_404_NOT_FOUND
-
-
 def test_toggle_stamp_service_maps_permission_error_to_403(monkeypatch):
     def failing_toggle_stamp(*_args, **_kwargs):
         raise PermissionError("forbidden")
@@ -55,7 +42,7 @@ def test_toggle_stamp_service_maps_permission_error_to_403(monkeypatch):
             SimpleNamespace(),
             StampToggleRequest(placeId="place-1", latitude=36.35, longitude=127.38),
             build_session_user(),
-            Settings(stamp_unlock_radius_meters=120),
+            page_service.Settings(stamp_unlock_radius_meters=120),
         )
 
     assert caught.value.status_code == status.HTTP_403_FORBIDDEN
@@ -72,7 +59,7 @@ def test_toggle_stamp_service_maps_missing_place_to_404(monkeypatch):
             SimpleNamespace(),
             StampToggleRequest(placeId="missing-place", latitude=36.35, longitude=127.38),
             build_session_user(),
-            Settings(stamp_unlock_radius_meters=120),
+            page_service.Settings(stamp_unlock_radius_meters=120),
         )
 
     assert caught.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- split my-page orchestration into dedicated service and repository facades
- remove my-page responsibility from the old page boundary

## Validation
- npm run typecheck
- npm run build
- backend pytest