### PR TITLE
Harden protected smoke contracts and docs

### DIFF
--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -118,21 +118,9 @@ jobs:
       SMOKE_RETRY_DELAY_MS: 15000
       SMOKE_AUTH_BEARER_TOKEN: ${{ secrets.SMOKE_AUTH_BEARER_TOKEN || '' }}
     steps:
-      - name: Check protected smoke token
-        id: guard
-        run: |
-          if [ -z "${SMOKE_AUTH_BEARER_TOKEN}" ]; then
-            echo "enabled=false" >> "$GITHUB_OUTPUT"
-            echo "Protected smoke skipped: SMOKE_AUTH_BEARER_TOKEN is not configured."
-          else
-            echo "enabled=true" >> "$GITHUB_OUTPUT"
-          fi
       - uses: actions/checkout@v4
-        if: steps.guard.outputs.enabled == 'true'
       - uses: actions/setup-node@v4
-        if: steps.guard.outputs.enabled == 'true'
         with:
           node-version: "20"
       - name: Run protected production smoke checks
-        if: steps.guard.outputs.enabled == 'true'
         run: node scripts/run-protected-smoke-checks.mjs

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -48,7 +48,18 @@
 ### 남은 후속
 - [x] 인증 없는 public smoke와 인증 필요한 protected smoke 분리
 - [ ] 브라우저 수준 smoke 시나리오 확장
-- [ ] protected smoke 토큰/엔드포인트 계약 테스트와 운영 문서 보강
+- [x] protected smoke 토큰 유무에 따른 skip 계약 명시
+- [x] protected smoke 엔드포인트 목록 계약 테스트 보강
+- [ ] protected smoke 운영 토큰 발급/로테이션 절차 문서화
+- [ ] protected smoke 대상 엔드포인트 추가 여부 주기적 점검
+
+### 현재 protected smoke 계약
+- `SMOKE_AUTH_BEARER_TOKEN`가 없으면 protected smoke는 실패하지 않고 skip으로 종료한다.
+- `SMOKE_AUTH_BEARER_TOKEN`가 있으면 아래 엔드포인트를 인증 상태로 검사한다.
+  - `/api/auth/me`
+  - `/api/my/summary`
+  - `/api/my/notifications`
+- public smoke와 protected smoke는 서로 독립적으로 결과를 남긴다.
 
 ### 완료 조건
 - 배포 후 최소 1개의 자동 스모크가 실행된다.

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -46,8 +46,9 @@
 - [x] 실패 시 요약 로그 출력
 
 ### 남은 후속
-- [ ] 인증 없는 public smoke와 인증 필요한 protected smoke 분리
+- [x] 인증 없는 public smoke와 인증 필요한 protected smoke 분리
 - [ ] 브라우저 수준 smoke 시나리오 확장
+- [ ] protected smoke 토큰/엔드포인트 계약 테스트와 운영 문서 보강
 
 ### 완료 조건
 - 배포 후 최소 1개의 자동 스모크가 실행된다.

--- a/scripts/run-protected-smoke-checks.mjs
+++ b/scripts/run-protected-smoke-checks.mjs
@@ -7,8 +7,49 @@ import {
   scriptEntryMatches,
 } from "./smoke/shared.mjs";
 
