### PR TITLE
Refactor notification and admin repository data access

### DIFF
--- a/backend/app/repositories/account_data_repository.py
+++ b/backend/app/repositories/account_data_repository.py
@@ -1,0 +1,12 @@
+from sqlalchemy.orm import Session
+
+from ..db_models import User
+
+
+def delete_account(db: Session, user_id: str) -> None:
+    user = db.get(User, user_id)
+    if not user:
+        raise ValueError("?ъ슜???뺣낫瑜?李얠? 紐삵뻽?댁슂.")
+    db.delete(user)
+    db.commit()
+

--- a/backend/app/repositories/account_repository.py
+++ b/backend/app/repositories/account_repository.py
@@ -1,6 +1,6 @@
 from sqlalchemy.orm import Session
 
-from ..repository_normalized import delete_account
+from .account_data_repository import delete_account
 
 
 def delete_account_entry(db: Session, user_id: str) -> None:

--- a/backend/app/repositories/admin_data_repository.py
+++ b/backend/app/repositories/admin_data_repository.py
@@ -1,0 +1,61 @@
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session
+
+from ..config import Settings
+from ..db_models import Feed, MapPlace, User, UserComment, UserStamp
+from ..models import AdminPlaceOut, AdminSummaryResponse, PublicImportResponse
+from ..public_data import import_public_bundle as sync_public_bundle
+from ..repository_support import to_admin_place_out, utcnow_naive
+
+
+def get_admin_summary(db: Session, settings: Settings) -> AdminSummaryResponse:
+    user_count = db.scalar(select(func.count()).select_from(User)) or 0
+    place_count = db.scalar(select(func.count()).select_from(MapPlace)) or 0
+    review_count = db.scalar(select(func.count()).select_from(Feed)) or 0
+    comment_count = db.scalar(select(func.count()).select_from(UserComment)) or 0
+    stamp_count = db.scalar(select(func.count()).select_from(UserStamp)) or 0
+    place_rows = db.execute(
+        select(MapPlace, func.count(Feed.feed_id))
+        .outerjoin(Feed, Feed.position_id == MapPlace.position_id)
+        .group_by(MapPlace.position_id)
+        .order_by(MapPlace.is_active.desc(), MapPlace.name.asc())
+    ).all()
+    return AdminSummaryResponse(
+        userCount=int(user_count),
+        placeCount=int(place_count),
+        reviewCount=int(review_count),
+        commentCount=int(comment_count),
+        stampCount=int(stamp_count),
+        sourceReady=settings.public_data_file_path.exists() or bool(settings.public_data_source_url),
+        places=[to_admin_place_out(place, int(count)) for place, count in place_rows],
+    )
+
+
+def update_place_visibility(
+    db: Session,
+    place_id: str,
+    is_active: bool | None = None,
+    is_manual_override: bool | None = None,
+) -> AdminPlaceOut:
+    place = db.scalars(select(MapPlace).where(MapPlace.slug == place_id)).first()
+    if not place:
+        raise ValueError("?μ냼瑜?李얠쓣 ???놁뼱??")
+
+    changed = False
+    if is_active is not None and place.is_active != is_active:
+        place.is_active = is_active
+        changed = True
+    if is_manual_override is not None and place.is_manual_override != is_manual_override:
+        place.is_manual_override = is_manual_override
+        changed = True
+    if changed:
+        place.updated_at = utcnow_naive()
+        db.commit()
+
+    review_count = db.scalar(select(func.count()).select_from(Feed).where(Feed.position_id == place.position_id)) or 0
+    return to_admin_place_out(place, int(review_count))
+
+
+def import_public_bundle(db: Session, settings: Settings) -> PublicImportResponse:
+    return sync_public_bundle(db, settings)
+

--- a/backend/app/repositories/admin_repository.py
+++ b/backend/app/repositories/admin_repository.py
@@ -2,7 +2,7 @@ from sqlalchemy.orm import Session
 
 from ..config import Settings
 from ..models import AdminPlaceOut, AdminSummaryResponse, PublicImportResponse
-from ..repository_normalized import get_admin_summary, import_public_bundle, update_place_visibility
+from .admin_data_repository import get_admin_summary, import_public_bundle, update_place_visibility
 
 
 def read_admin_summary_entry(db: Session, app_settings: Settings) -> AdminSummaryResponse:

