### PR TITLE
Refactor NaverMap interaction boundaries

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,13 +1,8 @@
 import { useEffect, useRef } from 'react';
 import { getClientConfig } from '../config';
 import type { ApiStatus, FestivalItem, Place } from '../types';
-import { useNaverCurrentLocationMarker } from './naver-map/useNaverCurrentLocationMarker';
-import { useNaverCurrentLocationFocus } from './naver-map/useNaverCurrentLocationFocus';
-import { useNaverFestivalMarkers } from './naver-map/useNaverFestivalMarkers';
 import { useNaverMapInstance } from './naver-map/useNaverMapInstance';
-import { useNaverPlaceMarkers } from './naver-map/useNaverPlaceMarkers';
-import { useNaverRoutePreviewOverlay } from './naver-map/useNaverRoutePreviewOverlay';
-import { useNaverSelectionSync } from './naver-map/useNaverSelectionSync';
+import { useNaverMapInteractions } from './naver-map/useNaverMapInteractions';
 
 interface NaverMapProps {
   places: Place[];
@@ -47,10 +42,7 @@ export function NaverMap({
   height = '100%',
 }: NaverMapProps) {
   const mapElementRef = useRef<HTMLDivElement | null>(null);
-  const routeLineRef = useRef<any | null>(null);
-  const routeStepMarkersRef = useRef<any[]>([]);
   const onViewportChangeRef = useRef(onViewportChange);
-  const lastHandledCurrentLocationFocusKeyRef = useRef(0);
   const clientId = getClientConfig().naverMapClientId;
 
   useEffect(() => {
@@ -65,32 +57,7 @@ export function NaverMap({
     onViewportChangeRef,
   });
 
-  useNaverPlaceMarkers({
-    status,
-    mapsApi: window.naver?.maps,
-    mapRef,
-    places,
-    selectedPlaceId,
-    onSelectPlace,
-  });
-
-  useNaverFestivalMarkers({
-    status,
-    mapsApi: window.naver?.maps,
-    mapRef,
-    festivals,
-    selectedFestivalId,
-    onSelectFestival,
-  });
-
-  useNaverCurrentLocationMarker({
-    status,
-    mapsApi: window.naver?.maps,
-    mapRef,
-    currentPosition,
-  });
-
-  useNaverSelectionSync({
+  useNaverMapInteractions({
     status,
     mapsApi: window.naver?.maps,
     mapRef,
@@ -99,28 +66,11 @@ export function NaverMap({
     festivals,
     selectedPlaceId,
     selectedFestivalId,
-  });
-
-  useNaverCurrentLocationFocus({
-    status,
-    mapsApi: window.naver?.maps,
-    mapRef,
+    onSelectPlace,
+    onSelectFestival,
     currentPosition,
     focusCurrentLocationKey,
-    selectedPlaceId,
-    selectedFestivalId,
-    lastHandledCurrentLocationFocusKeyRef,
-  });
-
-  useNaverRoutePreviewOverlay({
-    status,
-    mapsApi: window.naver?.maps,
-    mapRef,
-    routeLineRef,
-    routeStepMarkersRef,
     routePreviewPlaces,
-    selectedPlaceId,
-    selectedFestivalId,
   });
 
   if (!clientId || status === 'error') {

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,16 +1,11 @@
-﻿import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef } from 'react';
 import { getClientConfig } from '../config';
 import type { ApiStatus, FestivalItem, Place } from '../types';
-import {
-  currentLocationMarkerContent,
-  DAEJEON_CENTER,
-  festivalMarkerContent,
-  getSelectionVerticalOffset,
-  hasFestivalCoordinates,
-  loadNaverMaps,
-  placeMarkerContent,
-} from './naver-map/naverMapHelpers';
+import { useNaverCurrentLocationMarker } from './naver-map/useNaverCurrentLocationMarker';
 import { useNaverCurrentLocationFocus } from './naver-map/useNaverCurrentLocationFocus';
+import { useNaverFestivalMarkers } from './naver-map/useNaverFestivalMarkers';
+import { useNaverMapInstance } from './naver-map/useNaverMapInstance';
+import { useNaverPlaceMarkers } from './naver-map/useNaverPlaceMarkers';
 import { useNaverRoutePreviewOverlay } from './naver-map/useNaverRoutePreviewOverlay';
 import { useNaverSelectionSync } from './naver-map/useNaverSelectionSync';
 
@@ -52,251 +47,48 @@ export function NaverMap({
   height = '100%',
 }: NaverMapProps) {
   const mapElementRef = useRef<HTMLDivElement | null>(null);
-  const mapRef = useRef<any>(null);
-  const placeMarkersRef = useRef<Map<string, any>>(new Map());
-  const festivalMarkersRef = useRef<Map<string, any>>(new Map());
-  const currentMarkerRef = useRef<any | null>(null);
   const routeLineRef = useRef<any | null>(null);
   const routeStepMarkersRef = useRef<any[]>([]);
   const onViewportChangeRef = useRef(onViewportChange);
-  const idleListenerRef = useRef<any>(null);
-  const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastHandledCurrentLocationFocusKeyRef = useRef(0);
-  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
-  const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const clientId = getClientConfig().naverMapClientId;
 
   useEffect(() => {
     onViewportChangeRef.current = onViewportChange;
   }, [onViewportChange]);
 
-  useEffect(() => {
-    if (!clientId) {
-      setStatus('error');
-      setErrorMessage('네이버 지도 Client ID가 비어 있어요.');
-      return;
-    }
+  const { mapRef, status, errorMessage } = useNaverMapInstance({
+    clientId,
+    mapElementRef,
+    initialCenter,
+    initialZoom,
+    onViewportChangeRef,
+  });
 
-    if (!mapElementRef.current) {
-      return;
-    }
+  useNaverPlaceMarkers({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    places,
+    selectedPlaceId,
+    onSelectPlace,
+  });
 
-    let isMounted = true;
+  useNaverFestivalMarkers({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    festivals,
+    selectedFestivalId,
+    onSelectFestival,
+  });
 
-    loadNaverMaps(clientId)
-      .then((maps) => {
-        if (!isMounted || !mapElementRef.current || mapRef.current) {
-          return;
-        }
-
-        mapRef.current = new maps.Map(mapElementRef.current, {
-          center: new maps.LatLng(
-            initialCenter?.lat ?? DAEJEON_CENTER.latitude,
-            initialCenter?.lng ?? DAEJEON_CENTER.longitude,
-          ),
-          zoom: initialZoom ?? 13,
-          minZoom: 11,
-          scaleControl: false,
-          logoControl: false,
-          mapDataControl: false,
-          zoomControl: true,
-        });
-
-        const idleListener = maps.Event.addListener(mapRef.current, 'idle', () => {
-          if (!mapRef.current) {
-            return;
-          }
-          const center = mapRef.current.getCenter();
-          const zoom = mapRef.current.getZoom();
-          if (viewportDebounceTimerRef.current !== null) {
-            clearTimeout(viewportDebounceTimerRef.current);
-          }
-          viewportDebounceTimerRef.current = setTimeout(() => {
-            onViewportChangeRef.current?.(center.lat(), center.lng(), zoom);
-            viewportDebounceTimerRef.current = null;
-          }, 300);
-        });
-        idleListenerRef.current = idleListener;
-
-        setStatus('ready');
-
-        return () => {
-          if (viewportDebounceTimerRef.current !== null) {
-            clearTimeout(viewportDebounceTimerRef.current);
-          }
-          maps.Event.removeListener(idleListener);
-        };
-      })
-      .catch((error: Error) => {
-        if (!isMounted) {
-          return;
-        }
-        setStatus('error');
-        setErrorMessage(error.message);
-      });
-
-    return () => {
-      isMounted = false;
-      if (viewportDebounceTimerRef.current !== null) {
-        clearTimeout(viewportDebounceTimerRef.current);
-        viewportDebounceTimerRef.current = null;
-      }
-      if (idleListenerRef.current && window.naver?.maps) {
-        window.naver.maps.Event.removeListener(idleListenerRef.current);
-        idleListenerRef.current = null;
-      }
-    };
-  }, [clientId]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-    const nextIds = new Set(places.map((place) => place.id));
-
-    for (const [placeId, marker] of placeMarkersRef.current.entries()) {
-      if (!nextIds.has(placeId)) {
-        marker.setMap(null);
-        placeMarkersRef.current.delete(placeId);
-      }
-    }
-
-    places.forEach((place) => {
-      const existing = placeMarkersRef.current.get(place.id);
-      const position = new maps.LatLng(place.latitude, place.longitude);
-      if (existing) {
-        existing.setPosition(position);
-        return;
-      }
-
-      const marker = new maps.Marker({
-        map: mapRef.current,
-        position,
-        title: '',
-        icon: {
-          content: placeMarkerContent(place, place.id === selectedPlaceId),
-          anchor: new maps.Point(15, 15),
-        },
-      });
-      maps.Event.addListener(marker, 'click', () => onSelectPlace(place.id));
-      placeMarkersRef.current.set(place.id, marker);
-    });
-  }, [onSelectPlace, places, selectedPlaceId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-    places.forEach((place) => {
-      const marker = placeMarkersRef.current.get(place.id);
-      if (!marker) {
-        return;
-      }
-      marker.setIcon({
-        content: placeMarkerContent(place, place.id === selectedPlaceId),
-        anchor: new maps.Point(15, 15),
-      });
-      marker.setZIndex(place.id === selectedPlaceId ? 160 : 100);
-    });
-  }, [places, selectedPlaceId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-    const nextIds = new Set(festivals.filter(hasFestivalCoordinates).map((festival) => festival.id));
-
-    for (const [festivalId, marker] of festivalMarkersRef.current.entries()) {
-      if (!nextIds.has(festivalId)) {
-        marker.setMap(null);
-        festivalMarkersRef.current.delete(festivalId);
-      }
-    }
-
-    festivals.forEach((festival) => {
-      if (!hasFestivalCoordinates(festival)) {
-        return;
-      }
-      const existing = festivalMarkersRef.current.get(festival.id);
-      const position = new maps.LatLng(festival.latitude, festival.longitude);
-      if (existing) {
-        existing.setPosition(position);
-        return;
-      }
-
-      const marker = new maps.Marker({
-        map: mapRef.current,
-        position,
-        title: '',
-        zIndex: festival.id === selectedFestivalId ? 170 : 110,
-        icon: {
-          content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
-          anchor: new maps.Point(15, 15),
-        },
-      });
-      maps.Event.addListener(marker, 'click', () => onSelectFestival(festival.id));
-      festivalMarkersRef.current.set(festival.id, marker);
-    });
-  }, [festivals, onSelectFestival, selectedFestivalId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-    festivals.forEach((festival) => {
-      const marker = festivalMarkersRef.current.get(festival.id);
-      if (!marker) {
-        return;
-      }
-      marker.setIcon({
-        content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
-        anchor: new maps.Point(15, 15),
-      });
-      marker.setZIndex(festival.id === selectedFestivalId ? 170 : 110);
-    });
-  }, [festivals, selectedFestivalId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-
-    if (!currentPosition) {
-      if (currentMarkerRef.current) {
-        currentMarkerRef.current.setMap(null);
-        currentMarkerRef.current = null;
-      }
-      return;
-    }
-
-    const position = new maps.LatLng(currentPosition.latitude, currentPosition.longitude);
-    if (!currentMarkerRef.current) {
-      currentMarkerRef.current = new maps.Marker({
-        map: mapRef.current,
-        position,
-        title: '',
-        zIndex: 200,
-        icon: {
-          content: currentLocationMarkerContent(),
-          anchor: new maps.Point(15, 15),
-        },
-      });
-      return;
-    }
-
-    currentMarkerRef.current.setPosition(position);
-    currentMarkerRef.current.setMap(mapRef.current);
-  }, [currentPosition, status]);
+  useNaverCurrentLocationMarker({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    currentPosition,
+  });
 
   useNaverSelectionSync({
     status,
@@ -331,7 +123,6 @@ export function NaverMap({
     selectedFestivalId,
   });
 
-
   if (!clientId || status === 'error') {
     return (
       <div className="map-status-card">
@@ -359,10 +150,3 @@ export function NaverMap({
     </div>
   );
 }
-
-
-
-
-
-
-

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -9,8 +9,10 @@ import {
   hasFestivalCoordinates,
   loadNaverMaps,
   placeMarkerContent,
-  routeStepMarkerContent,
 } from './naver-map/naverMapHelpers';
+import { useNaverCurrentLocationFocus } from './naver-map/useNaverCurrentLocationFocus';
+import { useNaverRoutePreviewOverlay } from './naver-map/useNaverRoutePreviewOverlay';
+import { useNaverSelectionSync } from './naver-map/useNaverSelectionSync';
 
 interface NaverMapProps {
   places: Place[];
@@ -296,118 +298,38 @@ export function NaverMap({
     currentMarkerRef.current.setMap(mapRef.current);
   }, [currentPosition, status]);
 
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
+  useNaverSelectionSync({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    mapElementRef,
+    places,
+    festivals,
+    selectedPlaceId,
+    selectedFestivalId,
+  });
 
-    const selectedPlace = selectedPlaceId ? places.find((place) => place.id === selectedPlaceId) : null;
-    const selectedFestival = selectedFestivalId ? festivals.find((festival) => festival.id === selectedFestivalId) : null;
-    const targetType = selectedPlace ? 'place' : selectedFestival ? 'festival' : null;
-    const target = selectedPlace
-      ? { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude }
-      : selectedFestival && hasFestivalCoordinates(selectedFestival)
-        ? { latitude: selectedFestival.latitude, longitude: selectedFestival.longitude }
-        : null;
+  useNaverCurrentLocationFocus({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    currentPosition,
+    focusCurrentLocationKey,
+    selectedPlaceId,
+    selectedFestivalId,
+    lastHandledCurrentLocationFocusKeyRef,
+  });
 
-    if (!target || !targetType) {
-      return;
-    }
-
-    const map = mapRef.current;
-    const targetLatLng = new window.naver.maps.LatLng(target.latitude, target.longitude);
-    const currentZoom = typeof map.getZoom === 'function' ? Number(map.getZoom()) : 13;
-    const nextZoom = Number.isFinite(currentZoom) ? Math.max(currentZoom, 15) : 15;
-
-    if (typeof map.setZoom === 'function' && currentZoom < nextZoom) {
-      map.setZoom(nextZoom, false);
-    }
-
-    if (typeof map.panTo === 'function') {
-      map.panTo(targetLatLng);
-    } else if (typeof map.setCenter === 'function') {
-      map.setCenter(targetLatLng);
-    }
-
-    if (typeof map.panBy === 'function') {
-      const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 640;
-      const panDelayMs = isMobileViewport && targetType === 'place' ? 260 : 180;
-      window.setTimeout(() => {
-        if (mapRef.current === map) {
-          map.panBy(0, -getSelectionVerticalOffset(mapElementRef.current, targetType));
-        }
-      }, panDelayMs);
-    }
-  }, [festivals, places, selectedFestivalId, selectedPlaceId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current || !currentPosition || focusCurrentLocationKey === 0) {
-      return;
-    }
-
-    if (focusCurrentLocationKey === lastHandledCurrentLocationFocusKeyRef.current) {
-      return;
-    }
-
-    // A direct place/festival selection is a newer intent than an old
-    // "show my location" focus request, so consume and discard it here.
-    if (selectedPlaceId || selectedFestivalId) {
-      lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
-      return;
-    }
-
-    lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
-    mapRef.current.panTo(new window.naver.maps.LatLng(currentPosition.latitude, currentPosition.longitude));
-  }, [currentPosition, focusCurrentLocationKey, selectedFestivalId, selectedPlaceId, status]);
-
-  useEffect(() => {
-    if (status !== 'ready' || !window.naver?.maps || !mapRef.current) {
-      return;
-    }
-
-    const maps = window.naver.maps;
-    if (routeLineRef.current) {
-      routeLineRef.current.setMap(null);
-      routeLineRef.current = null;
-    }
-    routeStepMarkersRef.current.forEach((marker) => marker.setMap(null));
-    routeStepMarkersRef.current = [];
-
-    if (!routePreviewPlaces || routePreviewPlaces.length === 0) {
-      return;
-    }
-
-    const path = routePreviewPlaces.map((place) => new maps.LatLng(place.latitude, place.longitude));
-    routeLineRef.current = new maps.Polyline({
-      map: mapRef.current,
-      path,
-      strokeColor: '#ff6b9d',
-      strokeOpacity: 0.82,
-      strokeWeight: 4,
-      strokeLineCap: 'round',
-      strokeLineJoin: 'round',
-      zIndex: 120,
-    });
-
-    routeStepMarkersRef.current = routePreviewPlaces.map((place, index) => new maps.Marker({
-      map: mapRef.current,
-      position: new maps.LatLng(place.latitude, place.longitude),
-      title: '',
-      zIndex: 165,
-      icon: {
-        content: routeStepMarkerContent(index + 1),
-        anchor: new maps.Point(13, 13),
-      },
-    }));
-
-    if (routePreviewPlaces.length >= 2 && !selectedPlaceId && !selectedFestivalId) {
-      const bounds = new maps.LatLngBounds();
-      routePreviewPlaces.forEach((place) => bounds.extend(new maps.LatLng(place.latitude, place.longitude)));
-      mapRef.current.fitBounds(bounds, { top: 72, right: 40, bottom: 120, left: 40 });
-    } else if (routePreviewPlaces.length === 1 && !selectedPlaceId && !selectedFestivalId) {
-      mapRef.current.panTo(new maps.LatLng(routePreviewPlaces[0].latitude, routePreviewPlaces[0].longitude));
-    }
-  }, [routePreviewPlaces, selectedFestivalId, selectedPlaceId, status]);
+  useNaverRoutePreviewOverlay({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
+    routeLineRef,
+    routeStepMarkersRef,
+    routePreviewPlaces,
+    selectedPlaceId,
+    selectedFestivalId,
+  });
 
 
   if (!clientId || status === 'error') {

--- a/src/components/naver-map/useNaverCurrentLocationFocus.ts
+++ b/src/components/naver-map/useNaverCurrentLocationFocus.ts
@@ -1,0 +1,56 @@
+import { useEffect } from 'react';
+
+type NaverMapInstance = {
+  panTo?: (position: unknown) => void;
+};
+
+type MapsApi = typeof window.naver.maps;
+
+type CurrentLocationFocusArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: React.MutableRefObject<NaverMapInstance | null>;
+  currentPosition: { latitude: number; longitude: number } | null;
+  focusCurrentLocationKey: number;
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  lastHandledCurrentLocationFocusKeyRef: React.MutableRefObject<number>;
+};
+
+export function useNaverCurrentLocationFocus({
+  status,
+  mapsApi,
+  mapRef,
+  currentPosition,
+  focusCurrentLocationKey,
+  selectedPlaceId,
+  selectedFestivalId,
+  lastHandledCurrentLocationFocusKeyRef,
+}: CurrentLocationFocusArgs) {
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current || !currentPosition || focusCurrentLocationKey === 0) {
+      return;
+    }
+
+    if (focusCurrentLocationKey === lastHandledCurrentLocationFocusKeyRef.current) {
+      return;
+    }
+
+    if (selectedPlaceId || selectedFestivalId) {
+      lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
+      return;
+    }
+
+    lastHandledCurrentLocationFocusKeyRef.current = focusCurrentLocationKey;
+    mapRef.current.panTo?.(new mapsApi.LatLng(currentPosition.latitude, currentPosition.longitude));
+  }, [
+    currentPosition,
+    focusCurrentLocationKey,
+    lastHandledCurrentLocationFocusKeyRef,
+    mapRef,
+    mapsApi,
+    selectedFestivalId,
+    selectedPlaceId,
+    status,
+  ]);
+}

--- a/src/components/naver-map/useNaverCurrentLocationMarker.ts
+++ b/src/components/naver-map/useNaverCurrentLocationMarker.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import { currentLocationMarkerContent } from './naverMapHelpers';
+
+type MapsApi = typeof window.naver.maps;
+
+type CurrentLocationMarkerArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: MutableRefObject<any>;
+  currentPosition: { latitude: number; longitude: number } | null;
+};
+
+export function useNaverCurrentLocationMarker({
+  status,
+  mapsApi,
+  mapRef,
+  currentPosition,
+}: CurrentLocationMarkerArgs) {
+  const currentMarkerRef = useRef<any | null>(null);
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    if (!currentPosition) {
+      if (currentMarkerRef.current) {
+        currentMarkerRef.current.setMap(null);
+        currentMarkerRef.current = null;
+      }
+      return;
+    }
+
+    const position = new mapsApi.LatLng(currentPosition.latitude, currentPosition.longitude);
+    if (!currentMarkerRef.current) {
+      currentMarkerRef.current = new mapsApi.Marker({
+        map: mapRef.current,
+        position,
+        title: '',
+        zIndex: 200,
+        icon: {
+          content: currentLocationMarkerContent(),
+          anchor: new mapsApi.Point(15, 15),
+        },
+      });
+      return;
+    }
+
+    currentMarkerRef.current.setPosition(position);
+    currentMarkerRef.current.setMap(mapRef.current);
+  }, [currentPosition, mapRef, mapsApi, status]);
+}

--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { FestivalItem } from '../../types';
+import { festivalMarkerContent, hasFestivalCoordinates } from './naverMapHelpers';
+
+type MapsApi = typeof window.naver.maps;
+
+type FestivalMarkersArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: MutableRefObject<any>;
+  festivals: FestivalItem[];
+  selectedFestivalId: string | null;
+  onSelectFestival: (festivalId: string) => void;
+};
+
+export function useNaverFestivalMarkers({
+  status,
+  mapsApi,
+  mapRef,
+  festivals,
+  selectedFestivalId,
+  onSelectFestival,
+}: FestivalMarkersArgs) {
+  const festivalMarkersRef = useRef<Map<string, any>>(new Map());
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    const nextIds = new Set(festivals.filter(hasFestivalCoordinates).map((festival) => festival.id));
+
+    for (const [festivalId, marker] of festivalMarkersRef.current.entries()) {
+      if (!nextIds.has(festivalId)) {
+        marker.setMap(null);
+        festivalMarkersRef.current.delete(festivalId);
+      }
+    }
+
+    festivals.forEach((festival) => {
+      if (!hasFestivalCoordinates(festival)) {
+        return;
+      }
+      const existing = festivalMarkersRef.current.get(festival.id);
+      const position = new mapsApi.LatLng(festival.latitude, festival.longitude);
+      if (existing) {
+        existing.setPosition(position);
+        return;
+      }
+
+      const marker = new mapsApi.Marker({
+        map: mapRef.current,
+        position,
+        title: '',
+        zIndex: festival.id === selectedFestivalId ? 170 : 110,
+        icon: {
+          content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
+          anchor: new mapsApi.Point(15, 15),
+        },
+      });
+      mapsApi.Event.addListener(marker, 'click', () => onSelectFestival(festival.id));
+      festivalMarkersRef.current.set(festival.id, marker);
+    });
+  }, [festivals, mapRef, mapsApi, onSelectFestival, selectedFestivalId, status]);
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    festivals.forEach((festival) => {
+      const marker = festivalMarkersRef.current.get(festival.id);
+      if (!marker) {
+        return;
+      }
+      marker.setIcon({
+        content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
+        anchor: new mapsApi.Point(15, 15),
+      });
+      marker.setZIndex(festival.id === selectedFestivalId ? 170 : 110);
+    });
+  }, [festivals, mapRef, mapsApi, selectedFestivalId, status]);
+}

