### PR TITLE
Refactor MyPagePanel into section components

### DIFF
--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -3,6 +3,9 @@ import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { useAutoLoadMore } from '../hooks/useAutoLoadMore';
 import { MyCommentsTabSection } from './my-page/MyCommentsTabSection';
 import { MyFeedTabSection } from './my-page/MyFeedTabSection';
+import { MyPageAccountSection } from './my-page/MyPageAccountSection';
+import { MyPageOverviewSection } from './my-page/MyPageOverviewSection';
+import { MyPagePrimaryTabs } from './my-page/MyPagePrimaryTabs';
 import { MyRoutesTabSection } from './my-page/MyRoutesTabSection';
 import { MyStampTabSection } from './my-page/MyStampTabSection';
 import { ProviderButtons } from './ProviderButtons';
@@ -164,22 +167,13 @@ export function MyPagePanel({
           </button>
         </section>
       )}
-      <section className="sheet-card stack-gap account-action-card">
-        <div className="section-title-row section-title-row--tight">
-          <div>
-            <p className="eyebrow">ACCOUNT</p>
-            <h3>계정 관리</h3>
-          </div>
-        </div>
-        <div className="account-action-row">
-          <button type="button" className={showSettings ? 'secondary-button is-complete' : 'secondary-button'} onClick={() => setShowSettings((current) => !current)}>
-            {showSettings ? '설정 닫기' : '설정 열기'}
-          </button>
-          <button type="button" className="secondary-button" onClick={() => void onLogout()} disabled={isLoggingOut}>
-            {isLoggingOut ? '정리 중' : '로그아웃'}
-          </button>
-        </div>
-      </section>
+      <MyPageAccountSection
+        sessionUser={sessionUser}
+        isLoggingOut={isLoggingOut}
+        showSettings={showSettings}
+        onToggleSettings={() => setShowSettings((current) => !current)}
+        onLogout={() => void onLogout()}
+      />
       {(showSettings || !sessionUser.profileCompletedAt) && (
         <section className="sheet-card stack-gap settings-card">
           <div className="settings-card__header">
@@ -209,81 +203,21 @@ export function MyPagePanel({
 
       {myPage && (
         <>
-          <section className="sheet-card stack-gap">
-            <div className="my-stats-grid">
-              <article>
-                <strong>{myPage.stats.uniquePlaceCount}/{myPage.stats.totalPlaceCount}</strong>
-                <span>방문한 고유 명소</span>
-              </article>
-              <article>
-                <strong>{myPage.stats.stampCount}</strong>
-                <span>누적 스탬프 수</span>
-              </article>
-            </div>
-            {myPage.stats.totalPlaceCount > 0 && (
-              <div className="my-visit-progress">
-                <div className="my-visit-progress__bar">
-                  <div className="my-visit-progress__fill" style={{ width: `${visitPct}%` }} />
-                </div>
-                <span className="my-visit-progress__label">{visitPct}% 달성</span>
-              </div>
-            )}
-            <button type="button" className="secondary-button" onClick={() => setShowVisitedDetail((current) => !current)}>
-              {showVisitedDetail ? '방문 상세 닫기' : '방문 상세 보기'}
-            </button>
-            {showVisitedDetail && (
-              <div className="my-visited-grid">
-                <div>
-                  <div className="my-visited-section-header">
-                    <strong>가본 곳</strong>
-                    <span className="counter-pill">{myPage.visitedPlaces.length}곳</span>
-                  </div>
-                  <div className="chip-row compact-gap">
-                    {myPage.visitedPlaces.map((place) => (
-                      <button key={place.id} type="button" className="soft-tag soft-tag--button" onClick={() => onOpenPlace(place.id)}>
-                        {place.name}
-                      </button>
-                    ))}
-                    {myPage.visitedPlaces.length === 0 && <p className="empty-copy">아직 방문한 곳이 없어요.</p>}
-                  </div>
-                </div>
-                <div>
-                  <div className="my-visited-section-header">
-                    <strong>아직 못 가본 곳</strong>
-                    <span className="counter-pill counter-pill--muted">{myPage.unvisitedPlaces.length}곳</span>
-                  </div>
-                  <div className="chip-row compact-gap">
-                    {myPage.unvisitedPlaces.map((place) => (
-                      <button key={place.id} type="button" className="soft-tag soft-tag--button is-muted" onClick={() => onOpenPlace(place.id)}>
-                        {place.name}
-                      </button>
-                    ))}
-                  </div>
-                </div>
-              </div>
-            )}
-          </section>
+          <MyPageOverviewSection
+            uniquePlaceCount={myPage.stats.uniquePlaceCount}
+            totalPlaceCount={myPage.stats.totalPlaceCount}
+            stampCount={myPage.stats.stampCount}
+            visitPct={visitPct}
+            visitedPlaces={myPage.visitedPlaces}
+            unvisitedPlaces={myPage.unvisitedPlaces}
+            showVisitedDetail={showVisitedDetail}
+            onToggleVisitedDetail={() => setShowVisitedDetail((current) => !current)}
+            onOpenPlace={onOpenPlace}
+            travelSessions={myPage.travelSessions}
+          />
 
           <section className="sheet-card stack-gap">
-            <div className={sessionUser.isAdmin ? 'chip-row compact-gap my-page-primary-tabs my-page-primary-tabs--admin' : 'chip-row compact-gap my-page-primary-tabs'}>
-              <button type="button" className={activeTab === 'stamps' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('stamps')}>
-                {'\uC2A4\uD0EC\uD504'}
-              </button>
-              <button type="button" className={activeTab === 'feeds' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('feeds')}>
-                {'\uD53C\uB4DC'}
-              </button>
-              <button type="button" className={activeTab === 'comments' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('comments')}>
-                {'\uB313\uAE00'}
-              </button>
-              <button type="button" className={activeTab === 'routes' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('routes')}>
-                {'\uCF54\uC2A4'}
-              </button>
-              {sessionUser.isAdmin && (
-                <button type="button" className={activeTab === 'admin' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('admin')}>
-                  {'\uAD00\uB9AC'}
-                </button>
-              )}
-            </div>
+            <MyPagePrimaryTabs activeTab={activeTab} isAdmin={sessionUser.isAdmin} onChangeTab={onChangeTab} />
 
             {activeTab === 'stamps' && (
               <MyStampTabSection

--- a/src/components/my-page/MyPageAccountSection.tsx
+++ b/src/components/my-page/MyPageAccountSection.tsx
@@ -1,0 +1,40 @@
+import type { SessionUser } from '../../types';
+
+type MyPageAccountSectionProps = {
+  sessionUser: SessionUser;
+  isLoggingOut: boolean;
+  showSettings: boolean;
+  onToggleSettings: () => void;
+  onLogout: () => void;
+};
+
+export function MyPageAccountSection({
+  sessionUser,
+  isLoggingOut,
+  showSettings,
+  onToggleSettings,
+  onLogout,
+}: MyPageAccountSectionProps) {
+  return (
+    <section className="sheet-card stack-gap account-action-card">
+      <div className="section-title-row section-title-row--tight">
+        <div>
+          <p className="eyebrow">ACCOUNT</p>
+          <h3>계정 관리</h3>
+        </div>
+      </div>
+      <div className="account-action-row">
+        <button type="button" className={showSettings ? 'secondary-button is-complete' : 'secondary-button'} onClick={onToggleSettings}>
+          {showSettings ? '설정 닫기' : '설정 열기'}
+        </button>
+        <button type="button" className="secondary-button" onClick={onLogout} disabled={isLoggingOut}>
+          {isLoggingOut ? '정리 중' : '로그아웃'}
+        </button>
+      </div>
+      {!sessionUser.profileCompletedAt && (
+        <p className="section-copy">닉네임을 먼저 정하면 기록을 계정 기준으로 계속 이어갈 수 있어요.</p>
+      )}
+    </section>
+  );
+}
+

--- a/src/components/my-page/MyPageOverviewSection.tsx
+++ b/src/components/my-page/MyPageOverviewSection.tsx
@@ -1,0 +1,89 @@
+import type { Place, TravelSession } from '../../types';
+
+type MyPageOverviewSectionProps = {
+  uniquePlaceCount: number;
+  totalPlaceCount: number;
+  stampCount: number;
+  visitPct: number;
+  visitedPlaces: Place[];
+  unvisitedPlaces: Place[];
+  showVisitedDetail: boolean;
+  onToggleVisitedDetail: () => void;
+  onOpenPlace: (placeId: string) => void;
+  travelSessions: TravelSession[];
+};
+
+export function MyPageOverviewSection({
+  uniquePlaceCount,
+  totalPlaceCount,
+  stampCount,
+  visitPct,
+  visitedPlaces,
+  unvisitedPlaces,
+  showVisitedDetail,
+  onToggleVisitedDetail,
+  onOpenPlace,
+  travelSessions,
+}: MyPageOverviewSectionProps) {
+  return (
+    <section className="sheet-card stack-gap">
+      <div className="my-stats-grid">
+        <article>
+          <strong>{uniquePlaceCount}/{totalPlaceCount}</strong>
+          <span>방문한 고유 명소</span>
+        </article>
+        <article>
+          <strong>{stampCount}</strong>
+          <span>누적 스탬프 수</span>
+        </article>
+        <article>
+          <strong>{travelSessions.length}</strong>
+          <span>여행 세션 수</span>
+        </article>
+      </div>
+      {totalPlaceCount > 0 && (
+        <div className="my-visit-progress">
+          <div className="my-visit-progress__bar">
+            <div className="my-visit-progress__fill" style={{ width: `${visitPct}%` }} />
+          </div>
+          <span className="my-visit-progress__label">{visitPct}% 달성</span>
+        </div>
+      )}
+      <button type="button" className="secondary-button" onClick={onToggleVisitedDetail}>
+        {showVisitedDetail ? '방문 상세 닫기' : '방문 상세 보기'}
+      </button>
+      {showVisitedDetail && (
+        <div className="my-visited-grid">
+          <div>
+            <div className="my-visited-section-header">
+              <strong>가본 곳</strong>
+              <span className="counter-pill">{visitedPlaces.length}곳</span>
+            </div>
+            <div className="chip-row compact-gap">
+              {visitedPlaces.map((place) => (
+                <button key={place.id} type="button" className="soft-tag soft-tag--button" onClick={() => onOpenPlace(place.id)}>
+                  {place.name}
+                </button>
+              ))}
+              {visitedPlaces.length === 0 && <p className="empty-copy">아직 방문한 곳이 없어요.</p>}
+            </div>
+          </div>
+          <div>
+            <div className="my-visited-section-header">
+              <strong>아직 못 가본 곳</strong>
+              <span className="counter-pill counter-pill--muted">{unvisitedPlaces.length}곳</span>
+            </div>
+            <div className="chip-row compact-gap">
+              {unvisitedPlaces.map((place) => (
+                <button key={place.id} type="button" className="soft-tag soft-tag--button is-muted" onClick={() => onOpenPlace(place.id)}>
+                  {place.name}
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+

--- a/src/components/my-page/MyPagePrimaryTabs.tsx
+++ b/src/components/my-page/MyPagePrimaryTabs.tsx
@@ -1,0 +1,36 @@
+import type { MyPageTabKey } from '../../types';
+
+type MyPagePrimaryTabsProps = {
+  activeTab: MyPageTabKey;
+  isAdmin: boolean;
+  onChangeTab: (nextTab: MyPageTabKey) => void;
+};
+
+export function MyPagePrimaryTabs({
+  activeTab,
+  isAdmin,
+  onChangeTab,
+}: MyPagePrimaryTabsProps) {
+  return (
+    <div className={isAdmin ? 'chip-row compact-gap my-page-primary-tabs my-page-primary-tabs--admin' : 'chip-row compact-gap my-page-primary-tabs'}>
+      <button type="button" className={activeTab === 'stamps' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('stamps')}>
+        {'\uC2A4\uD0EC\uD504'}
+      </button>
+      <button type="button" className={activeTab === 'feeds' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('feeds')}>
+        {'\uD53C\uB4DC'}
+      </button>
+      <button type="button" className={activeTab === 'comments' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('comments')}>
+        {'\uB313\uAE00'}
+      </button>
+      <button type="button" className={activeTab === 'routes' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('routes')}>
+        {'\uCF54\uC2A4'}
+      </button>
+      {isAdmin && (
+        <button type="button" className={activeTab === 'admin' ? 'chip is-active' : 'chip'} onClick={() => onChangeTab('admin')}>
+          {'\uAD00\uB9AC'}
+        </button>
+      )}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- extract account, overview, and primary-tab sections from MyPagePanel
- keep MyPagePanel focused on data wiring and section composition
- preserve existing tab behavior and settings flow

## Validation
- npm run typecheck
- npm run build
- npm run test:regression -- my-page-panel