### PR TITLE
Upgrade GitHub Actions Node runtime to 22

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
       - run: npm ci
       - run: npm run typecheck

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -28,7 +28,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
       - run: npm install -g wrangler@4.74.0
       - run: npm ci

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - run: npm install -g wrangler@4.74.0
       - name: Validate worker bundle
         run: wrangler deploy --dry-run
@@ -39,7 +39,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - run: npm install -g wrangler@4.74.0
       - name: Deploy production worker
         env:

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
           cache: npm
       - run: npm install -g wrangler@4.74.0
       - run: npm ci
@@ -76,7 +76,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - run: npm install -g wrangler@4.74.0
       - name: Deploy production worker
         env:
@@ -100,7 +100,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Run public production smoke checks
         run: node scripts/run-public-smoke-checks.mjs
 
@@ -121,6 +121,6 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Run protected production smoke checks
         run: node scripts/run-protected-smoke-checks.mjs

--- a/.github/workflows/public-event-sync.yml
+++ b/.github/workflows/public-event-sync.yml
@@ -19,7 +19,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
       - name: Import Daejeon public events
         env:
           PUBLIC_EVENT_IMPORT_URL: https://daejeon-jamissue-api.yhh4433.workers.dev/api/internal/public-events/import


### PR DESCRIPTION
## Summary`n- upgrade workflow jobs from Node 20 to Node 22 across CI, deploy, smoke, and event sync workflows`n- remove the GitHub Actions Node 20 deprecation warning without changing application code`n`n## Validation`n- workflow-only change; validate through PR and main GitHub Actions runs