--- a/src/components/naver-map/useNaverMapInstance.ts
+++ b/src/components/naver-map/useNaverMapInstance.ts
@@ -1,0 +1,96 @@
+import { useEffect, useRef, useState } from 'react';
+import { loadNaverMaps } from './naverMapHelpers';
+
+type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
+
+type MapInstanceArgs = {
+  clientId: string;
+  mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
+  initialCenter?: { lat: number; lng: number };
+  initialZoom?: number;
+  onViewportChangeRef: React.MutableRefObject<ViewportChangeHandler>;
+};
+
+export function useNaverMapInstance({
+  clientId,
+  mapElementRef,
+  initialCenter,
+  initialZoom,
+  onViewportChangeRef,
+}: MapInstanceArgs) {
+  const mapRef = useRef<any>(null);
+  const idleListenerRef = useRef<any>(null);
+  const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!clientId) {
+      setStatus('error');
+      setErrorMessage('네이버 지도 Client ID가 비어 있어요.');
+      return;
+    }
+
+    if (!mapElementRef.current) {
+      return;
+    }
+
+    let isMounted = true;
+
+    loadNaverMaps(clientId)
+      .then((maps) => {
+        if (!isMounted || !mapElementRef.current || mapRef.current) {
+          return;
+        }
+
+        mapRef.current = new maps.Map(mapElementRef.current, {
+          center: new maps.LatLng(initialCenter?.lat ?? 36.3504, initialCenter?.lng ?? 127.3845),
+          zoom: initialZoom ?? 13,
+          minZoom: 11,
+          scaleControl: false,
+          logoControl: false,
+          mapDataControl: false,
+          zoomControl: true,
+        });
+
+        const idleListener = maps.Event.addListener(mapRef.current, 'idle', () => {
+          if (!mapRef.current) {
+            return;
+          }
+          const center = mapRef.current.getCenter();
+          const zoom = mapRef.current.getZoom();
+          if (viewportDebounceTimerRef.current !== null) {
+            clearTimeout(viewportDebounceTimerRef.current);
+          }
+          viewportDebounceTimerRef.current = setTimeout(() => {
+            onViewportChangeRef.current?.(center.lat(), center.lng(), zoom);
+            viewportDebounceTimerRef.current = null;
+          }, 300);
+        });
+
+        idleListenerRef.current = idleListener;
+        setStatus('ready');
+      })
+      .catch((error: Error) => {
+        if (!isMounted) {
+          return;
+        }
+        setStatus('error');
+        setErrorMessage(error.message);
+      });
+
+    return () => {
+      isMounted = false;
+      if (viewportDebounceTimerRef.current !== null) {
+        clearTimeout(viewportDebounceTimerRef.current);
+        viewportDebounceTimerRef.current = null;
+      }
+      if (idleListenerRef.current && window.naver?.maps) {
+        window.naver.maps.Event.removeListener(idleListenerRef.current);
+        idleListenerRef.current = null;
+      }
+    };
+  }, [clientId, initialCenter?.lat, initialCenter?.lng, initialZoom, mapElementRef, onViewportChangeRef]);
+
+  return { mapRef, status, errorMessage };
+}

