### PR TITLE
Clean up code quality warnings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-from pathlib import Path
 from uuid import uuid4
 
 from fastapi import Depends, FastAPI, File, HTTPException, Query, Request, Response, UploadFile, status

--- a/backend/app/repository.py
+++ b/backend/app/repository.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
 from datetime import UTC, date, datetime
 from math import asin, cos, radians, sin, sqrt
 from uuid import uuid4

--- a/backend/app/repository_normalized.py
+++ b/backend/app/repository_normalized.py
@@ -44,7 +44,6 @@ from .models import (
     ReviewCreate,
     ReviewLikeResponse,
     ReviewOut,
-    SessionUser,
     StampLogOut,
     StampState,
     TravelSessionOut,

--- a/backend/tests/test_repository.py
+++ b/backend/tests/test_repository.py
@@ -1,6 +1,7 @@
 ﻿from datetime import timedelta
 from pathlib import Path
 
+import pytest
 from sqlalchemy import create_engine, event, func, select
 from sqlalchemy.orm import sessionmaker
 
@@ -183,7 +184,6 @@ def test_review_allows_different_places_on_same_day(tmp_path: Path):
     second_stamp_state = claim_stamp_for(session, 'user-1', 'expo-bridge')
 
     # 같은 날이더라도 다른 장소라면 피드 작성이 허용되어야 함
-    blocked = False
     try:
         create_review(
             session,
@@ -191,10 +191,8 @@ def test_review_allows_different_places_on_same_day(tmp_path: Path):
             'user-1',
             '민서',
         )
-    except ValueError:
-        blocked = True
-
-    assert blocked is False
+    except ValueError as exc:  # pragma: no cover - defensive branch for regression readability
+        pytest.fail(f'리뷰 작성이 차단되면 안 됩니다: {exc}')
 
 
 def test_review_is_limited_to_one_per_place_per_day(tmp_path: Path):
@@ -212,34 +210,25 @@ def test_review_is_limited_to_one_per_place_per_day(tmp_path: Path):
     second_stamp_state = claim_stamp_for(session, 'user-1', 'hanbat-forest')
 
     # 같은 날, 같은 장소에서 다시 피드를 작성하면 차단되어야 함
-    blocked = False
-    try:
+    with pytest.raises(ValueError):
         create_review(
             session,
             ReviewCreate(placeId='hanbat-forest', stampId=stamp_id_for_place(second_stamp_state, 'hanbat-forest'), body='한밭 숲 중복 피드.', mood='설렘', imageUrl=None),
             'user-1',
             '민서',
         )
-    except ValueError:
-        blocked = True
-
-    assert blocked is True
 
 
 def test_stamp_requires_real_distance_and_same_day_dedup(tmp_path: Path):
     session = build_session(tmp_path)
     load_seed_data(session)
 
-    blocked = False
-    try:
+    with pytest.raises(PermissionError):
         toggle_stamp(session, 'user-1', 'hanbat-forest', 37.0, 127.0, 120)
-    except PermissionError:
-        blocked = True
 
     first_state = toggle_stamp(session, 'user-1', 'hanbat-forest', 36.3671, 127.3886, 120)
     second_state = toggle_stamp(session, 'user-1', 'hanbat-forest', 36.3671, 127.3886, 120)
 
-    assert blocked is True
     assert 'hanbat-forest' in first_state.collected_place_ids
     assert len(first_state.logs) == 1
     assert len(second_state.logs) == 1
@@ -551,13 +540,8 @@ def test_profile_update_rejects_duplicate_nickname(tmp_path: Path):
     first = upsert_social_user(session, provider='naver', provider_user_id='naver-111', nickname='민서', email='a@example.com')
     second = upsert_social_user(session, provider='kakao', provider_user_id='kakao-222', nickname='가은', email='b@example.com')
 
-    error = None
-    try:
+    with pytest.raises(ValueError, match='이미 사용 중인 닉네임이에요.'):
         update_user_profile(session, second.user_id, ProfileUpdateRequest(nickname=first.nickname))
-    except ValueError as exc:
-        error = str(exc)
-
-    assert error == '이미 사용 중인 닉네임이에요.'
 
 
 def test_social_signup_generates_distinct_duplicate_nickname(tmp_path: Path):
@@ -596,11 +580,8 @@ def test_legacy_stamp_blocks_same_day_duplicate(tmp_path: Path):
 
     legacy_toggle_stamp(session, 'user-1', 'hanbat-forest', 36.3671, 127.3886, 120)
 
-    blocked = False
-    try:
+    with pytest.raises(ValueError, match='이미 오늘 스탬프를 획득했습니다.'):
         legacy_toggle_stamp(session, 'user-1', 'hanbat-forest', 36.3671, 127.3886, 120)
-    except ValueError as exc:
-        blocked = '이미 오늘 스탬프를 획득했습니다.' in str(exc)
 
     today = to_seoul_date()
     today_stamp_count = session.scalar(
@@ -609,5 +590,4 @@ def test_legacy_stamp_blocks_same_day_duplicate(tmp_path: Path):
             UserStamp.stamp_date == today,
         )
     )
