### PR TITLE
Refactor stamp service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -86,6 +86,8 @@ from .services.page_service import (
     read_place_service,
     read_places_service,
     read_reviews_service,
+)
+from .services.stamp_service import (
     read_stamps_service,
     toggle_stamp_service,
 )

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -4,10 +4,8 @@ from ..models import CategoryFilter, CourseMood
 from ..repository_normalized import (
     get_bootstrap,
     get_place,
-    get_stamps,
     list_courses,
     list_places,
-    toggle_stamp,
 )
 
 
@@ -25,18 +23,3 @@ def read_place_entry(db: Session, place_id: str):
 
 def list_course_entries(db: Session, mood: CourseMood | None):
     return list_courses(db, mood)
-
-
-def read_stamp_state(db: Session, user_id: str | None):
-    return get_stamps(db, user_id)
-
-
-def toggle_stamp_entry(
-    db: Session,
-    user_id: str,
-    place_id: str,
-    latitude: float,
-    longitude: float,
-    unlock_radius_meters: int,
-):
-    return toggle_stamp(db, user_id, place_id, latitude, longitude, unlock_radius_meters)

--- a/backend/app/repositories/stamp_repository.py
+++ b/backend/app/repositories/stamp_repository.py
@@ -1,0 +1,18 @@
+from sqlalchemy.orm import Session
+
+from ..repository_normalized import get_stamps, toggle_stamp
+
+
+def read_stamp_state(db: Session, user_id: str | None):
+    return get_stamps(db, user_id)
+
+
+def toggle_stamp_entry(
+    db: Session,
+    user_id: str,
+    place_id: str,
+    latitude: float,
+    longitude: float,
+    unlock_radius_meters: int,
+):
+    return toggle_stamp(db, user_id, place_id, latitude, longitude, unlock_radius_meters)

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -3,15 +3,12 @@ from collections.abc import Callable
 from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from ..config import Settings
-from ..models import CategoryFilter, CourseMood, SessionUser, StampToggleRequest
+from ..models import CategoryFilter, CourseMood, SessionUser
 from ..repositories.page_repository import (
     list_course_entries,
     list_place_entries,
     read_bootstrap_bundle,
     read_place_entry,
-    read_stamp_state,
-    toggle_stamp_entry,
 )
 from ..repositories.review_repository import list_review_entries
 
@@ -19,23 +16,9 @@ from ..repositories.review_repository import list_review_entries
 def _raise_not_found(detail: str) -> None:
     raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
 
-
-def _raise_forbidden(detail: str) -> None:
-    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
-
-
 def _run_not_found_policy(action: Callable[[], object]):
     try:
         return action()
-    except ValueError as error:
-        _raise_not_found(str(error))
-
-
-def _run_stamp_policy(action: Callable[[], object]):
-    try:
-        return action()
-    except PermissionError as error:
-        _raise_forbidden(str(error))
     except ValueError as error:
         _raise_not_found(str(error))
 
@@ -58,20 +41,3 @@ def read_courses_service(db: Session, mood: CourseMood | None):
 
 def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
     return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)
-
-
-def read_stamps_service(db: Session, session_user: SessionUser | None):
-    return read_stamp_state(db, session_user.id if session_user else None)
-
-
-def toggle_stamp_service(db: Session, payload: StampToggleRequest, session_user: SessionUser, app_settings: Settings):
-    return _run_stamp_policy(
-        lambda: toggle_stamp_entry(
-            db,
-            session_user.id,
-            payload.place_id,
-            payload.latitude,
-            payload.longitude,
-            app_settings.stamp_unlock_radius_meters,
-        ),
-    )