--- a/src/components/naver-map/useNaverMapInteractions.ts
+++ b/src/components/naver-map/useNaverMapInteractions.ts
@@ -1,0 +1,102 @@
+import { useRef } from 'react';
+import type { FestivalItem, Place } from '../../types';
+import { useNaverCurrentLocationMarker } from './useNaverCurrentLocationMarker';
+import { useNaverCurrentLocationFocus } from './useNaverCurrentLocationFocus';
+import { useNaverFestivalMarkers } from './useNaverFestivalMarkers';
+import { useNaverPlaceMarkers } from './useNaverPlaceMarkers';
+import { useNaverRoutePreviewOverlay } from './useNaverRoutePreviewOverlay';
+import { useNaverSelectionSync } from './useNaverSelectionSync';
+
+type MapInteractionsArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: typeof window.naver.maps | undefined;
+  mapRef: React.MutableRefObject<any>;
+  mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
+  places: Place[];
+  festivals: FestivalItem[];
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  onSelectPlace: (placeId: string) => void;
+  onSelectFestival: (festivalId: string) => void;
+  currentPosition: { latitude: number; longitude: number } | null;
+  focusCurrentLocationKey: number;
+  routePreviewPlaces: Place[];
+};
+
+export function useNaverMapInteractions({
+  status,
+  mapsApi,
+  mapRef,
+  mapElementRef,
+  places,
+  festivals,
+  selectedPlaceId,
+  selectedFestivalId,
+  onSelectPlace,
+  onSelectFestival,
+  currentPosition,
+  focusCurrentLocationKey,
+  routePreviewPlaces,
+}: MapInteractionsArgs) {
+  const routeLineRef = useRef<any | null>(null);
+  const routeStepMarkersRef = useRef<any[]>([]);
+  const lastHandledCurrentLocationFocusKeyRef = useRef(0);
+
+  useNaverPlaceMarkers({
+    status,
+    mapsApi,
+    mapRef,
+    places,
+    selectedPlaceId,
+    onSelectPlace,
+  });
+
+  useNaverFestivalMarkers({
+    status,
+    mapsApi,
+    mapRef,
+    festivals,
+    selectedFestivalId,
+    onSelectFestival,
+  });
+
+  useNaverCurrentLocationMarker({
+    status,
+    mapsApi,
+    mapRef,
+    currentPosition,
+  });
+
+  useNaverSelectionSync({
+    status,
+    mapsApi,
+    mapRef,
+    mapElementRef,
+    places,
+    festivals,
+    selectedPlaceId,
+    selectedFestivalId,
+  });
+
+  useNaverCurrentLocationFocus({
+    status,
+    mapsApi,
+    mapRef,
+    currentPosition,
+    focusCurrentLocationKey,
+    selectedPlaceId,
+    selectedFestivalId,
+    lastHandledCurrentLocationFocusKeyRef,
+  });
+
+  useNaverRoutePreviewOverlay({
+    status,
+    mapsApi,
+    mapRef,
+    routeLineRef,
+    routeStepMarkersRef,
+    routePreviewPlaces,
+    selectedPlaceId,
+    selectedFestivalId,
+  });
+}

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -1,0 +1,80 @@
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { Place } from '../../types';
+import { placeMarkerContent } from './naverMapHelpers';
+
+type MapsApi = typeof window.naver.maps;
+
+type PlaceMarkersArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: MutableRefObject<any>;
+  places: Place[];
+  selectedPlaceId: string | null;
+  onSelectPlace: (placeId: string) => void;
+};
+
+export function useNaverPlaceMarkers({
+  status,
+  mapsApi,
+  mapRef,
+  places,
+  selectedPlaceId,
+  onSelectPlace,
+}: PlaceMarkersArgs) {
+  const placeMarkersRef = useRef<Map<string, any>>(new Map());
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    const nextIds = new Set(places.map((place) => place.id));
+
+    for (const [placeId, marker] of placeMarkersRef.current.entries()) {
+      if (!nextIds.has(placeId)) {
+        marker.setMap(null);
+        placeMarkersRef.current.delete(placeId);
+      }
+    }
+
+    places.forEach((place) => {
+      const existing = placeMarkersRef.current.get(place.id);
+      const position = new mapsApi.LatLng(place.latitude, place.longitude);
+      if (existing) {
+        existing.setPosition(position);
+        return;
+      }
+
+      const marker = new mapsApi.Marker({
+        map: mapRef.current,
+        position,
+        title: '',
+        icon: {
+          content: placeMarkerContent(place, place.id === selectedPlaceId),
+          anchor: new mapsApi.Point(15, 15),
+        },
+      });
+      mapsApi.Event.addListener(marker, 'click', () => onSelectPlace(place.id));
+      placeMarkersRef.current.set(place.id, marker);
+    });
+  }, [mapRef, mapsApi, onSelectPlace, places, selectedPlaceId, status]);
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    places.forEach((place) => {
+      const marker = placeMarkersRef.current.get(place.id);
+      if (!marker) {
+        return;
+      }
+      marker.setIcon({
+        content: placeMarkerContent(place, place.id === selectedPlaceId),
+        anchor: new mapsApi.Point(15, 15),
+      });
+      marker.setZIndex(place.id === selectedPlaceId ? 160 : 100);
+    });
+  }, [mapRef, mapsApi, places, selectedPlaceId, status]);
+}

