### PR TITLE
Refactor course service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -82,9 +82,9 @@ from .services.auth_service import (
 from .services.my_page_service import read_my_page_service
 from .services.page_service import (
     read_bootstrap_service,
-    read_courses_service,
     read_reviews_service,
 )
+from .services.course_service import read_courses_service
 from .services.place_service import read_place_service, read_places_service
 from .services.stamp_service import (
     read_stamps_service,

--- a/backend/app/repositories/course_repository.py
+++ b/backend/app/repositories/course_repository.py
@@ -1,0 +1,8 @@
+from sqlalchemy.orm import Session
+
+from ..models import CourseMood
+from ..repository_normalized import list_courses
+
+
+def list_course_entries(db: Session, mood: CourseMood | None):
+    return list_courses(db, mood)

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -1,13 +1,9 @@
 from sqlalchemy.orm import Session
 
-from ..models import CourseMood
 from ..repository_normalized import (
     get_bootstrap,
-    list_courses,
 )
 
 
 def read_bootstrap_bundle(db: Session, user_id: str | None):
     return get_bootstrap(db, user_id)
-def list_course_entries(db: Session, mood: CourseMood | None):
-    return list_courses(db, mood)

--- a/backend/app/services/course_service.py
+++ b/backend/app/services/course_service.py
@@ -1,0 +1,8 @@
+from sqlalchemy.orm import Session
+
+from ..models import CourseMood
+from ..repositories.course_repository import list_course_entries
+
+
+def read_courses_service(db: Session, mood: CourseMood | None):
+    return list_course_entries(db, mood)

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -1,8 +1,7 @@
 from sqlalchemy.orm import Session
 
-from ..models import CourseMood, SessionUser
+from ..models import SessionUser
 from ..repositories.page_repository import (
-    list_course_entries,
     read_bootstrap_bundle,
 )
 from ..repositories.review_repository import list_review_entries
@@ -10,10 +9,6 @@ from ..repositories.review_repository import list_review_entries
 
 def read_bootstrap_service(db: Session, session_user: SessionUser | None):
     return read_bootstrap_bundle(db, session_user.id if session_user else None)
-
-
-def read_courses_service(db: Session, mood: CourseMood | None):
-    return list_course_entries(db, mood)
 
 
 def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):

--- a/backend/tests/test_course_service.py
+++ b/backend/tests/test_course_service.py
@@ -1,0 +1,15 @@
+from app.services import course_service
+
+
+def test_read_courses_service_delegates_to_repository(monkeypatch):
+    sentinel = [{"id": "course-1"}]
+    mood_token = "mood-token"
+
+    def fake_list_course_entries(db, mood):
+        assert db == "db-session"
+        assert mood == mood_token
+        return sentinel
+
+    monkeypatch.setattr(course_service, "list_course_entries", fake_list_course_entries)
+
+    assert course_service.read_courses_service("db-session", mood_token) == sentinel

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -2,5 +2,4 @@ def test_page_service_imports():
     from app.services import page_service
 
     assert callable(page_service.read_bootstrap_service)
-    assert callable(page_service.read_courses_service)
     assert callable(page_service.read_reviews_service)


### PR DESCRIPTION
## Summary
- split course list orchestration into dedicated service and repository facades
- remove course responsibility from the old page boundary

## Validation
- npm run typecheck
- npm run build
- backend pytest