### PR TITLE
Build python-multipart for security fix

### DIFF
--- a/backend/requirements.local.txt
+++ b/backend/requirements.local.txt
@@ -8,5 +8,5 @@ psycopg[binary]==3.2.9
 itsdangerous==2.2.0
 cryptography==46.0.7
 PyJWT==2.12.0
-python-multipart==0.0.20
+python-multipart==0.0.26
 pytest==8.3.4


### PR DESCRIPTION
## Summary
- bump python-multipart from 0.0.20 to 0.0.26 to address the open security advisory
- keep the change scoped to the backend dependency manifest

## Validation
- npm run typecheck
- npm run build
- C:\Users\PC\AppData\Local\Programs\Python\Python314\python.exe -m pytest tests/test_storage.py