--- a/src/components/naver-map/useNaverRoutePreviewOverlay.ts
+++ b/src/components/naver-map/useNaverRoutePreviewOverlay.ts
@@ -1,0 +1,100 @@
+import { useEffect } from 'react';
+import type { Place } from '../../types';
+import { routeStepMarkerContent } from './naverMapHelpers';
+
+type NaverMapInstance = {
+  fitBounds?: (bounds: unknown, padding?: Record<string, number>) => void;
+  panTo?: (position: unknown) => void;
+};
+
+type MarkerInstance = {
+  setMap: (map: unknown) => void;
+};
+
+type PolylineInstance = {
+  setMap: (map: unknown) => void;
+};
+
+type MapsApi = typeof window.naver.maps;
+
+type RoutePreviewOverlayArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: React.MutableRefObject<NaverMapInstance | null>;
+  routeLineRef: React.MutableRefObject<PolylineInstance | null>;
+  routeStepMarkersRef: React.MutableRefObject<MarkerInstance[]>;
+  routePreviewPlaces: Place[];
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+};
+
+export function useNaverRoutePreviewOverlay({
+  status,
+  mapsApi,
+  mapRef,
+  routeLineRef,
+  routeStepMarkersRef,
+  routePreviewPlaces,
+  selectedPlaceId,
+  selectedFestivalId,
+}: RoutePreviewOverlayArgs) {
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    if (routeLineRef.current) {
+      routeLineRef.current.setMap(null);
+      routeLineRef.current = null;
+    }
+    routeStepMarkersRef.current.forEach((marker) => marker.setMap(null));
+    routeStepMarkersRef.current = [];
+
+    if (!routePreviewPlaces || routePreviewPlaces.length === 0) {
+      return;
+    }
+
+    const path = routePreviewPlaces.map((place) => new mapsApi.LatLng(place.latitude, place.longitude));
+    routeLineRef.current = new mapsApi.Polyline({
+      map: mapRef.current,
+      path,
+      strokeColor: '#ff6b9d',
+      strokeOpacity: 0.82,
+      strokeWeight: 4,
+      strokeLineCap: 'round',
+      strokeLineJoin: 'round',
+      zIndex: 120,
+    });
+
+    routeStepMarkersRef.current = routePreviewPlaces.map(
+      (place, index) =>
+        new mapsApi.Marker({
+          map: mapRef.current,
+          position: new mapsApi.LatLng(place.latitude, place.longitude),
+          title: '',
+          zIndex: 165,
+          icon: {
+            content: routeStepMarkerContent(index + 1),
+            anchor: new mapsApi.Point(13, 13),
+          },
+        }),
+    );
+
+    if (routePreviewPlaces.length >= 2 && !selectedPlaceId && !selectedFestivalId) {
+      const bounds = new mapsApi.LatLngBounds();
+      routePreviewPlaces.forEach((place) => bounds.extend(new mapsApi.LatLng(place.latitude, place.longitude)));
+      mapRef.current.fitBounds?.(bounds, { top: 72, right: 40, bottom: 120, left: 40 });
+    } else if (routePreviewPlaces.length === 1 && !selectedPlaceId && !selectedFestivalId) {
+      mapRef.current.panTo?.(new mapsApi.LatLng(routePreviewPlaces[0].latitude, routePreviewPlaces[0].longitude));
+    }
+  }, [
+    mapRef,
+    mapsApi,
+    routeLineRef,
+    routePreviewPlaces,
+    routeStepMarkersRef,
+    selectedFestivalId,
+    selectedPlaceId,
+    status,
+  ]);
+}

