### PR TITLE
Refactor bootstrap service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -81,9 +81,9 @@ from .services.auth_service import (
 )
 from .services.my_page_service import read_my_page_service
 from .services.page_service import (
-    read_bootstrap_service,
     read_reviews_service,
 )
+from .services.bootstrap_service import read_bootstrap_service
 from .services.course_service import read_courses_service
 from .services.place_service import read_place_service, read_places_service
 from .services.stamp_service import (

--- a/backend/app/repositories/bootstrap_repository.py
+++ b/backend/app/repositories/bootstrap_repository.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import Session
+
+from ..repository_normalized import get_bootstrap
+
+
+def read_bootstrap_bundle(db: Session, user_id: str | None):
+    return get_bootstrap(db, user_id)

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -1,9 +1,1 @@
-from sqlalchemy.orm import Session
-
-from ..repository_normalized import (
-    get_bootstrap,
-)
-
-
-def read_bootstrap_bundle(db: Session, user_id: str | None):
-    return get_bootstrap(db, user_id)
+"""Legacy page repository placeholder for remaining page-domain boundaries."""

--- a/backend/app/services/bootstrap_service.py
+++ b/backend/app/services/bootstrap_service.py
@@ -1,0 +1,8 @@
+from sqlalchemy.orm import Session
+
+from ..models import SessionUser
+from ..repositories.bootstrap_repository import read_bootstrap_bundle
+
+
+def read_bootstrap_service(db: Session, session_user: SessionUser | None):
+    return read_bootstrap_bundle(db, session_user.id if session_user else None)

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -1,15 +1,7 @@
 from sqlalchemy.orm import Session
 
 from ..models import SessionUser
-from ..repositories.page_repository import (
-    read_bootstrap_bundle,
-)
 from ..repositories.review_repository import list_review_entries
-
-
-def read_bootstrap_service(db: Session, session_user: SessionUser | None):
-    return read_bootstrap_bundle(db, session_user.id if session_user else None)
-
 
 def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
     return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)

--- a/backend/tests/test_bootstrap_service.py
+++ b/backend/tests/test_bootstrap_service.py
@@ -1,0 +1,16 @@
+from app.services import bootstrap_service
+
+
+def test_read_bootstrap_service_delegates_to_repository(monkeypatch):
+    sentinel = {"places": [], "festivals": []}
+
+    def fake_read_bootstrap_bundle(db, user_id):
+        assert db == "db-session"
+        assert user_id == "user-1"
+        return sentinel
+
+    monkeypatch.setattr(bootstrap_service, "read_bootstrap_bundle", fake_read_bootstrap_bundle)
+
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+
+    assert bootstrap_service.read_bootstrap_service("db-session", session_user) == sentinel

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -1,5 +1,4 @@
 def test_page_service_imports():
     from app.services import page_service
 
-    assert callable(page_service.read_bootstrap_service)
     assert callable(page_service.read_reviews_service)


### PR DESCRIPTION
## Summary
- split bootstrap orchestration into dedicated service and repository facades
- remove bootstrap responsibility from the old page boundary

## Validation
- npm run typecheck
- npm run build
- backend pytest