-export function getProtectedAuthHeaders() {
-  const token = process.env.SMOKE_AUTH_BEARER_TOKEN || "";
+export const PROTECTED_SMOKE_ENDPOINTS = [
+  {
+    name: "api-auth-me-authenticated",
+    path: "/api/auth/me",
+    assertJson(response, json) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(json?.isAuthenticated === true, "session should be authenticated");
+      assert(Boolean(json?.user?.id), "authenticated user id is missing");
+    },
+  },
+  {
+    name: "api-my-summary-authenticated",
+    path: "/api/my/summary",
+    assertJson(response, json) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(Array.isArray(json?.stamps), "my summary stamps array is missing");
+      assert(Array.isArray(json?.reviews), "my summary reviews array is missing");
+      assert(Array.isArray(json?.notifications), "my summary notifications array is missing");
+    },
+  },
+  {
+    name: "api-my-notifications-authenticated",
+    path: "/api/my/notifications",
+    assertJson(response, json) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(Array.isArray(json), "notifications response is not an array");
+    },
+  },
+];
+
+export function isProtectedSmokeEnabled(env = process.env) {
+  return Boolean((env.SMOKE_AUTH_BEARER_TOKEN || "").trim());
+}
+
+export function getProtectedSmokeSkipReason(env = process.env) {
+  if (isProtectedSmokeEnabled(env)) {
+    return null;
+  }
+  return "SMOKE_AUTH_BEARER_TOKEN is not configured";
+}
+
+export function getProtectedAuthHeaders(env = process.env) {
+  const token = env.SMOKE_AUTH_BEARER_TOKEN || "";
   if (!token) {
     throw new Error("SMOKE_AUTH_BEARER_TOKEN is required for protected smoke checks");
   }
@@ -21,43 +62,47 @@ export function getProtectedAuthHeaders() {
 export function createProtectedSmokeChecks({ apiBaseUrl }) {
   const authHeaders = getProtectedAuthHeaders();
 
-  return [
-    { name: "api-auth-me-authenticated", run: () => runCheck("api-auth-me-authenticated", async () => {
-      const { response, json } = await fetchJson(`${apiBaseUrl}/api/auth/me`, {
+  return PROTECTED_SMOKE_ENDPOINTS.map((endpoint) => ({
+    name: endpoint.name,
+    run: () => runCheck(endpoint.name, async () => {
+      const { response, json } = await fetchJson(`${apiBaseUrl}${endpoint.path}`, {
         headers: authHeaders,
       });
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(json?.isAuthenticated === true, "session should be authenticated");
-      assert(Boolean(json?.user?.id), "authenticated user id is missing");
-    }) },
-    { name: "api-my-summary-authenticated", run: () => runCheck("api-my-summary-authenticated", async () => {
-      const { response, json } = await fetchJson(`${apiBaseUrl}/api/my/summary`, {
-        headers: authHeaders,
-      });
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(Array.isArray(json?.stamps), "my summary stamps array is missing");
-      assert(Array.isArray(json?.reviews), "my summary reviews array is missing");
-      assert(Array.isArray(json?.notifications), "my summary notifications array is missing");
-    }) },
-    { name: "api-my-notifications-authenticated", run: () => runCheck("api-my-notifications-authenticated", async () => {
-      const { response, json } = await fetchJson(`${apiBaseUrl}/api/my/notifications`, {
-        headers: authHeaders,
-      });
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(Array.isArray(json), "notifications response is not an array");
-    }) },
-  ];
+      endpoint.assertJson(response, json);
+    }),
+  }));
 }
 
-export async function main() {
-  const { appConfigResult, runtimeConfig, apiBaseUrl } = await loadRuntimeConfig();
-  return runSmokeSuite({
+export async function runProtectedSmokeSuite({
+  env = process.env,
+  loadRuntimeConfigImpl = loadRuntimeConfig,
+  runSmokeSuiteImpl = runSmokeSuite,
+} = {}) {
+  const skipReason = getProtectedSmokeSkipReason(env);
+  if (skipReason) {
+    const payload = {
+      suite: "protected",
+      skipped: true,
+      reason: skipReason,
+      checkedAt: new Date().toISOString(),
+      endpoints: PROTECTED_SMOKE_ENDPOINTS.map((endpoint) => endpoint.name),
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return payload;
+  }
+
+  const { appConfigResult, runtimeConfig, apiBaseUrl } = await loadRuntimeConfigImpl();
+  return runSmokeSuiteImpl({
     suiteName: "protected",
     checks: createProtectedSmokeChecks({ apiBaseUrl, appConfigResult }),
     runtimeConfig,
     appConfigResult,
     apiBaseUrl,
   });
+}
+
+export async function main() {
+  return runProtectedSmokeSuite();
 }
 
 if (scriptEntryMatches(import.meta.url, process.argv[1])) {

--- a/test/unit/smoke-checks.test.ts
+++ b/test/unit/smoke-checks.test.ts
@@ -1,11 +1,18 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import {
   buildRequestHeaders,
   parseRuntimeConfig,
   resolveApiBaseUrl,
 } from '../../scripts/run-smoke-checks.mjs';
-import { createProtectedSmokeChecks, getProtectedAuthHeaders } from '../../scripts/run-protected-smoke-checks.mjs';
+import {
+  createProtectedSmokeChecks,
+  getProtectedAuthHeaders,
+  getProtectedSmokeSkipReason,
+  isProtectedSmokeEnabled,
+  PROTECTED_SMOKE_ENDPOINTS,
+  runProtectedSmokeSuite,
+} from '../../scripts/run-protected-smoke-checks.mjs';
 
 describe('run-smoke-checks helpers', () => {
   it('parses runtime app config from the bootstrap script', () => {
@@ -86,5 +93,35 @@ describe('run-smoke-checks helpers', () => {
     ]);
 
     delete process.env.SMOKE_AUTH_BEARER_TOKEN;
+  });
+
+  it('reports whether protected smoke is enabled from the token env', () => {
+    expect(isProtectedSmokeEnabled({ SMOKE_AUTH_BEARER_TOKEN: 'token-123' })).toBe(true);
+    expect(isProtectedSmokeEnabled({ SMOKE_AUTH_BEARER_TOKEN: '' })).toBe(false);
+  });
+
+  it('describes why protected smoke is skipped when the token is missing', () => {
+    expect(getProtectedSmokeSkipReason({ SMOKE_AUTH_BEARER_TOKEN: '' })).toBe('SMOKE_AUTH_BEARER_TOKEN is not configured');
+    expect(getProtectedSmokeSkipReason({ SMOKE_AUTH_BEARER_TOKEN: 'token-123' })).toBeNull();
+  });
+
+  it('skips protected smoke without trying to load runtime config when the token is missing', async () => {
+    const loadRuntimeConfigImpl = vi.fn();
+    const runSmokeSuiteImpl = vi.fn();
+
+    const result = await runProtectedSmokeSuite({
+      env: { SMOKE_AUTH_BEARER_TOKEN: '' },
+      loadRuntimeConfigImpl,
+      runSmokeSuiteImpl,
+    });
+
+    expect(result).toMatchObject({
+      suite: 'protected',
+      skipped: true,
+      reason: 'SMOKE_AUTH_BEARER_TOKEN is not configured',
+      endpoints: PROTECTED_SMOKE_ENDPOINTS.map((endpoint) => endpoint.name),
+    });
+    expect(loadRuntimeConfigImpl).not.toHaveBeenCalled();
+    expect(runSmokeSuiteImpl).not.toHaveBeenCalled();
   });
 });

--- a/test/unit/smoke-checks.test.ts
+++ b/test/unit/smoke-checks.test.ts
@@ -5,7 +5,7 @@ import {
   parseRuntimeConfig,
   resolveApiBaseUrl,
 } from '../../scripts/run-smoke-checks.mjs';
-import { getProtectedAuthHeaders } from '../../scripts/run-protected-smoke-checks.mjs';
+import { createProtectedSmokeChecks, getProtectedAuthHeaders } from '../../scripts/run-protected-smoke-checks.mjs';
 
 describe('run-smoke-checks helpers', () => {
   it('parses runtime app config from the bootstrap script', () => {
@@ -66,6 +66,24 @@ describe('run-smoke-checks helpers', () => {
     expect(getProtectedAuthHeaders()).toEqual({
       Authorization: 'Bearer token-123',
     });
+
+    delete process.env.SMOKE_AUTH_BEARER_TOKEN;
+  });
+
+  it('throws when the protected smoke token is missing', () => {
+    delete process.env.SMOKE_AUTH_BEARER_TOKEN;
+
+    expect(() => getProtectedAuthHeaders()).toThrow('SMOKE_AUTH_BEARER_TOKEN is required for protected smoke checks');
+  });
+
+  it('defines the protected smoke endpoint contract', () => {
+    process.env.SMOKE_AUTH_BEARER_TOKEN = 'token-123';
+
+    expect(createProtectedSmokeChecks({ apiBaseUrl: 'https://api.example.com' }).map((check) => check.name)).toEqual([
+      'api-auth-me-authenticated',
+      'api-my-summary-authenticated',
+      'api-my-notifications-authenticated',
+    ]);
 
     delete process.env.SMOKE_AUTH_BEARER_TOKEN;
   });


### PR DESCRIPTION
## Summary
- codify protected smoke skip behavior inside the script instead of relying on workflow-only guards
- define the protected smoke endpoint contract in code and tests
- refresh the operations roadmap with the current smoke contract and remaining follow-up items

## Validation
- npm run typecheck
- npm run build
- npm run test:unit -- smoke-checks
- npm run test:all