### PR TITLE
Refactor app coordinator services

### DIFF
--- a/src/hooks/useAppCoordinatorAuthLoaders.ts
+++ b/src/hooks/useAppCoordinatorAuthLoaders.ts
@@ -1,0 +1,66 @@
+import { useAppAuthActions } from './useAppAuthActions';
+import { useAppTabDataLoaders } from './useAppTabDataLoaders';
+import type { CoordinatorServicesArgs } from './useAppCoordinatorServices.types';
+
+export function useAppCoordinatorAuthLoaders({
+  routeState,
+  domainState,
+  dataState,
+}: CoordinatorServicesArgs) {
+  const { activeTab } = routeState;
+  const {
+    auth: { sessionUser },
+  } = domainState;
+  const {
+    adminSummary,
+    communityRoutesCacheRef,
+    coursesLoadedRef,
+    feedLoadedRef,
+    myPage,
+    replaceCommunityRoutes,
+    setAdminLoading,
+    setAdminSummary,
+    setCommunityRoutes,
+    setCourses,
+    setMyPage,
+    setReviews,
+  } = dataState;
+
+  const { startProviderLogin, handleUpdateProfile, handleLogout } = useAppAuthActions({
+    setMyPage,
+    formatErrorMessage,
+  });
+
+  const dataLoaders = useAppTabDataLoaders({
+    activeTab,
+    adminSummary,
+    myPage,
+    sessionUser,
+    communityRoutesCacheRef,
+    feedLoadedRef,
+    coursesLoadedRef,
+    replaceCommunityRoutes,
+    setCommunityRoutes,
+    setReviews,
+    setCourses,
+    setAdminLoading,
+    setAdminSummary,
+    setMyPage,
+  });
+
+  return {
+    sessionUser,
+    myPage,
+    startProviderLogin,
+    handleUpdateProfile,
+    handleLogout,
+    dataLoaders,
+  };
+}
+
+function formatErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '?遺욧퍕??筌ｌ꼶???? 筌륁궢六??곸뒄. ?醫롫뻻 ??쇰퓠 ??쇰뻻 ??뺣즲??雅뚯눘苑??';
+}

--- a/src/hooks/useAppCoordinatorNavigationNotifications.ts
+++ b/src/hooks/useAppCoordinatorNavigationNotifications.ts
@@ -1,0 +1,78 @@
+import { useAppNavigationHelpers } from './useAppNavigationHelpers';
+import { useGlobalNotifications } from './useGlobalNotifications';
+import type { CoordinatorServicesArgs } from './useAppCoordinatorServices.types';
+import type { useAppCoordinatorAuthLoaders } from './useAppCoordinatorAuthLoaders';
+
+type CoordinatorAuthLoaders = ReturnType<typeof useAppCoordinatorAuthLoaders>;
+
+export function useAppCoordinatorNavigationNotifications(
+  { routeState, domainState, shellRuntimeState, dataState }: CoordinatorServicesArgs,
+  { sessionUser, myPage }: CoordinatorAuthLoaders,
+) {
+  const {
+    activeTab,
+    drawerState,
+    selectedPlaceId,
+    selectedFestivalId,
+    commitRouteState,
+    goToTab,
+  } = routeState;
+  const {
+    map: { setSelectedRoutePreview },
+    myPage: { myPageTab, setMyPageTab },
+    returnView: { setReturnView },
+    review: {
+      feedPlaceFilterId,
+      activeCommentReviewId,
+      highlightedCommentId,
+      highlightedReviewId,
+      setActiveCommentReviewId,
+      setFeedPlaceFilterId,
+      setHighlightedCommentId,
+      setHighlightedReviewId,
+      setHighlightedRouteId,
+    },
+  } = domainState;
+  const { setNotice } = shellRuntimeState;
+  const { reviews, selectedPlaceReviews, upsertReviewCollections } = dataState;
+
+  const navigationHelpers = useAppNavigationHelpers({
+    activeTab,
+    myPageTab,
+    activeCommentReviewId,
+    highlightedCommentId,
+    highlightedReviewId,
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    feedPlaceFilterId,
+    reviews,
+    selectedPlaceReviews,
+    myPageReviews: myPage?.reviews ?? [],
+    setActiveCommentReviewId,
+    setHighlightedCommentId,
+    setHighlightedReviewId,
+    setHighlightedRouteId,
+    setReturnView,
+    setSelectedRoutePreview,
+    setFeedPlaceFilterId,
+    setNotice,
+    goToTab,
+    commitRouteState,
+    upsertReviewCollections,
+  });
+
+  const notificationState = useGlobalNotifications({
+    sessionUser,
+    myPage,
+    goToTab,
+    setMyPageTab,
+    handleOpenCommentWithReturn: navigationHelpers.handleOpenCommentWithReturn,
+    handleOpenReviewWithReturn: navigationHelpers.handleOpenReviewWithReturn,
+  });
+
+  return {
+    navigationHelpers,
+    ...notificationState,
+  };
+}

