### PR TITLE
Refactor NaverMap viewport and status boundaries

### DIFF
--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,8 +1,11 @@
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import { getClientConfig } from '../config';
 import type { ApiStatus, FestivalItem, Place } from '../types';
+import { NaverMapStatus } from './naver-map/NaverMapStatus';
 import { useNaverMapInstance } from './naver-map/useNaverMapInstance';
 import { useNaverMapInteractions } from './naver-map/useNaverMapInteractions';
+import { useNaverViewportChangeRef } from './naver-map/useNaverViewportChangeRef';
+import { useNaverViewportSync } from './naver-map/useNaverViewportSync';
 
 interface NaverMapProps {
   places: Place[];
@@ -42,18 +45,20 @@ export function NaverMap({
   height = '100%',
 }: NaverMapProps) {
   const mapElementRef = useRef<HTMLDivElement | null>(null);
-  const onViewportChangeRef = useRef(onViewportChange);
+  const onViewportChangeRef = useNaverViewportChangeRef(onViewportChange);
   const clientId = getClientConfig().naverMapClientId;
-
-  useEffect(() => {
-    onViewportChangeRef.current = onViewportChange;
-  }, [onViewportChange]);
 
   const { mapRef, status, errorMessage } = useNaverMapInstance({
     clientId,
     mapElementRef,
     initialCenter,
     initialZoom,
+  });
+
+  useNaverViewportSync({
+    status,
+    mapsApi: window.naver?.maps,
+    mapRef,
     onViewportChangeRef,
   });
 
@@ -73,30 +78,18 @@ export function NaverMap({
     routePreviewPlaces,
   });
 
-  if (!clientId || status === 'error') {
-    return (
-      <div className="map-status-card">
-        <strong>네이버 지도 연결 대기</strong>
-        <p>{errorMessage || '네이버 지도 SDK를 불러오지 못했어요.'}</p>
-      </div>
-    );
-  }
-
   return (
     <div className="map-surface-frame">
-      {status === 'loading' && (
-        <div className="map-status-card map-status-card--overlay">
-          <strong>대전 지도를 준비하고 있어요</strong>
-          <p>잠시만 기다리면 지도와 마커를 바로 보여드릴게요.</p>
-        </div>
-      )}
-      <div className="map-floating-controls">
-        <button type="button" className="map-locate-button" onClick={onLocateCurrentPosition} disabled={currentLocationStatus === 'loading'}>
-          {currentLocationStatus === 'loading' ? '확인 중' : currentPosition ? '내 위치 보기' : '내 위치 켜기'}
-        </button>
-      </div>
+      <NaverMapStatus
+        clientId={clientId}
+        status={status}
+        errorMessage={errorMessage}
+        currentLocationStatus={currentLocationStatus}
+        currentLocationMessage={currentLocationMessage}
+        currentPosition={currentPosition}
+        onLocateCurrentPosition={onLocateCurrentPosition}
+      />
       <div ref={mapElementRef} style={{ width: '100%', height }} />
-      {currentLocationMessage && <div className="map-location-pill">{currentLocationMessage}</div>}
     </div>
   );
 }

--- a/src/components/naver-map/NaverMapStatus.tsx
+++ b/src/components/naver-map/NaverMapStatus.tsx
@@ -1,0 +1,47 @@
+import type { ApiStatus } from '../../types';
+
+type NaverMapStatusProps = {
+  clientId: string;
+  status: 'loading' | 'ready' | 'error';
+  errorMessage: string | null;
+  currentLocationStatus: ApiStatus;
+  currentLocationMessage: string | null;
+  currentPosition: { latitude: number; longitude: number } | null;
+  onLocateCurrentPosition: () => void;
+};
+
+export function NaverMapStatus({
+  clientId,
+  status,
+  errorMessage,
+  currentLocationStatus,
+  currentLocationMessage,
+  currentPosition,
+  onLocateCurrentPosition,
+}: NaverMapStatusProps) {
+  if (!clientId || status === 'error') {
+    return (
+      <div className="map-status-card">
+        <strong>네이버 지도 연결 대기</strong>
+        <p>{errorMessage || '네이버 지도 SDK를 불러오지 못했어요.'}</p>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {status === 'loading' && (
+        <div className="map-status-card map-status-card--overlay">
+          <strong>대전 지도를 준비하고 있어요</strong>
+          <p>잠시만 기다리면 지도와 마커를 바로 보여드릴게요.</p>
+        </div>
+      )}
+      <div className="map-floating-controls">
+        <button type="button" className="map-locate-button" onClick={onLocateCurrentPosition} disabled={currentLocationStatus === 'loading'}>
+          {currentLocationStatus === 'loading' ? '확인 중' : currentPosition ? '내 위치 보기' : '내 위치 찾기'}
+        </button>
+      </div>
+      {currentLocationMessage && <div className="map-location-pill">{currentLocationMessage}</div>}
+    </>
+  );
+}

--- a/src/components/naver-map/useNaverMapInstance.ts
+++ b/src/components/naver-map/useNaverMapInstance.ts
@@ -1,14 +1,11 @@
 import { useEffect, useRef, useState } from 'react';
-import { loadNaverMaps } from './naverMapHelpers';
-
-type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
+import { DAEJEON_CENTER, loadNaverMaps } from './naverMapHelpers';
 
 type MapInstanceArgs = {
   clientId: string;
   mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
   initialCenter?: { lat: number; lng: number };
   initialZoom?: number;
-  onViewportChangeRef: React.MutableRefObject<ViewportChangeHandler>;
 };
 
 export function useNaverMapInstance({
@@ -16,11 +13,8 @@ export function useNaverMapInstance({
   mapElementRef,
   initialCenter,
   initialZoom,
-  onViewportChangeRef,
 }: MapInstanceArgs) {
   const mapRef = useRef<any>(null);
-  const idleListenerRef = useRef<any>(null);
-  const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
@@ -44,7 +38,7 @@ export function useNaverMapInstance({
         }
 
         mapRef.current = new maps.Map(mapElementRef.current, {
-          center: new maps.LatLng(initialCenter?.lat ?? 36.3504, initialCenter?.lng ?? 127.3845),
+          center: new maps.LatLng(initialCenter?.lat ?? DAEJEON_CENTER.latitude, initialCenter?.lng ?? DAEJEON_CENTER.longitude),
           zoom: initialZoom ?? 13,
           minZoom: 11,
           scaleControl: false,
@@ -53,22 +47,6 @@ export function useNaverMapInstance({
           zoomControl: true,
         });
 
-        const idleListener = maps.Event.addListener(mapRef.current, 'idle', () => {
-          if (!mapRef.current) {
-            return;
-          }
-          const center = mapRef.current.getCenter();
-          const zoom = mapRef.current.getZoom();
-          if (viewportDebounceTimerRef.current !== null) {
-            clearTimeout(viewportDebounceTimerRef.current);
-          }
-          viewportDebounceTimerRef.current = setTimeout(() => {
-            onViewportChangeRef.current?.(center.lat(), center.lng(), zoom);
-            viewportDebounceTimerRef.current = null;
-          }, 300);
-        });
-
-        idleListenerRef.current = idleListener;
         setStatus('ready');
       })
       .catch((error: Error) => {
@@ -81,16 +59,8 @@ export function useNaverMapInstance({
 
     return () => {
       isMounted = false;
-      if (viewportDebounceTimerRef.current !== null) {
-        clearTimeout(viewportDebounceTimerRef.current);
-        viewportDebounceTimerRef.current = null;
-      }
-      if (idleListenerRef.current && window.naver?.maps) {
-        window.naver.maps.Event.removeListener(idleListenerRef.current);
-        idleListenerRef.current = null;
-      }
     };
-  }, [clientId, initialCenter?.lat, initialCenter?.lng, initialZoom, mapElementRef, onViewportChangeRef]);
+  }, [clientId, initialCenter?.lat, initialCenter?.lng, initialZoom, mapElementRef]);
 
   return { mapRef, status, errorMessage };
 }

--- a/src/components/naver-map/useNaverViewportChangeRef.ts
+++ b/src/components/naver-map/useNaverViewportChangeRef.ts
@@ -1,0 +1,13 @@
+import { useEffect, useRef } from 'react';
+
+type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
+
+export function useNaverViewportChangeRef(onViewportChange: ViewportChangeHandler) {
+  const onViewportChangeRef = useRef(onViewportChange);
+
+  useEffect(() => {
+    onViewportChangeRef.current = onViewportChange;
+  }, [onViewportChange]);
+
+  return onViewportChangeRef;
+}

--- a/src/components/naver-map/useNaverViewportSync.ts
+++ b/src/components/naver-map/useNaverViewportSync.ts
@@ -1,0 +1,54 @@
+import { useEffect, useRef } from 'react';
+
+type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
+
+type NaverViewportSyncArgs = {
+  status: 'loading' | 'ready' | 'error';
+  mapsApi: typeof window.naver.maps | undefined;
+  mapRef: React.MutableRefObject<any>;
+  onViewportChangeRef: React.MutableRefObject<ViewportChangeHandler>;
+};
+
+export function useNaverViewportSync({
+  status,
+  mapsApi,
+  mapRef,
+  onViewportChangeRef,
+}: NaverViewportSyncArgs) {
+  const idleListenerRef = useRef<any>(null);
+  const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (status !== 'ready' || !mapsApi || !mapRef.current) {
+      return;
+    }
+
+    const idleListener = mapsApi.Event.addListener(mapRef.current, 'idle', () => {
+      if (!mapRef.current) {
+        return;
+      }
+      const center = mapRef.current.getCenter();
+      const zoom = mapRef.current.getZoom();
+      if (viewportDebounceTimerRef.current !== null) {
+        clearTimeout(viewportDebounceTimerRef.current);
+      }
+      viewportDebounceTimerRef.current = setTimeout(() => {
+        onViewportChangeRef.current?.(center.lat(), center.lng(), zoom);
+        viewportDebounceTimerRef.current = null;
+      }, 300);
+    });
+
+    idleListenerRef.current = idleListener;
+
+    return () => {
+      if (viewportDebounceTimerRef.current !== null) {
+        clearTimeout(viewportDebounceTimerRef.current);
+        viewportDebounceTimerRef.current = null;
+      }
+      if (idleListenerRef.current) {
+        mapsApi.Event.removeListener(idleListenerRef.current);
+        idleListenerRef.current = null;
+      }
+    };
+  }, [mapRef, mapsApi, onViewportChangeRef, status]);
+}


### PR DESCRIPTION
## Summary
- split NaverMap viewport synchronization and status UI into dedicated modules
- keep the map interaction flow intact while reducing the component surface area
- fix map status copy that was corrupted by encoding issues

## Validation
- npm run typecheck
- npm run build
- npm run test:all