### PR TITLE
Harden protected smoke contracts and docs (redo)

### DIFF
--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -60,6 +60,7 @@
   - `/api/my/summary`
   - `/api/my/notifications`
 - public smoke와 protected smoke는 서로 독립적으로 결과를 남긴다.
+- protected smoke 엔드포인트 목록과 skip 규칙은 `scripts/smoke/protected.mjs`를 단일 계약 원본으로 사용한다.
 
 ### 완료 조건
 - 배포 후 최소 1개의 자동 스모크가 실행된다.

--- a/scripts/run-protected-smoke-checks.mjs
+++ b/scripts/run-protected-smoke-checks.mjs
@@ -6,58 +6,11 @@ import {
   runSmokeSuite,
   scriptEntryMatches,
 } from "./smoke/shared.mjs";
-
-export const PROTECTED_SMOKE_ENDPOINTS = [
-  {
-    name: "api-auth-me-authenticated",
-    path: "/api/auth/me",
-    assertJson(response, json) {
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(json?.isAuthenticated === true, "session should be authenticated");
-      assert(Boolean(json?.user?.id), "authenticated user id is missing");
-    },
-  },
-  {
-    name: "api-my-summary-authenticated",
-    path: "/api/my/summary",
-    assertJson(response, json) {
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(Array.isArray(json?.stamps), "my summary stamps array is missing");
-      assert(Array.isArray(json?.reviews), "my summary reviews array is missing");
-      assert(Array.isArray(json?.notifications), "my summary notifications array is missing");
-    },
-  },
-  {
-    name: "api-my-notifications-authenticated",
-    path: "/api/my/notifications",
-    assertJson(response, json) {
-      assert(response.status === 200, `expected 200, received ${response.status}`);
-      assert(Array.isArray(json), "notifications response is not an array");
-    },
-  },
-];
-
-export function isProtectedSmokeEnabled(env = process.env) {
-  return Boolean((env.SMOKE_AUTH_BEARER_TOKEN || "").trim());
-}
-
-export function getProtectedSmokeSkipReason(env = process.env) {
-  if (isProtectedSmokeEnabled(env)) {
-    return null;
-  }
-  return "SMOKE_AUTH_BEARER_TOKEN is not configured";
-}
-
-export function getProtectedAuthHeaders(env = process.env) {
-  const token = env.SMOKE_AUTH_BEARER_TOKEN || "";
-  if (!token) {
-    throw new Error("SMOKE_AUTH_BEARER_TOKEN is required for protected smoke checks");
-  }
-
-  return {
-    Authorization: `Bearer ${token}`,
-  };
-}
+import {
+  getProtectedAuthHeaders,
+  getProtectedSmokeSkipReason,
+  PROTECTED_SMOKE_ENDPOINTS,
+} from "./smoke/protected.mjs";
 
 export function createProtectedSmokeChecks({ apiBaseUrl }) {
   const authHeaders = getProtectedAuthHeaders();
@@ -68,7 +21,7 @@ export function createProtectedSmokeChecks({ apiBaseUrl }) {
       const { response, json } = await fetchJson(`${apiBaseUrl}${endpoint.path}`, {
         headers: authHeaders,
       });
-      endpoint.assertJson(response, json);
+      endpoint.assertJson(response, json, assert);
     }),
   }));
 }

--- a/scripts/smoke/protected.mjs
+++ b/scripts/smoke/protected.mjs
@@ -1,0 +1,51 @@
+export const PROTECTED_SMOKE_ENDPOINTS = [
+  {
+    name: "api-auth-me-authenticated",
+    path: "/api/auth/me",
+    assertJson(response, json, assert) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(json?.isAuthenticated === true, "session should be authenticated");
+      assert(Boolean(json?.user?.id), "authenticated user id is missing");
+    },
+  },
+  {
+    name: "api-my-summary-authenticated",
+    path: "/api/my/summary",
+    assertJson(response, json, assert) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(Array.isArray(json?.stamps), "my summary stamps array is missing");
+      assert(Array.isArray(json?.reviews), "my summary reviews array is missing");
+      assert(Array.isArray(json?.notifications), "my summary notifications array is missing");
+    },
+  },
+  {
+    name: "api-my-notifications-authenticated",
+    path: "/api/my/notifications",
+    assertJson(response, json, assert) {
+      assert(response.status === 200, `expected 200, received ${response.status}`);
+      assert(Array.isArray(json), "notifications response is not an array");
+    },
+  },
+];
+
+export function isProtectedSmokeEnabled(env = process.env) {
+  return Boolean((env.SMOKE_AUTH_BEARER_TOKEN || "").trim());
+}
+
+export function getProtectedSmokeSkipReason(env = process.env) {
+  if (isProtectedSmokeEnabled(env)) {
+    return null;
+  }
+  return "SMOKE_AUTH_BEARER_TOKEN is not configured";
+}
+
+export function getProtectedAuthHeaders(env = process.env) {
+  const token = env.SMOKE_AUTH_BEARER_TOKEN || "";
+  if (!token) {
+    throw new Error("SMOKE_AUTH_BEARER_TOKEN is required for protected smoke checks");
+  }
+
+  return {
+    Authorization: `Bearer ${token}`,
+  };
+}

--- a/test/unit/smoke-checks.test.ts
+++ b/test/unit/smoke-checks.test.ts
@@ -6,11 +6,13 @@ import {
   resolveApiBaseUrl,
 } from '../../scripts/run-smoke-checks.mjs';
 import {
-  createProtectedSmokeChecks,
   getProtectedAuthHeaders,
   getProtectedSmokeSkipReason,
   isProtectedSmokeEnabled,
   PROTECTED_SMOKE_ENDPOINTS,
+} from '../../scripts/smoke/protected.mjs';
+import {
+  createProtectedSmokeChecks,
   runProtectedSmokeSuite,
 } from '../../scripts/run-protected-smoke-checks.mjs';
 
@@ -93,6 +95,14 @@ describe('run-smoke-checks helpers', () => {
     ]);
 
     delete process.env.SMOKE_AUTH_BEARER_TOKEN;
+  });
+
+  it('keeps protected endpoint definitions in the shared contract module', () => {
+    expect(PROTECTED_SMOKE_ENDPOINTS.map((endpoint) => endpoint.path)).toEqual([
+      '/api/auth/me',
+      '/api/my/summary',
+      '/api/my/notifications',
+    ]);
   });
 
   it('reports whether protected smoke is enabled from the token env', () => {


### PR DESCRIPTION
## Summary`n- move protected smoke endpoint planning into a shared contract module`n- make token-based skip behavior explicit in the protected smoke script`n- extend smoke contract tests and refresh the roadmap docs to match the current workflow`n`n## Validation`n- npm run typecheck`n- npm run build`n- npm run test:unit -- smoke-checks`n- npm run test:all