### PR TITLE
Refactor place service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -83,10 +83,9 @@ from .services.my_page_service import read_my_page_service
 from .services.page_service import (
     read_bootstrap_service,
     read_courses_service,
-    read_place_service,
-    read_places_service,
     read_reviews_service,
 )
+from .services.place_service import read_place_service, read_places_service
 from .services.stamp_service import (
     read_stamps_service,
     toggle_stamp_service,

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -1,25 +1,13 @@
 from sqlalchemy.orm import Session
 
-from ..models import CategoryFilter, CourseMood
+from ..models import CourseMood
 from ..repository_normalized import (
     get_bootstrap,
-    get_place,
     list_courses,
-    list_places,
 )
 
 
 def read_bootstrap_bundle(db: Session, user_id: str | None):
     return get_bootstrap(db, user_id)
-
-
-def list_place_entries(db: Session, category: CategoryFilter):
-    return list_places(db, category)
-
-
-def read_place_entry(db: Session, place_id: str):
-    return get_place(db, place_id)
-
-
 def list_course_entries(db: Session, mood: CourseMood | None):
     return list_courses(db, mood)

--- a/backend/app/repositories/place_repository.py
+++ b/backend/app/repositories/place_repository.py
@@ -1,0 +1,12 @@
+from sqlalchemy.orm import Session
+
+from ..models import CategoryFilter
+from ..repository_normalized import get_place, list_places
+
+
+def list_place_entries(db: Session, category: CategoryFilter):
+    return list_places(db, category)
+
+
+def read_place_entry(db: Session, place_id: str):
+    return get_place(db, place_id)

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -1,38 +1,15 @@
-from collections.abc import Callable
-
-from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from ..models import CategoryFilter, CourseMood, SessionUser
+from ..models import CourseMood, SessionUser
 from ..repositories.page_repository import (
     list_course_entries,
-    list_place_entries,
     read_bootstrap_bundle,
-    read_place_entry,
 )
 from ..repositories.review_repository import list_review_entries
 
 
-def _raise_not_found(detail: str) -> None:
-    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
-
-def _run_not_found_policy(action: Callable[[], object]):
-    try:
-        return action()
-    except ValueError as error:
-        _raise_not_found(str(error))
-
-
 def read_bootstrap_service(db: Session, session_user: SessionUser | None):
     return read_bootstrap_bundle(db, session_user.id if session_user else None)
-
-
-def read_places_service(db: Session, category: CategoryFilter):
-    return list_place_entries(db, category)
-
-
-def read_place_service(db: Session, place_id: str):
-    return _run_not_found_policy(lambda: read_place_entry(db, place_id))
 
 
 def read_courses_service(db: Session, mood: CourseMood | None):

--- a/backend/app/services/place_service.py
+++ b/backend/app/services/place_service.py
@@ -1,0 +1,26 @@
+from collections.abc import Callable
+
+from fastapi import HTTPException, status
+from sqlalchemy.orm import Session
+
+from ..models import CategoryFilter
+from ..repositories.place_repository import list_place_entries, read_place_entry
+
+
+def _raise_not_found(detail: str) -> None:
+    raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=detail)
+
+
+def _run_not_found_policy(action: Callable[[], object]):
+    try:
+        return action()
+    except ValueError as error:
+        _raise_not_found(str(error))
+
+
+def read_places_service(db: Session, category: CategoryFilter):
+    return list_place_entries(db, category)
+
+
+def read_place_service(db: Session, place_id: str):
+    return _run_not_found_policy(lambda: read_place_entry(db, place_id))

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -1,18 +1,6 @@
-from types import SimpleNamespace
+def test_page_service_imports():
+    from app.services import page_service
 
-import pytest
-from fastapi import HTTPException, status
-
-from app.services import page_service
-
-
-def test_read_place_service_maps_missing_place_to_404(monkeypatch):
-    def failing_read_place(*_args, **_kwargs):
-        raise ValueError("장소를 찾을 수 없어요.")
-
-    monkeypatch.setattr(page_service, "read_place_entry", failing_read_place)
-
-    with pytest.raises(HTTPException) as caught:
-        page_service.read_place_service(SimpleNamespace(), "missing-place")
-
-    assert caught.value.status_code == status.HTTP_404_NOT_FOUND
+    assert callable(page_service.read_bootstrap_service)
+    assert callable(page_service.read_courses_service)
+    assert callable(page_service.read_reviews_service)

--- a/backend/tests/test_place_service.py
+++ b/backend/tests/test_place_service.py
@@ -1,0 +1,18 @@
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException, status
+
+from app.services import place_service
+
+
+def test_read_place_service_maps_missing_place_to_404(monkeypatch):
+    def failing_read_place(*_args, **_kwargs):
+        raise ValueError("장소를 찾을 수 없어요.")
+
+    monkeypatch.setattr(place_service, "read_place_entry", failing_read_place)
+
+    with pytest.raises(HTTPException) as caught:
+        place_service.read_place_service(SimpleNamespace(), "missing-place")
+
+    assert caught.value.status_code == status.HTTP_404_NOT_FOUND


### PR DESCRIPTION
## Summary
- split place list/read orchestration into dedicated service and repository facades
- remove place responsibility from the old page boundary

## Validation
- npm run typecheck
- npm run build
- backend pytest