-    assert blocked is True
     assert today_stamp_count == 1

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,6 +1,6 @@
 ﻿from pathlib import Path
 
-import app.storage as storage_module
+from app import storage as storage_module
 from app.config import Settings
 from app.storage import (
     FileTooLargeError,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,6 @@ import { GlobalStatusBanner } from './components/GlobalStatusBanner';
 import {
   useAppRouteState,
   getInitialMapViewport,
-  updateMapViewportInUrl,
 } from './hooks/useAppRouteState';
 import { useAppDataState } from './hooks/useAppDataState';
 import { useAppPageRuntimeState } from './hooks/useAppPageRuntimeState';
@@ -21,7 +20,6 @@ import { useMapDomainState } from './hooks/useMapDomainState';
 import { useMyPageDomainState } from './hooks/useMyPageDomainState';
 import { useReturnViewDomainState } from './hooks/useReturnViewDomainState';
 import { useReviewDomainState } from './hooks/useReviewDomainState';
-import type { Tab } from './types';
 
 export default function App() {
   const routeState = useAppRouteState();

--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -216,11 +216,6 @@ export const AppPageStage = memo(function AppPageStage({
             onSaveNickname: myPageActions.onSaveNickname,
             onPublishRoute: myPageActions.onPublishRoute,
           }}
-          notificationActions={{
-            onMarkNotificationRead: myPageActions.onMarkNotificationRead,
-            onMarkAllNotificationsRead: myPageActions.onMarkAllNotificationsRead,
-            onDeleteNotification: myPageActions.onDeleteNotification,
-          }}
           adminData={{
             adminSummary: myPageData.adminSummary,
             adminBusyPlaceId: myPageData.adminBusyPlaceId,

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -42,11 +42,6 @@ interface MyPagePanelProps {
     onSaveNickname: (nickname: string) => Promise<void>;
     onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
   };
-  notificationActions: {
-    onMarkNotificationRead: (notificationId: string) => Promise<void>;
-    onMarkAllNotificationsRead: () => Promise<void>;
-    onDeleteNotification: (notificationId: string) => Promise<void>;
-  };
   adminData: {
     adminSummary: AdminSummaryResponse | null;
     adminBusyPlaceId: string | null;
@@ -61,29 +56,11 @@ interface MyPagePanelProps {
 
 const AdminPanel = lazy(() => import('./AdminPanel').then((module) => ({ default: module.AdminPanel })));
 
-type NotificationItem = NonNullable<MyPageResponse>['notifications'][number];
-
-function getNotificationLabel(notification: NotificationItem) {
-  switch (notification.type) {
-    case 'review-created':
-      return '피드';
-    case 'route-published':
-      return '코스';
-    case 'review-comment':
-      return '댓글';
-    case 'comment-reply':
-      return '답글';
-    default:
-      return '알림';
-  }
-}
-
 export function MyPagePanel({
   sessionData,
   panelState,
   reviewActions,
   panelActions,
-  notificationActions,
   adminData,
   adminActions,
 }: MyPagePanelProps) {
@@ -115,20 +92,11 @@ export function MyPagePanel({
     onSaveNickname,
     onPublishRoute,
   } = panelActions;
-  const {
-    onMarkNotificationRead,
-    onMarkAllNotificationsRead,
-    onDeleteNotification,
-  } = notificationActions;
   const { adminSummary, adminBusyPlaceId, adminLoading } = adminData;
   const { onRefreshAdmin, onToggleAdminPlace, onToggleAdminManualOverride } = adminActions;
   const [nickname, setNickname] = useState(sessionUser?.nickname ?? '');
   const [showVisitedDetail, setShowVisitedDetail] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
-  const [showNotifications, setShowNotifications] = useState(false);
-  const [notificationBusyId, setNotificationBusyId] = useState<string | null>(null);
-  const [notificationsBusy, setNotificationsBusy] = useState(false);
-  const [notificationError, setNotificationError] = useState<string | null>(null);
   const scrollRef = useScrollRestoration<HTMLElement>('my');
   const commentsLoadMoreRef = useAutoLoadMore({
     enabled: activeTab === 'comments' && commentsHasMore,
@@ -144,78 +112,16 @@ export function MyPagePanel({
     }
   }, [sessionUser?.nickname, sessionUser?.profileCompletedAt]);
 
-  useEffect(() => {
-    if (!myPage) {
-      setShowNotifications(false);
-    }
-  }, [myPage]);
-
   const visitPct = useMemo(
     () => (myPage && myPage.stats.totalPlaceCount > 0
       ? Math.round((myPage.stats.uniquePlaceCount / myPage.stats.totalPlaceCount) * 100)
       : 0),
     [myPage],
   );
-  const unreadNotificationCount = myPage?.unreadNotificationCount ?? 0;
-
   async function handleNicknameSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     await onSaveNickname(nickname.trim());
     setShowSettings(false);
-  }
-
-  async function handleOpenNotification(notification: NotificationItem) {
-    try {
-      setNotificationBusyId(notification.id);
-      setNotificationError(null);
-      if (!notification.isRead) {
-        await onMarkNotificationRead(notification.id);
-      }
-
-      if (notification.reviewId && notification.commentId) {
-        onOpenComment(notification.reviewId, notification.commentId);
-        setShowNotifications(false);
-        return;
-      }
-      if (notification.reviewId) {
-        onOpenReview(notification.reviewId);
-        setShowNotifications(false);
-        return;
-      }
-      if (notification.routeId) {
-        onChangeTab('routes');
-        setShowNotifications(false);
-      }
-    } catch (error) {
-      setNotificationError(error instanceof Error ? error.message : '알림을 열지 못했어요.');
-    } finally {
-      setNotificationBusyId(null);
-    }
-  }
-
-  async function handleDeleteNotificationClick(event: React.MouseEvent<HTMLButtonElement>, notificationId: string) {
-    event.stopPropagation();
-    try {
-      setNotificationBusyId(notificationId);
-      setNotificationError(null);
-      await onDeleteNotification(notificationId);
-    } catch (error) {
-      setNotificationError(error instanceof Error ? error.message : '알림을 삭제하지 못했어요.');
-    } finally {
-      setNotificationBusyId(null);
-    }
-  }
-
-  async function handleMarkAllNotifications() {
-    try {
-      setNotificationsBusy(true);
-      setNotificationError(null);
-      await onMarkAllNotificationsRead();
-    } catch (error) {
-      setNotificationError(error instanceof Error ? error.message : '알림 상태를 바꾸지 못했어요.');
-    } finally {
-      setNotificationsBusy(false);
-    }
   }
 
   if (!sessionUser) {
@@ -422,14 +328,16 @@ export function MyPagePanel({
               />
             )}
             {activeTab === 'admin' && sessionUser.isAdmin && (
-              <AdminPanel
-                summary={adminSummary}
-                busyPlaceId={adminBusyPlaceId}
-                isImporting={adminLoading}
-                onRefreshImport={onRefreshAdmin}
-                onTogglePlace={onToggleAdminPlace}
-                onToggleManualOverride={onToggleAdminManualOverride}
-              />
+              <Suspense fallback={null}>
+                <AdminPanel
+                  summary={adminSummary}
+                  busyPlaceId={adminBusyPlaceId}
+                  isImporting={adminLoading}
+                  onRefreshImport={onRefreshAdmin}
+                  onTogglePlace={onToggleAdminPlace}
+                  onToggleManualOverride={onToggleAdminManualOverride}
+                />
+              </Suspense>
             )}
           </section>
         </>

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -38,7 +38,7 @@ export function ReviewList({
   onSubmitComment,
   onUpdateComment,
   onDeleteComment,
-  onDeleteReview,
+  onDeleteReview: _onDeleteReview,
   onRequestLogin,
   onOpenPlace,
   onOpenComments,

--- a/src/components/naver-map/naverMapHelpers.ts
+++ b/src/components/naver-map/naverMapHelpers.ts
@@ -59,7 +59,7 @@ export function placeMarkerContent(place: Place, isActive: boolean) {
   `;
 }
 
-export function festivalMarkerContent(festival: FestivalItem, isActive: boolean) {
+export function festivalMarkerContent(_festival: FestivalItem, isActive: boolean) {
   const ring = isActive ? '#ff4f93' : 'rgba(255, 79, 147, 0.22)';
   const scale = isActive ? 'scale(1.06)' : 'scale(1)';
   const label = '';

--- a/src/hooks/useAppAuthActions.ts
+++ b/src/hooks/useAppAuthActions.ts
@@ -4,16 +4,9 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useAuthStore } from '../store/auth-store';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type { MyPageResponse, SessionUser } from '../types';
+import type { MyPageResponse } from '../types';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
-
-interface ProviderOption {
-  key: 'naver' | 'kakao';
-  label: string;
-  isEnabled: boolean;
-  loginUrl: string | null;
-}
 
 interface UseAppAuthActionsParams {
   setMyPage: SetState<MyPageResponse | null>;

--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -38,7 +38,6 @@ interface UseAppBootstrapLifecycleParams {
   resetReviewCaches: () => void;
   refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
   ensureFeedReviews: (force?: boolean) => Promise<void>;
-  ensureCuratedCourses: (force?: boolean) => Promise<void>;
   fetchCommunityRoutes: (sort: 'popular' | 'latest', force?: boolean) => Promise<unknown>;
   refreshAdminSummary: (force?: boolean) => Promise<AdminSummaryResponse | null>;
   loadMoreMyComments: (initial?: boolean) => Promise<void>;
@@ -66,7 +65,6 @@ export function useAppBootstrapLifecycle({
   resetReviewCaches,
   refreshMyPageForUser,
   ensureFeedReviews,
-  ensureCuratedCourses,
   fetchCommunityRoutes,
   refreshAdminSummary,
   loadMoreMyComments,

--- a/src/hooks/useAppCoordinatorActions.ts
+++ b/src/hooks/useAppCoordinatorActions.ts
@@ -53,8 +53,6 @@ export function useAppCoordinatorActions({
   const { setNotice } = shellRuntimeState;
   const {
     communityRoutesCacheRef,
-    communityRouteSort,
-    adminSummary,
     patchCommunityRoutes,
     patchReviewCollections,
     placeReviewsCacheRef,

--- a/src/hooks/useAppCoordinatorEffects.ts
+++ b/src/hooks/useAppCoordinatorEffects.ts
@@ -53,7 +53,6 @@ export function useAppCoordinatorEffects({
   } = dataState;
   const {
     dataLoaders: {
-      ensureCuratedCourses,
       ensureFeedReviews,
       fetchCommunityRoutes,
       refreshAdminSummary,
@@ -101,7 +100,6 @@ export function useAppCoordinatorEffects({
     resetReviewCaches,
     refreshMyPageForUser,
     ensureFeedReviews,
-    ensureCuratedCourses,
     fetchCommunityRoutes,
     refreshAdminSummary,
     loadMoreMyComments,

--- a/src/hooks/useAppCoordinatorServices.ts
+++ b/src/hooks/useAppCoordinatorServices.ts
@@ -35,8 +35,6 @@ export function useAppCoordinatorServices({
     selectedFestivalId,
     commitRouteState,
     goToTab,
-    openPlace,
-    openFestival,
   } = routeState;
   const {
     auth: { sessionUser },
@@ -129,8 +127,6 @@ export function useAppCoordinatorServices({
     setNotice,
     goToTab,
     commitRouteState,
-    openPlace,
-    openFestival,
     upsertReviewCollections: dataState.upsertReviewCollections,
   });
 

--- a/src/hooks/useAppDerivedState.ts
+++ b/src/hooks/useAppDerivedState.ts
@@ -1,7 +1,7 @@
 ﻿import { useMemo } from 'react';
 import { calculateDistanceMeters, getLatestPlaceStamp, getTodayStampLog } from '../lib/visits';
 import { filterPlacesByCategory } from '../lib/filterPlaces';
-import type { Category, FestivalItem, MyPageResponse, Place, Review, SessionUser, StampState, UserRoute } from '../types';
+import type { Category, FestivalItem, Place, Review, SessionUser, StampState } from '../types';
 
 interface UseAppDerivedStateParams {
   places: Place[];

--- a/src/hooks/useAppMapActions.ts
+++ b/src/hooks/useAppMapActions.ts
@@ -3,7 +3,7 @@ import { claimStamp } from '../api/client';
 import { getCurrentDevicePosition } from '../lib/geolocation';
 import { formatDistanceMeters } from '../lib/visits';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type { ApiStatus, DrawerState, Place, SessionUser, StampState, Tab } from '../types';
+import type { DrawerState, Place, SessionUser, StampState, Tab } from '../types';
 import type { RouteStateCommitOptions } from './useAppRouteState';
 
 type HistoryMode = 'push' | 'replace';

--- a/src/hooks/useAppNavigationHelpers.ts
+++ b/src/hooks/useAppNavigationHelpers.ts
@@ -36,8 +36,6 @@ interface UseAppNavigationHelpersParams {
     historyMode?: 'push' | 'replace',
     options?: RouteStateCommitOptions,
   ) => void;
-  openPlace: (placeId: string) => void;
-  openFestival: (festivalId: string) => void;
   upsertReviewCollections: (review: Review) => void;
 }
 
@@ -75,8 +73,6 @@ export function useAppNavigationHelpers({
   setNotice,
   goToTab,
   commitRouteState,
-  openPlace,
-  openFestival,
   upsertReviewCollections,
 }: UseAppNavigationHelpersParams) {
   function snapshotReturnView(overrides: Partial<ReturnViewState> = {}) {


### PR DESCRIPTION
## Summary
- remove unused TypeScript symbols and dead notification-only handlers
- remove unused Python imports flagged by code quality checks
- simplify Python test patterns that trigger code quality warnings
- keep behavior unchanged while cleaning low-risk maintainability issues

## Validation
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npm run build`
- `npm run test:all`