--- a/src/hooks/useAppCoordinatorServices.ts
+++ b/src/hooks/useAppCoordinatorServices.ts
@@ -1,25 +1,7 @@
-import { useAppAuthActions } from './useAppAuthActions';
-import { useAppTabDataLoaders } from './useAppTabDataLoaders';
-import { useAppNavigationHelpers } from './useAppNavigationHelpers';
-import { useGlobalNotifications } from './useGlobalNotifications';
-import { useAppViewModels } from './useAppViewModels';
-import { useAppPagePaginationActions } from './useAppPagePaginationActions';
-import { useActiveReviewComments } from './useActiveReviewComments';
-import type {
-  DataState,
-  DomainState,
-  PageRuntimeState,
-  RouteState,
-  ShellRuntimeState,
-} from './useAppShellCoordinator.types';
-
-type CoordinatorServicesArgs = {
-  routeState: RouteState;
-  domainState: DomainState;
-  shellRuntimeState: ShellRuntimeState;
-  pageRuntimeState: PageRuntimeState;
-  dataState: DataState;
-};
+import { useAppCoordinatorAuthLoaders } from './useAppCoordinatorAuthLoaders';
+import { useAppCoordinatorNavigationNotifications } from './useAppCoordinatorNavigationNotifications';
+import { useAppCoordinatorViewState } from './useAppCoordinatorViewState';
+import type { CoordinatorServicesArgs } from './useAppCoordinatorServices.types';
 
 export function useAppCoordinatorServices({
   routeState,
@@ -28,186 +10,34 @@ export function useAppCoordinatorServices({
   pageRuntimeState,
   dataState,
 }: CoordinatorServicesArgs) {
-  const {
-    activeTab,
-    drawerState,
-    selectedPlaceId,
-    selectedFestivalId,
-    commitRouteState,
-    goToTab,
-  } = routeState;
-  const {
-    auth: { sessionUser },
-    map: { activeCategory, selectedRoutePreview, setSelectedRoutePreview },
-    myPage: { myPageTab, setMyPageTab },
-    returnView: { setReturnView },
-    review: {
-      feedPlaceFilterId,
-      activeCommentReviewId,
-      highlightedCommentId,
-      highlightedReviewId,
-      setActiveCommentReviewId,
-      setFeedPlaceFilterId,
-      setHighlightedCommentId,
-      setHighlightedReviewId,
-      setHighlightedRouteId,
-    },
-  } = domainState;
-  const {
-    notice,
-    setNotice,
-    currentPosition,
-    mapLocationStatus,
-    mapLocationMessage,
-    bootstrapStatus,
-    bootstrapError,
-  } = shellRuntimeState;
-  const {
-    adminSummary,
-    communityRoutesCacheRef,
-    coursesLoadedRef,
-    feedLoadedRef,
-    festivals,
-    myPage,
-    places,
-    replaceCommunityRoutes,
-    reviews,
-    selectedPlaceReviews,
-    setAdminLoading,
-    setAdminSummary,
-    setCommunityRoutes,
-    setCourses,
-    setMyPage,
-    setReviews,
-    stampState,
-  } = dataState;
-
-  const { startProviderLogin, handleUpdateProfile, handleLogout } = useAppAuthActions({
-    setMyPage,
-    formatErrorMessage,
+  const authLoaders = useAppCoordinatorAuthLoaders({
+    routeState,
+    domainState,
+    shellRuntimeState,
+    pageRuntimeState,
+    dataState,
   });
 
-  const dataLoaders = useAppTabDataLoaders({
-    activeTab,
-    adminSummary,
-    myPage,
-    sessionUser,
-    communityRoutesCacheRef,
-    feedLoadedRef,
-    coursesLoadedRef,
-    replaceCommunityRoutes,
-    setCommunityRoutes,
-    setReviews,
-    setCourses,
-    setAdminLoading,
-    setAdminSummary,
-    setMyPage,
-  });
+  const navigationNotifications = useAppCoordinatorNavigationNotifications({
+    routeState,
+    domainState,
+    shellRuntimeState,
+    pageRuntimeState,
+    dataState,
+  }, authLoaders);
 
-  const navigationHelpers = useAppNavigationHelpers({
-    activeTab,
-    myPageTab,
-    activeCommentReviewId,
-    highlightedCommentId,
-    highlightedReviewId,
-    selectedPlaceId,
-    selectedFestivalId,
-    drawerState,
-    feedPlaceFilterId,
-    reviews,
-    selectedPlaceReviews,
-    myPageReviews: myPage?.reviews ?? [],
-    setActiveCommentReviewId,
-    setHighlightedCommentId,
-    setHighlightedReviewId,
-    setHighlightedRouteId,
-    setReturnView,
-    setSelectedRoutePreview,
-    setFeedPlaceFilterId,
-    setNotice,
-    goToTab,
-    commitRouteState,
-    upsertReviewCollections: dataState.upsertReviewCollections,
-  });
-
-  const {
-    notifications,
-    unreadNotificationCount,
-    handleMarkNotificationRead,
-    handleMarkAllNotificationsRead,
-    handleDeleteNotification,
-    handleOpenGlobalNotification,
-  } = useGlobalNotifications({
-    sessionUser,
-    myPage,
-    goToTab,
-    setMyPageTab,
-    handleOpenCommentWithReturn: navigationHelpers.handleOpenCommentWithReturn,
-    handleOpenReviewWithReturn: navigationHelpers.handleOpenReviewWithReturn,
-  });
-
-  const viewModels = useAppViewModels({
-    places,
-    festivals,
-    reviews,
-    selectedPlaceReviews,
-    selectedPlaceId,
-    selectedFestivalId,
-    selectedRoutePreview,
-    activeCategory,
-    myPage,
-    notifications,
-    unreadNotificationCount,
-    stampState,
-    currentPosition,
-    sessionUser,
-    notice,
-    bootstrapStatus,
-    bootstrapError,
-    mapLocationStatus,
-    mapLocationMessage,
-  });
-
-  const paginationActions = useAppPagePaginationActions({
-    sessionUser,
-    myPage,
-    setReviews,
-    setMyPage,
-    reportBackgroundError,
-  });
-
-  const activeReviewCommentsState = useActiveReviewComments({
-    activeCommentReviewId,
-    setNotice,
-    formatErrorMessage,
-  });
+  const viewState = useAppCoordinatorViewState({
+    routeState,
+    domainState,
+    shellRuntimeState,
+    pageRuntimeState,
+    dataState,
+  }, authLoaders, navigationNotifications);
 
   return {
-    startProviderLogin,
-    handleUpdateProfile,
-    handleLogout,
-    dataLoaders,
-    navigationHelpers,
-    notifications,
-    unreadNotificationCount,
-    handleMarkNotificationRead,
-    handleMarkAllNotificationsRead,
-    handleDeleteNotification,
-    handleOpenGlobalNotification,
-    viewModels,
-    paginationActions,
-    activeReviewCommentsState,
+    ...authLoaders,
+    ...navigationNotifications,
+    ...viewState,
     pageRuntimeState,
   };
-}
-
-function formatErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return '?붿껌??泥섎━?섏? 紐삵뻽?댁슂. ?좎떆 ?ㅼ뿉 ?ㅼ떆 ?쒕룄??二쇱꽭??';
-}
-
-function reportBackgroundError(error: unknown) {
-  console.error(error);
 }

--- a/src/hooks/useAppCoordinatorServices.types.ts
+++ b/src/hooks/useAppCoordinatorServices.types.ts
@@ -1,0 +1,15 @@
+import type {
+  DataState,
+  DomainState,
+  PageRuntimeState,
+  RouteState,
+  ShellRuntimeState,
+} from './useAppShellCoordinator.types';
+
+export type CoordinatorServicesArgs = {
+  routeState: RouteState;
+  domainState: DomainState;
+  shellRuntimeState: ShellRuntimeState;
+  pageRuntimeState: PageRuntimeState;
+  dataState: DataState;
+};

--- a/src/hooks/useAppCoordinatorViewState.ts
+++ b/src/hooks/useAppCoordinatorViewState.ts
@@ -1,0 +1,93 @@
+import { useActiveReviewComments } from './useActiveReviewComments';
+import { useAppPagePaginationActions } from './useAppPagePaginationActions';
+import { useAppViewModels } from './useAppViewModels';
+import type { CoordinatorServicesArgs } from './useAppCoordinatorServices.types';
+import type { useAppCoordinatorAuthLoaders } from './useAppCoordinatorAuthLoaders';
+import type { useAppCoordinatorNavigationNotifications } from './useAppCoordinatorNavigationNotifications';
+
+type CoordinatorAuthLoaders = ReturnType<typeof useAppCoordinatorAuthLoaders>;
+type CoordinatorNavigationNotifications = ReturnType<typeof useAppCoordinatorNavigationNotifications>;
+
+export function useAppCoordinatorViewState(
+  { routeState, domainState, shellRuntimeState, dataState }: CoordinatorServicesArgs,
+  { sessionUser, myPage }: CoordinatorAuthLoaders,
+  { notifications, unreadNotificationCount }: CoordinatorNavigationNotifications,
+) {
+  const { selectedPlaceId, selectedFestivalId } = routeState;
+  const {
+    map: { activeCategory, selectedRoutePreview },
+    review: { activeCommentReviewId },
+  } = domainState;
+  const {
+    notice,
+    setNotice,
+    currentPosition,
+    mapLocationStatus,
+    mapLocationMessage,
+    bootstrapStatus,
+    bootstrapError,
+  } = shellRuntimeState;
+  const {
+    festivals,
+    myPage: myPageData,
+    places,
+    reviews,
+    selectedPlaceReviews,
+    setMyPage,
+    setReviews,
+    stampState,
+  } = dataState;
+
+  const viewModels = useAppViewModels({
+    places,
+    festivals,
+    reviews,
+    selectedPlaceReviews,
+    selectedPlaceId,
+    selectedFestivalId,
+    selectedRoutePreview,
+    activeCategory,
+    myPage: myPageData,
+    notifications,
+    unreadNotificationCount,
+    stampState,
+    currentPosition,
+    sessionUser,
+    notice,
+    bootstrapStatus,
+    bootstrapError,
+    mapLocationStatus,
+    mapLocationMessage,
+  });
+
+  const paginationActions = useAppPagePaginationActions({
+    sessionUser,
+    myPage,
+    setReviews,
+    setMyPage,
+    reportBackgroundError,
+  });
+
+  const activeReviewCommentsState = useActiveReviewComments({
+    activeCommentReviewId,
+    setNotice,
+    formatErrorMessage,
+  });
+
+  return {
+    viewModels,
+    paginationActions,
+    activeReviewCommentsState,
+  };
+}
+
+function formatErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '?遺욧퍕??筌ｌ꼶???? 筌륁궢六??곸뒄. ?醫롫뻻 ??쇰퓠 ??쇰뻻 ??뺣즲??雅뚯눘苑??';
+}
+
+function reportBackgroundError(error: unknown) {
+  console.error(error);
+}


### PR DESCRIPTION
## Summary
- split app coordinator services into smaller hooks by responsibility
- keep useAppCoordinatorServices as a thin composition layer
- preserve existing coordinator behavior while reducing service coupling

## Validation
- npm run typecheck
- npm run build
- npm run test:all