### PR TITLE
Bump cryptography for security fixes

### DIFF
--- a/backend/requirements.local.txt
+++ b/backend/requirements.local.txt
@@ -6,7 +6,7 @@ SQLAlchemy==2.0.36
 PyMySQL==1.1.1
 psycopg[binary]==3.2.9
 itsdangerous==2.2.0
-cryptography==45.0.7
+cryptography==46.0.7
 PyJWT==2.12.0
 python-multipart==0.0.20
 pytest==8.3.4


### PR DESCRIPTION
## Summary`n- bump cryptography from 45.0.7 to 46.0.7 to pick up the current security fixes`n- keep the change scoped to the backend dependency pin only`n`n## Validation`n- py -3.14 -m pytest tests/test_jwt_auth.py`n- py -3.14 -m pytest tests/test_auth_service.py