### PR TITLE
Trim exact remaining quality findings

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -54,12 +54,8 @@ from .seed import seed_database
 from .storage import FileTooLargeError, InvalidFileTypeError, StorageConfigurationError, StorageUploadError
 from .services.admin_service import import_public_data_service, patch_admin_place_service, read_admin_summary_service
 from .services.auth_service import (
-    PROVIDER_LABELS,
-    SUPPORTED_PROVIDERS,
     build_auth_providers,
-    build_auth_response,
     complete_naver_login,
-    get_redirect_target,
     update_profile_session_payload,
 )
 from .services.my_page_service import read_my_page_service

--- a/backend/app/naver_oauth.py
+++ b/backend/app/naver_oauth.py
@@ -118,7 +118,7 @@ def _load_json(request: Request, default_detail: str) -> dict:
             payload = json.loads(error.read().decode("utf-8"))
             detail = payload.get("error_description") or payload.get("message") or detail
         except Exception:
-            detail = detail
+            pass
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=detail) from error
     except URLError as error:
         raise HTTPException(status_code=status.HTTP_502_BAD_GATEWAY, detail=default_detail) from error

--- a/deploy/api-worker-shell/index.js
+++ b/deploy/api-worker-shell/index.js
@@ -1,9 +1,7 @@
 import { formatDate, formatDateTime, toSeoulDateKey } from './lib/dates.js';
-import { applyCorsHeaders, handlePreflight, jsonResponse, redirectResponse } from './lib/http.js';
+import { applyCorsHeaders, handlePreflight, jsonResponse } from './lib/http.js';
 import {
-  buildAuthProviders,
   createAuthResponse,
-  getSigningSecret,
   handleAuthProviders,
   handleAuthSession,
   handleLogout,
@@ -12,7 +10,6 @@ import {
   handleUpdateProfile,
   naverConfigured,
   readSessionUser,
-  sha256Base64Url,
 } from './services/auth.js';
 import { handleBannerEvents, handleFestivalImport, handleFestivals } from './services/festivals.js';
 import {
@@ -46,15 +43,9 @@ import {
   buildInFilter,
   encodeFilterValue,
   getSupabaseKey,
-  parseListLimit,
   rememberPending,
   supabaseRequest,
 } from './lib/supabase.js';
-
-const PROVIDERS = [
-  { key: 'naver', label: '네이버' },
-  { key: 'kakao', label: '카카오' },
-];
 
 const BADGE_BY_MOOD = {
   '설렘': '첫 방문',
@@ -65,9 +56,7 @@ const BADGE_BY_MOOD = {
 };
 
 const STATIC_BASE_CACHE_TTL_MS = 5 * 60 * 1000;
-const FESTIVALS_CACHE_TTL_MS = 10 * 60 * 1000;
 let staticBaseCache = { expiresAt: 0, value: null, pending: null };
-let festivalsCache = { expiresAt: 0, syncAt: 0, value: null, pending: null };
 
 function formatVisitLabel(visitNumber) {
   const safeVisitNumber = Number.isFinite(Number(visitNumber)) && Number(visitNumber) > 0 ? Number(visitNumber) : 1;

--- a/scripts/run-public-smoke-checks.mjs
+++ b/scripts/run-public-smoke-checks.mjs
@@ -1,7 +1,6 @@
 import {
   assert,
   baseUrl,
-  buildRequestHeaders,
   fetchJson,
   fetchText,
   loadRuntimeConfig,

--- a/scripts/smoke/shared.mjs
+++ b/scripts/smoke/shared.mjs
@@ -162,7 +162,6 @@ export async function runChecksWithRetries(checks) {
     }
 
     if (attempt === retryAttempts) {
-      pendingChecks = failedChecks;
       break;
     }
 


### PR DESCRIPTION
## Summary
- remove exact unused imports and constants called out by GitHub quality findings
- fix the redundant self-assignment in naver_oauth
- remove the useless retry assignment in smoke shared helpers

## Verification
- npm run build
- npm run test:all
- npx tsc --noEmit --noUnusedLocals --noUnusedParameters
- backend auth/storage pytest