### PR TITLE
Refactor auth, admin, notification, and account repository facades

### DIFF
--- a/backend/app/repositories/account_repository.py
+++ b/backend/app/repositories/account_repository.py
@@ -1,0 +1,7 @@
+from sqlalchemy.orm import Session
+
+from ..repository_normalized import delete_account
+
+
+def delete_account_entry(db: Session, user_id: str) -> None:
+    delete_account(db, user_id)

--- a/backend/app/repositories/admin_repository.py
+++ b/backend/app/repositories/admin_repository.py
@@ -1,0 +1,28 @@
+from sqlalchemy.orm import Session
+
+from ..config import Settings
+from ..models import AdminPlaceOut, AdminSummaryResponse, PublicImportResponse
+from ..repository_normalized import get_admin_summary, import_public_bundle, update_place_visibility
+
+
+def read_admin_summary_entry(db: Session, app_settings: Settings) -> AdminSummaryResponse:
+    return get_admin_summary(db, app_settings)
+
+
+def update_admin_place_visibility_entry(
+    db: Session,
+    place_id: str,
+    *,
+    is_active: bool | None,
+    is_manual_override: bool | None,
+) -> AdminPlaceOut:
+    return update_place_visibility(
+        db,
+        place_id,
+        is_active=is_active,
+        is_manual_override=is_manual_override,
+    )
+
+
+def import_public_bundle_entry(db: Session, app_settings: Settings) -> PublicImportResponse:
+    return import_public_bundle(db, app_settings)

--- a/backend/app/repositories/auth_repository.py
+++ b/backend/app/repositories/auth_repository.py
@@ -1,0 +1,29 @@
+from sqlalchemy.orm import Session
+
+from ..db_models import User
+from ..models import ProfileUpdateRequest, SessionUser
+from ..naver_oauth import NaverProfile
+from ..repository_normalized import link_naver_identity, update_user_profile, upsert_naver_user
+from ..repository_support import to_session_user
+
+
+def update_user_profile_entry(db: Session, user_id: str, payload: ProfileUpdateRequest) -> User:
+    return update_user_profile(db, user_id, payload)
+
+
+def upsert_naver_user_entry(db: Session, profile: NaverProfile) -> User:
+    return upsert_naver_user(db, profile)
+
+
+def link_naver_identity_entry(db: Session, user_id: str, profile: NaverProfile) -> User:
+    return link_naver_identity(db, user_id, profile)
+
+
+def build_session_user(
+    user: User,
+    *,
+    is_admin: bool,
+    profile_image: str | None = None,
+    provider: str | None = None,
+) -> SessionUser:
+    return to_session_user(user, is_admin, profile_image, provider)

--- a/backend/app/repositories/notification_repository.py
+++ b/backend/app/repositories/notification_repository.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+
+from ..models import NotificationDeleteResponse, NotificationReadResponse, UserNotificationOut
+from ..repository_normalized import (
+    delete_notification,
+    get_unread_notification_count,
+    list_user_notifications,
+    mark_all_notifications_read,
+    mark_notification_read,
+)
+
+
+def list_user_notification_entries(db: Session, user_id: str) -> list[UserNotificationOut]:
+    return list_user_notifications(db, user_id)
+
+
+def mark_notification_read_entry(db: Session, notification_id: str, user_id: str) -> NotificationReadResponse:
+    return mark_notification_read(db, notification_id, user_id)
+
+
+def mark_all_notifications_read_entry(db: Session, user_id: str) -> int:
+    return mark_all_notifications_read(db, user_id)
+
+
+def delete_notification_entry(db: Session, notification_id: str, user_id: str) -> NotificationDeleteResponse:
+    return delete_notification(db, notification_id, user_id)
+
+
+def read_unread_notification_count(db: Session, user_id: str) -> int:
+    return get_unread_notification_count(db, user_id)

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -1,12 +1,12 @@
-﻿from fastapi import HTTPException, status
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
-from ..repository_normalized import delete_account
+from ..repositories.account_repository import delete_account_entry
 
 
 def delete_my_account_service(db: Session, user_id: str) -> None:
     try:
-        delete_account(db, user_id)
+        delete_account_entry(db, user_id)
     except ValueError as error:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/backend/app/services/admin_service.py
