### PR TITLE
Remove remaining page service boundary

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -80,9 +80,6 @@ from .services.auth_service import (
     update_profile_session_payload,
 )
 from .services.my_page_service import read_my_page_service
-from .services.page_service import (
-    read_reviews_service,
-)
 from .services.bootstrap_service import read_bootstrap_service
 from .services.course_service import read_courses_service
 from .services.place_service import read_place_service, read_places_service
@@ -101,6 +98,7 @@ from .services.review_service import (
     create_review_service,
     delete_comment_service,
     delete_review_service,
+    read_reviews_service,
     read_review_comments_service,
     toggle_review_like_service,
 )

--- a/backend/app/repositories/page_repository.py
+++ b/backend/app/repositories/page_repository.py
@@ -1,1 +1,0 @@
-"""Legacy page repository placeholder for remaining page-domain boundaries."""

--- a/backend/app/services/page_service.py
+++ b/backend/app/services/page_service.py
@@ -1,7 +1,0 @@
-from sqlalchemy.orm import Session
-
-from ..models import SessionUser
-from ..repositories.review_repository import list_review_entries
-
-def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
-    return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -10,6 +10,7 @@ from ..repositories.review_repository import (
     create_review_entry,
     delete_review_comment,
     delete_review_entry,
+    list_review_entries,
     list_review_comments,
     toggle_review_like_entry,
 )
@@ -87,6 +88,10 @@ def create_review_service(db: Session, payload: ReviewCreate, session_user: Sess
         lambda: create_review_entry(db, payload, session_user.id, session_user.nickname),
         not_found_tokens=(_PLACE_NOT_FOUND_TOKEN,),
     )
+
+
+def read_reviews_service(db: Session, place_id: str | None, user_id: str | None, session_user: SessionUser | None):
+    return list_review_entries(db, place_id=place_id, user_id=user_id, current_user_id=session_user.id if session_user else None)
 
 
 def delete_review_service(db: Session, review_id: str, session_user: SessionUser) -> None:

--- a/backend/tests/test_page_service.py
+++ b/backend/tests/test_page_service.py
@@ -1,4 +1,0 @@
-def test_page_service_imports():
-    from app.services import page_service
-
-    assert callable(page_service.read_reviews_service)

--- a/backend/tests/test_review_read_service.py
+++ b/backend/tests/test_review_read_service.py
@@ -1,0 +1,18 @@
+from app.services import review_service
+
+
+def test_read_reviews_service_delegates_to_repository(monkeypatch):
+    sentinel = [{"id": "review-1"}]
+
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+
+    def fake_list_review_entries(db, *, place_id=None, user_id=None, current_user_id=None):
+        assert db == "db-session"
+        assert place_id == "place-1"
+        assert user_id == "author-1"
+        assert current_user_id == "user-1"
+        return sentinel
+
+    monkeypatch.setattr(review_service, "list_review_entries", fake_list_review_entries)
+
+    assert review_service.read_reviews_service("db-session", "place-1", "author-1", session_user) == sentinel


### PR DESCRIPTION
## Summary
- move remaining review read orchestration into the review service
- remove the now-empty page service and repository files

## Validation
- npm run typecheck
- npm run build
- backend pytest