--- a/backend/app/services/stamp_service.py
+++ b/backend/app/services/stamp_service.py
@@ -1,0 +1,42 @@
+from collections.abc import Callable
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..config import Settings
+from ..models import SessionUser, StampToggleRequest
+from ..repositories.stamp_repository import read_stamp_state, toggle_stamp_entry
+
+
+def _raise_not_found(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def _raise_forbidden(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail=detail)
+
+
+def _run_stamp_policy(action: Callable[[], object]):
+    try:
+        return action()
+    except PermissionError as error:
+        _raise_forbidden(str(error))
+    except ValueError as error:
+        _raise_not_found(str(error))
+
+
+def read_stamps_service(db: Session, session_user: SessionUser | None):
+    return read_stamp_state(db, session_user.id if session_user else None)
+
+
+def toggle_stamp_service(db: Session, payload: StampToggleRequest, session_user: SessionUser, app_settings: Settings):
+    return _run_stamp_policy(
+        lambda: toggle_stamp_entry(
+            db,
+            session_user.id,
+            payload.place_id,
+            payload.latitude,
+            payload.longitude,
+            app_settings.stamp_unlock_radius_meters,
+        ),
+    )

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -3,20 +3,7 @@ from types import SimpleNamespace
 import pytest
 from fastapi import HTTPException, status
 
-from app.models import SessionUser, StampToggleRequest
 from app.services import page_service
-
-
-def build_session_user() -> SessionUser:
-    return SessionUser(
-        id="user-1",
-        nickname="tester",
-        email="tester@example.com",
-        provider="kakao",
-        profileImage=None,
-        isAdmin=False,
-        profileCompletedAt=None,
-    )
 
 
 def test_read_place_service_maps_missing_place_to_404(monkeypatch):
@@ -27,39 +14,5 @@ def test_read_place_service_maps_missing_place_to_404(monkeypatch):
 
     with pytest.raises(HTTPException) as caught:
         page_service.read_place_service(SimpleNamespace(), "missing-place")
-
-    assert caught.value.status_code == status.HTTP_404_NOT_FOUND
-
-
-def test_toggle_stamp_service_maps_permission_error_to_403(monkeypatch):
-    def failing_toggle_stamp(*_args, **_kwargs):
-        raise PermissionError("forbidden")
-
-    monkeypatch.setattr(page_service, "toggle_stamp_entry", failing_toggle_stamp)
-
-    with pytest.raises(HTTPException) as caught:
-        page_service.toggle_stamp_service(
-            SimpleNamespace(),
-            StampToggleRequest(placeId="place-1", latitude=36.35, longitude=127.38),
-            build_session_user(),
-            page_service.Settings(stamp_unlock_radius_meters=120),
-        )
-
-    assert caught.value.status_code == status.HTTP_403_FORBIDDEN
-
-
-def test_toggle_stamp_service_maps_missing_place_to_404(monkeypatch):
-    def failing_toggle_stamp(*_args, **_kwargs):
-        raise ValueError("장소를 찾을 수 없어요.")
-
-    monkeypatch.setattr(page_service, "toggle_stamp_entry", failing_toggle_stamp)
-
-    with pytest.raises(HTTPException) as caught:
-        page_service.toggle_stamp_service(
-            SimpleNamespace(),
-            StampToggleRequest(placeId="missing-place", latitude=36.35, longitude=127.38),
-            build_session_user(),
-            page_service.Settings(stamp_unlock_radius_meters=120),
-        )
 
     assert caught.value.status_code == status.HTTP_404_NOT_FOUND

--- a/backend/tests/test_stamp_service.py
+++ b/backend/tests/test_stamp_service.py
@@ -1,0 +1,54 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.config import Settings
+from app.models import SessionUser, StampToggleRequest
+from app.services import stamp_service
+
+
+def build_session_user() -> SessionUser:
+    return SessionUser(
+        id="user-1",
+        nickname="tester",
+        email="tester@example.com",
+        provider="kakao",
+        profileImage=None,
+        isAdmin=False,
+        profileCompletedAt=None,
+    )
+
+
+def test_toggle_stamp_service_maps_permission_error_to_403(monkeypatch):
+    def failing_toggle_stamp(*_args, **_kwargs):
+        raise PermissionError("forbidden")
+
+    monkeypatch.setattr(stamp_service, "toggle_stamp_entry", failing_toggle_stamp)
+
+    with pytest.raises(HTTPException) as caught:
+        stamp_service.toggle_stamp_service(
+            SimpleNamespace(),
+            StampToggleRequest(placeId="place-1", latitude=36.35, longitude=127.38),
+            build_session_user(),
+            Settings(stamp_unlock_radius_meters=120),
+        )
+
+    assert caught.value.status_code == status.HTTP_403_FORBIDDEN
+
+
+def test_toggle_stamp_service_maps_missing_place_to_404(monkeypatch):
+    def failing_toggle_stamp(*_args, **_kwargs):
+        raise ValueError("장소를 찾을 수 없어요.")
+
+    monkeypatch.setattr(stamp_service, "toggle_stamp_entry", failing_toggle_stamp)
+
+    with pytest.raises(HTTPException) as caught:
+        stamp_service.toggle_stamp_service(
+            SimpleNamespace(),
+            StampToggleRequest(placeId="missing-place", latitude=36.35, longitude=127.38),
+            build_session_user(),
+            Settings(stamp_unlock_radius_meters=120),
+        )
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- split stamp read/toggle orchestration into dedicated service and repository facades
- remove stamp responsibility from the old page boundary

## Validation
- npm run typecheck
- npm run build
- backend pytest