--- a/backend/app/repositories/notification_data_repository.py
+++ b/backend/app/repositories/notification_data_repository.py
@@ -1,0 +1,157 @@
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from ..db_models import UserNotification
+from ..models import NotificationDeleteResponse, NotificationReadResponse, UserNotificationOut
+from ..repository_support import format_datetime, utcnow_naive
+
+
+def to_notification_out(notification: UserNotification) -> UserNotificationOut:
+    return UserNotificationOut(
+        id=str(notification.notification_id),
+        type=notification.type,
+        title=notification.title,
+        body=notification.body,
+        createdAt=format_datetime(notification.created_at),
+        isRead=notification.is_read,
+        reviewId=str(notification.review_id) if notification.review_id else None,
+        commentId=str(notification.comment_id) if notification.comment_id else None,
+        routeId=str(notification.route_id) if notification.route_id else None,
+        actorName=notification.actor.nickname if notification.actor else None,
+    )
+
+
+def list_user_notifications(db: Session, user_id: str, *, limit: int = 50) -> list[UserNotificationOut]:
+    notifications = db.scalars(
+        select(UserNotification)
+        .options(joinedload(UserNotification.actor))
+        .where(UserNotification.user_id == user_id)
+        .order_by(UserNotification.created_at.desc(), UserNotification.notification_id.desc())
+        .limit(limit)
+    ).unique().all()
+    return [to_notification_out(notification) for notification in notifications]
+
+
+def get_unread_notification_count(db: Session, user_id: str) -> int:
+    return int(
+        db.scalar(
+            select(func.count())
+            .select_from(UserNotification)
+            .where(UserNotification.user_id == user_id, UserNotification.is_read.is_(False))
+        )
+        or 0
+    )
+
+
+def get_unread_notification_counts(db: Session, user_ids: list[str]) -> dict[str, int]:
+    if not user_ids:
+        return {}
+
+    counts = {
+        user_id: int(total)
+        for user_id, total in db.execute(
+            select(UserNotification.user_id, func.count(UserNotification.notification_id))
+            .where(UserNotification.user_id.in_(user_ids), UserNotification.is_read.is_(False))
+            .group_by(UserNotification.user_id)
+        ).all()
+    }
+    return {user_id: counts.get(user_id, 0) for user_id in user_ids}
+
+
+def create_user_notification(
+    db: Session,
+    *,
+    user_id: str,
+    actor_user_id: str | None,
+    notification_type: str,
+    title: str,
+    body: str,
+    review_id: int | None = None,
+    comment_id: int | None = None,
+    route_id: int | None = None,
+    payload_metadata: dict | None = None,
+) -> UserNotificationOut | None:
+    if user_id == actor_user_id:
+        return None
+
+    now = utcnow_naive()
+    notification = UserNotification(
+        user_id=user_id,
+        actor_user_id=actor_user_id,
+        type=notification_type,
+        title=title,
+        body=body,
+        review_id=review_id,
+        comment_id=comment_id,
+        route_id=route_id,
+        is_read=False,
+        read_at=None,
+        payload_metadata=payload_metadata or {},
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(notification)
+    db.flush()
+    stored_notification = db.scalars(
+        select(UserNotification)
+        .options(joinedload(UserNotification.actor))
+        .where(UserNotification.notification_id == notification.notification_id)
+    ).unique().one()
+    return to_notification_out(stored_notification)
+
+
+def mark_notification_read(db: Session, notification_id: str, user_id: str) -> NotificationReadResponse:
+    try:
+        notification_key = int(notification_id)
+    except ValueError as error:
+        raise ValueError("?뚮┝ ID ?뺤떇???щ컮瑜댁? ?딆븘??") from error
+
+    notification = db.scalars(
+        select(UserNotification).where(
+            UserNotification.notification_id == notification_key,
+            UserNotification.user_id == user_id,
+        )
+    ).first()
+    if not notification:
+        raise ValueError("?뚮┝??李얠? 紐삵뻽?댁슂.")
+    if not notification.is_read:
+        notification.is_read = True
+        notification.read_at = utcnow_naive()
+        notification.updated_at = utcnow_naive()
+        db.commit()
+    return NotificationReadResponse(notificationId=str(notification.notification_id), read=True)
+
+
+def mark_all_notifications_read(db: Session, user_id: str) -> int:
+    notifications = db.scalars(
+        select(UserNotification).where(UserNotification.user_id == user_id, UserNotification.is_read.is_(False))
+    ).all()
+    if not notifications:
+        return 0
+    now = utcnow_naive()
+    for notification in notifications:
+        notification.is_read = True
+        notification.read_at = now
+        notification.updated_at = now
+    db.commit()
+    return len(notifications)
+
+
+def delete_notification(db: Session, notification_id: str, user_id: str) -> NotificationDeleteResponse:
+    try:
+        notification_key = int(notification_id)
+    except ValueError as error:
+        raise ValueError("?뚮┝ ID ?뺤떇???щ컮瑜댁? ?딆븘??") from error
+
+    notification = db.scalars(
+        select(UserNotification).where(
+            UserNotification.notification_id == notification_key,
+            UserNotification.user_id == user_id,
+        )
+    ).first()
+    if not notification:
+        raise ValueError("?뚮┝??李얠? 紐삵뻽?댁슂.")
+    db.delete(notification)
+    db.commit()
+    return NotificationDeleteResponse(notificationId=str(notification_key), deleted=True)
+

--- a/backend/app/repositories/notification_repository.py
+++ b/backend/app/repositories/notification_repository.py
@@ -1,7 +1,8 @@
 from sqlalchemy.orm import Session
 
 from ..models import NotificationDeleteResponse, NotificationReadResponse, UserNotificationOut
-from ..repository_normalized import (
+from .notification_data_repository import (
+    get_unread_notification_counts,
     delete_notification,
     get_unread_notification_count,
     list_user_notifications,
@@ -28,3 +29,7 @@ def delete_notification_entry(db: Session, notification_id: str, user_id: str) -
 
 def read_unread_notification_count(db: Session, user_id: str) -> int:
     return get_unread_notification_count(db, user_id)
+
+
+def read_unread_notification_counts(db: Session, user_ids: list[str]) -> dict[str, int]:
+    return get_unread_notification_counts(db, user_ids)

--- a/backend/app/services/review_service.py
+++ b/backend/app/services/review_service.py
@@ -14,7 +14,7 @@ from ..repositories.review_repository import (
     list_review_entries,
     toggle_review_like_entry,
 )
-from ..repository_normalized import get_unread_notification_counts
+from ..repositories.notification_repository import read_unread_notification_counts as get_unread_notification_counts
 
 _PLACE_NOT_FOUND_TOKEN = "장소"
 _ENTITY_NOT_FOUND_TOKEN = "찾을 수"


### PR DESCRIPTION
## Summary
- move notification data access into a dedicated repository module
- move admin/account data access into dedicated repository modules
- point services and repository facades at the new data repositories

## Validation
- backend notification/admin/account/review tests