### PR TITLE
Bump PyJWT for security fix

### DIFF
--- a/backend/requirements.local.txt
+++ b/backend/requirements.local.txt
@@ -7,6 +7,6 @@ PyMySQL==1.1.1
 psycopg[binary]==3.2.9
 itsdangerous==2.2.0
 cryptography==45.0.7
-PyJWT==2.10.1
+PyJWT==2.12.0
 python-multipart==0.0.20
 pytest==8.3.4

--- a/backend/tests/test_jwt_auth.py
+++ b/backend/tests/test_jwt_auth.py
@@ -53,3 +53,17 @@ def test_auth_cookie_settings_disable_secure_in_local_env():
     cookie_settings = auth_cookie_settings(settings)
 
     assert cookie_settings['secure'] is False
+
+
+def test_access_token_with_unknown_crit_header_is_rejected():
+    import jwt
+
+    settings = Settings(jwt_secret='unit-test-secret', jwt_access_token_minutes=10)
+    token = jwt.encode(
+        {"sub": "user-crit", "nickname": "tester", "provider": "naver"},
+        settings.jwt_secret,
+        algorithm=settings.jwt_algorithm,
+        headers={"crit": ["unknown-extension"], "unknown-extension": "enabled"},
+    )
+
+    assert read_access_token(settings, token) is None


### PR DESCRIPTION
## Summary`n- bump PyJWT from 2.10.1 to 2.12.0 to address the crit header advisory`n- add a JWT regression test that rejects tokens with unknown crit header extensions`n`n## Validation`n- py -3.14 -m pytest tests/test_jwt_auth.py`n- py -3.14 -m pytest tests/test_auth_service.py