--- a/src/components/naver-map/useNaverSelectionSync.ts
+++ b/src/components/naver-map/useNaverSelectionSync.ts
@@ -1,0 +1,79 @@
+import { useEffect } from 'react';
+import type { FestivalItem, Place } from '../../types';
+import { getSelectionVerticalOffset, hasFestivalCoordinates } from './naverMapHelpers';
+
+type NaverMapInstance = {
+  getZoom?: () => number;
+  setZoom?: (zoom: number, effect?: boolean) => void;
+  panTo?: (position: unknown) => void;
+  setCenter?: (position: unknown) => void;
+  panBy?: (x: number, y: number) => void;
+};
+
+type MapsApi = typeof window.naver.maps;
+
+type SelectionSyncArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: MapsApi | undefined;
+  mapRef: React.MutableRefObject<NaverMapInstance | null>;
+  mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
+  places: Place[];
+  festivals: FestivalItem[];
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+};
+
+export function useNaverSelectionSync({
+  status,
+  mapsApi,
+  mapRef,
+  mapElementRef,
+  places,
+  festivals,
+  selectedPlaceId,
+  selectedFestivalId,
+}: SelectionSyncArgs) {
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    const selectedPlace = selectedPlaceId ? places.find((place) => place.id === selectedPlaceId) : null;
+    const selectedFestival = selectedFestivalId ? festivals.find((festival) => festival.id === selectedFestivalId) : null;
+    const targetType = selectedPlace ? 'place' : selectedFestival ? 'festival' : null;
+    const target = selectedPlace
+      ? { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude }
+      : selectedFestival && hasFestivalCoordinates(selectedFestival)
+        ? { latitude: selectedFestival.latitude, longitude: selectedFestival.longitude }
+        : null;
+
+    if (!target || !targetType) {
+      return;
+    }
+
+    const map = mapRef.current;
+    const targetLatLng = new mapsApi.LatLng(target.latitude, target.longitude);
+    const currentZoom = typeof map.getZoom === 'function' ? Number(map.getZoom()) : 13;
+    const nextZoom = Number.isFinite(currentZoom) ? Math.max(currentZoom, 15) : 15;
+
+    if (typeof map.setZoom === 'function' && currentZoom < nextZoom) {
+      map.setZoom(nextZoom, false);
+    }
+
+    if (typeof map.panTo === 'function') {
+      map.panTo(targetLatLng);
+    } else if (typeof map.setCenter === 'function') {
+      map.setCenter(targetLatLng);
+    }
+
+    if (typeof map.panBy === 'function') {
+      const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 640;
+      const panDelayMs = isMobileViewport && targetType === 'place' ? 260 : 180;
+      window.setTimeout(() => {
+        if (mapRef.current === map) {
+          map.panBy?.(0, -getSelectionVerticalOffset(mapElementRef.current, targetType));
+        }
+      }, panDelayMs);
+    }
+  }, [festivals, mapElementRef, mapRef, mapsApi, places, selectedFestivalId, selectedPlaceId, status]);
+}


### PR DESCRIPTION
## Summary
- split NaverMap marker lifecycle, map instance setup, and interaction composition into focused hooks
- keep map behavior the same while shrinking the main component responsibility
- restore readable map status copy while tightening the map boundary

## Validation
- npm run typecheck
- npm run build
- npm run test:all