+++ b/backend/app/services/admin_service.py
@@ -1,18 +1,22 @@
-﻿from fastapi import HTTPException, status
+from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from ..config import Settings
 from ..models import AdminPlaceOut, AdminSummaryResponse, PlaceVisibilityUpdate, PublicImportResponse
-from ..repository_normalized import get_admin_summary, import_public_bundle, update_place_visibility
+from ..repositories.admin_repository import (
+    import_public_bundle_entry,
+    read_admin_summary_entry,
+    update_admin_place_visibility_entry,
+)
 
 
 def read_admin_summary_service(db: Session, app_settings: Settings) -> AdminSummaryResponse:
-    return get_admin_summary(db, app_settings)
+    return read_admin_summary_entry(db, app_settings)
 
 
 def patch_admin_place_service(db: Session, place_id: str, payload: PlaceVisibilityUpdate) -> AdminPlaceOut:
     try:
-        return update_place_visibility(
+        return update_admin_place_visibility_entry(
             db,
             place_id,
             is_active=payload.is_active,
@@ -23,4 +27,4 @@ def patch_admin_place_service(db: Session, place_id: str, payload: PlaceVisibili
 
 
 def import_public_data_service(db: Session, app_settings: Settings) -> PublicImportResponse:
-    return import_public_bundle(db, app_settings)
+    return import_public_bundle_entry(db, app_settings)

--- a/backend/app/services/auth_service.py
+++ b/backend/app/services/auth_service.py
@@ -1,4 +1,4 @@
-﻿from fastapi import HTTPException, status
+from fastapi import HTTPException, status
 from fastapi.responses import RedirectResponse
 from sqlalchemy.orm import Session
 from starlette.requests import Request
@@ -7,7 +7,12 @@ from ..config import Settings
 from ..jwt_auth import issue_access_token
 from ..models import AuthProviderOut, AuthSessionResponse, ProfileUpdateRequest, SessionUser
 from ..naver_oauth import build_redirect_url, exchange_code_for_token, fetch_naver_profile
-from ..repository_normalized import link_naver_identity, to_session_user, update_user_profile, upsert_naver_user
+from ..repositories.auth_repository import (
+    build_session_user,
+    link_naver_identity_entry,
+    update_user_profile_entry,
+    upsert_naver_user_entry,
+)
 
 PROVIDER_LABELS = {
     "naver": "네이버",
@@ -49,11 +54,15 @@ def update_profile_session_payload(
     app_settings: Settings,
 ) -> tuple[AuthSessionResponse, str]:
     try:
-        user = update_user_profile(db, user_id, payload)
+        user = update_user_profile_entry(db, user_id, payload)
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error)) from error
 
-    next_session_user = to_session_user(user, app_settings.is_admin(user.user_id), provider=user.provider)
+    next_session_user = build_session_user(
+        user,
+        is_admin=app_settings.is_admin(user.user_id),
+        provider=user.provider,
+    )
     access_token = issue_access_token(app_settings, next_session_user)
     return build_auth_response(next_session_user, app_settings), access_token
 
@@ -95,10 +104,10 @@ def complete_naver_login(
         token_payload = exchange_code_for_token(app_settings, code, state)
         profile = fetch_naver_profile(token_payload["access_token"])
         if link_user_id and link_provider == "naver":
-            user = link_naver_identity(db, link_user_id, profile)
+            user = link_naver_identity_entry(db, link_user_id, profile)
             success_code = "naver-linked"
         else:
-            user = upsert_naver_user(db, profile)
+            user = upsert_naver_user_entry(db, profile)
             success_code = "naver-success"
     except (HTTPException, ValueError) as oauth_error:
         detail = oauth_error.detail if isinstance(oauth_error, HTTPException) else str(oauth_error)
@@ -110,10 +119,10 @@ def complete_naver_login(
             None,
         )
 
-    session_user = to_session_user(
+    session_user = build_session_user(
         user,
-        app_settings.is_admin(user.user_id),
-        profile.profile_image,
+        is_admin=app_settings.is_admin(user.user_id),
+        profile_image=profile.profile_image,
         provider="naver",
     )
     access_token = issue_access_token(app_settings, session_user)

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -5,25 +5,25 @@ from sqlalchemy.orm import Session
 
 from ..models import NotificationDeleteResponse, NotificationReadResponse, SessionUser, UserNotificationOut
 from ..notification_broker import notification_broker
-from ..repository_normalized import (
-    delete_notification,
-    get_unread_notification_count,
-    list_user_notifications,
-    mark_all_notifications_read,
-    mark_notification_read,
+from ..repositories.notification_repository import (
+    delete_notification_entry,
+    list_user_notification_entries,
+    mark_all_notifications_read_entry,
+    mark_notification_read_entry,
+    read_unread_notification_count,
 )
 
 
 def read_notifications_service(db: Session, session_user: SessionUser) -> list[UserNotificationOut]:
-    return list_user_notifications(db, session_user.id)
+    return list_user_notification_entries(db, session_user.id)
 
 
 def mark_notification_read_service(db: Session, notification_id: str, session_user: SessionUser) -> NotificationReadResponse:
     try:
-        response = mark_notification_read(db, notification_id, session_user.id)
+        response = mark_notification_read_entry(db, notification_id, session_user.id)
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
-    unread_count = get_unread_notification_count(db, session_user.id)
+    unread_count = read_unread_notification_count(db, session_user.id)
     notification_broker.publish(
         session_user.id,
         {
@@ -36,7 +36,7 @@ def mark_notification_read_service(db: Session, notification_id: str, session_us
 
 
 def mark_all_notifications_read_service(db: Session, session_user: SessionUser) -> dict[str, int]:
-    updated = mark_all_notifications_read(db, session_user.id)
+    updated = mark_all_notifications_read_entry(db, session_user.id)
     notification_broker.publish(
         session_user.id,
         {
@@ -50,10 +50,10 @@ def mark_all_notifications_read_service(db: Session, session_user: SessionUser) 
 
 def delete_notification_service(db: Session, notification_id: str, session_user: SessionUser) -> NotificationDeleteResponse:
     try:
-        response = delete_notification(db, notification_id, session_user.id)
+        response = delete_notification_entry(db, notification_id, session_user.id)
     except ValueError as error:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error)) from error
-    unread_count = get_unread_notification_count(db, session_user.id)
+    unread_count = read_unread_notification_count(db, session_user.id)
     notification_broker.publish(
         session_user.id,
         {

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -1,0 +1,28 @@
+from fastapi import HTTPException
+
+from app.services import account_service
+
+
+def test_delete_my_account_service_uses_repository_entry(monkeypatch):
+    calls = []
+    monkeypatch.setattr(account_service, "delete_account_entry", lambda db, user_id: calls.append((db, user_id)))
+
+    account_service.delete_my_account_service("db-session", "user-1")
+
+    assert calls == [("db-session", "user-1")]
+
+
+def test_delete_my_account_service_maps_value_error(monkeypatch):
+    monkeypatch.setattr(
+        account_service,
+        "delete_account_entry",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("missing")),
+    )
+
+    try:
+        account_service.delete_my_account_service("db-session", "user-1")
+    except HTTPException as error:
+        assert error.status_code == 404
+        assert error.detail == "사용자 정보를 찾지 못했어요."
+    else:
+        raise AssertionError("Expected HTTPException")

--- a/backend/tests/test_admin_service.py
+++ b/backend/tests/test_admin_service.py
@@ -1,0 +1,31 @@
+from fastapi import HTTPException
+
+from app.models import PlaceVisibilityUpdate
+from app.services import admin_service
+
+
+def test_read_admin_summary_service_uses_repository_entry(monkeypatch):
+    sentinel = {"places": []}
+    monkeypatch.setattr(admin_service, "read_admin_summary_entry", lambda db, settings: sentinel)
+
+    assert admin_service.read_admin_summary_service("db-session", object()) == sentinel
+
+
+def test_patch_admin_place_service_maps_value_error(monkeypatch):
+    monkeypatch.setattr(
+        admin_service,
+        "update_admin_place_visibility_entry",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("장소를 찾을 수 없어요.")),
+    )
+
+    try:
+        admin_service.patch_admin_place_service(
+            "db-session",
+            "place-1",
+            PlaceVisibilityUpdate(is_active=True, is_manual_override=True),
+        )
+    except HTTPException as error:
+        assert error.status_code == 404
+        assert error.detail == "장소를 찾을 수 없어요."
+    else:
+        raise AssertionError("Expected HTTPException")

--- a/backend/tests/test_auth_service.py
+++ b/backend/tests/test_auth_service.py
@@ -1,0 +1,53 @@
+from fastapi import HTTPException
+
+from app.config import Settings
+from app.models import SessionUser
+from app.services import auth_service
+
+
+def test_update_profile_session_payload_uses_auth_repository(monkeypatch):
+    payload = object()
+    user = type("UserLike", (), {"user_id": "user-1", "provider": "naver"})()
+    session_user = SessionUser(
+        id="user-1",
+        nickname="테스터",
+        email=None,
+        provider="naver",
+        profileImage=None,
+        isAdmin=True,
+        profileCompletedAt=None,
+    )
+
+    monkeypatch.setattr(auth_service, "update_user_profile_entry", lambda db, user_id, incoming: user)
+    monkeypatch.setattr(
+        auth_service,
+        "build_session_user",
+        lambda incoming_user, **kwargs: session_user,
+    )
+    monkeypatch.setattr(auth_service, "issue_access_token", lambda settings, current_user: "token-123")
+
+    response, access_token = auth_service.update_profile_session_payload(
+        "db-session",
+        "user-1",
+        payload,
+        Settings(admin_user_ids="user-1"),
+    )
+
+    assert response.user is session_user
+    assert access_token == "token-123"
+
+
+def test_update_profile_session_payload_maps_value_error(monkeypatch):
+    monkeypatch.setattr(
+        auth_service,
+        "update_user_profile_entry",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("닉네임 형식이 올바르지 않아요.")),
+    )
+
+    try:
+        auth_service.update_profile_session_payload("db-session", "user-1", object(), Settings())
+    except HTTPException as error:
+        assert error.status_code == 400
+        assert error.detail == "닉네임 형식이 올바르지 않아요."
+    else:
+        raise AssertionError("Expected HTTPException")

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -1,0 +1,52 @@
+from fastapi import HTTPException
+
+from app.services import notification_service
+
+
+def test_read_notifications_service_uses_repository_entry(monkeypatch):
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+    sentinel = [{"id": "notification-1"}]
+    monkeypatch.setattr(notification_service, "list_user_notification_entries", lambda db, user_id: sentinel)
+
+    assert notification_service.read_notifications_service("db-session", session_user) == sentinel
+
+
+def test_mark_notification_read_service_publishes_unread_count(monkeypatch):
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+    response = type("NotificationReadLike", (), {"notification_id": "notification-1"})()
+    published = []
+
+    monkeypatch.setattr(notification_service, "mark_notification_read_entry", lambda db, notification_id, user_id: response)
+    monkeypatch.setattr(notification_service, "read_unread_notification_count", lambda db, user_id: 3)
+    monkeypatch.setattr(notification_service.notification_broker, "publish", lambda user_id, payload: published.append((user_id, payload)))
+
+    result = notification_service.mark_notification_read_service("db-session", "notification-1", session_user)
+
+    assert result is response
+    assert published == [
+        (
+            "user-1",
+            {
+                "event": "notification.read",
+                "notificationId": "notification-1",
+                "unreadCount": 3,
+            },
+        )
+    ]
+
+
+def test_delete_notification_service_maps_value_error(monkeypatch):
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+    monkeypatch.setattr(
+        notification_service,
+        "delete_notification_entry",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("알림을 찾을 수 없어요.")),
+    )
+
+    try:
+        notification_service.delete_notification_service("db-session", "notification-1", session_user)
+    except HTTPException as error:
+        assert error.status_code == 404
+        assert error.detail == "알림을 찾을 수 없어요."
+    else:
+        raise AssertionError("Expected HTTPException")


### PR DESCRIPTION
## Summary
- split auth, admin, notification, and account service dependencies behind dedicated repository facades
- remove direct epository_normalized access from those services
- add focused service tests for the new boundaries

## Validation
- npm run typecheck
- npm run build
- backend service facade tests