### PR TITLE
Refactor app coordinator actions

### DIFF
--- a/src/hooks/useAppCoordinatorActionUtils.ts
+++ b/src/hooks/useAppCoordinatorActionUtils.ts
@@ -1,0 +1,10 @@
+export function formatCoordinatorErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '?遺욧퍕??筌ｌ꼶???? 筌륁궢六??곸뒄. ?醫롫뻻 ??쇰퓠 ??쇰뻻 ??뺣즲??雅뚯눘苑??';
+}
+
+export function reportCoordinatorBackgroundError(error: unknown) {
+  console.error(error);
+}

--- a/src/hooks/useAppCoordinatorActions.ts
+++ b/src/hooks/useAppCoordinatorActions.ts
@@ -1,10 +1,5 @@
-import { useAppMapActions } from './useAppMapActions';
-import { useAppReviewActions } from './useAppReviewActions';
-import { useAppRouteActions } from './useAppRouteActions';
-import { useAppAdminActions } from './useAppAdminActions';
-import { useAppShellNavigation } from './useAppShellNavigation';
-import { useAppStageActions } from './useAppStageActions';
-import { useAppPageStageActions } from './useAppPageStageActions';
+import { useAppCoordinatorMutationActions } from './useAppCoordinatorMutationActions';
+import { useAppCoordinatorStageActions } from './useAppCoordinatorStageActions';
 import type {
   DataState,
   DomainState,
@@ -28,182 +23,29 @@ export function useAppCoordinatorActions({
   dataState,
   services,
 }: CoordinatorActionsArgs) {
-  const {
-    activeTab,
-    commitRouteState,
-    drawerState,
-    goToTab,
-    selectedFestivalId,
-    selectedPlaceId,
-  } = routeState;
-  const {
-    auth: { sessionUser },
-    map: { selectedRoutePreview, setSelectedRoutePreview },
-    myPage: { setMyPageTab },
-    returnView: { returnView, setReturnView },
-    review: {
-      activeCommentReviewId,
-      highlightedReviewId,
-      setActiveCommentReviewId,
-      setFeedPlaceFilterId,
-      setHighlightedCommentId,
-      setHighlightedReviewId,
-    },
-  } = domainState;
-  const { setNotice } = shellRuntimeState;
-  const {
-    communityRoutesCacheRef,
-    patchCommunityRoutes,
-    patchReviewCollections,
-    placeReviewsCacheRef,
-    myPage,
-    reviews,
-    selectedPlaceReviews,
-    setAdminBusyPlaceId,
-    setAdminLoading,
-    setAdminSummary,
-    setFestivals,
-    setHasRealData,
-    setMyPage,
-    setPlaces,
-    setReviews,
-    setSelectedPlaceReviews,
-    setStampState,
-    upsertReviewCollections,
-  } = dataState;
-  const {
-    activeReviewCommentsState,
-    dataLoaders: { fetchCommunityRoutes, refreshAdminSummary, refreshMyPageForUser },
-    navigationHelpers: {
-      handleCloseReviewComments,
-      handleOpenCommentWithReturn,
-      handleOpenCommunityRouteWithReturn,
-      handleOpenPlaceFeedWithReturn,
-    },
-    viewModels,
-  } = services;
-
-  const { refreshCurrentPosition, handleClaimStamp } = useAppMapActions({
-    sessionUser,
-    setPlaces,
-    setStampState,
-    goToTab,
-    commitRouteState,
-    refreshMyPageForUser,
-    formatErrorMessage,
+  const mutationActions = useAppCoordinatorMutationActions({
+    routeState,
+    domainState,
+    shellRuntimeState,
+    dataState,
+    services,
   });
 
-  const reviewActions = useAppReviewActions({
-    activeTab,
-    sessionUser,
-    selectedPlace: viewModels.selectedPlace,
-    reviews,
-    selectedPlaceReviews,
-    myPage,
-    activeCommentReviewId,
-    highlightedReviewId,
-    setSelectedPlaceReviews,
-    setReviews,
-    setMyPage,
-    setNotice,
-    goToTab,
-    commitRouteState,
-    refreshMyPageForUser,
-    patchReviewCollections,
-    upsertReviewCollections,
-    placeReviewsCacheRef,
-    handleCloseReviewComments,
-    syncReviewComments: activeReviewCommentsState.syncReviewComments,
-    clearReviewComments: activeReviewCommentsState.clearReviewComments,
-    formatErrorMessage,
-  });
-
-  const routeActions = useAppRouteActions({
-    setMyPage,
-    communityRoutesCacheRef,
-    patchCommunityRoutes,
-    refreshMyPageForUser,
-    formatErrorMessage,
-    goToTab,
-  });
-
-  const adminActions = useAppAdminActions({
-    sessionUser,
-    setAdminBusyPlaceId,
-    setAdminSummary,
-    setPlaces,
-    setStampState,
-    setHasRealData,
-    setAdminLoading,
-    setFestivals,
-    refreshAdminSummary,
-    formatErrorMessage,
-  });
-
-  const shellNavigation = useAppShellNavigation({
-    sessionUser,
-    returnView,
-    activeCommentReviewId,
-    activeTab,
-    selectedPlaceId,
-    selectedFestivalId,
-    drawerState,
-    selectedRoutePreview,
-    setMyPageTab,
-    setActiveCommentReviewId,
-    setHighlightedCommentId,
-    setHighlightedReviewId,
-    setFeedPlaceFilterId,
-    setSelectedRoutePreview,
-    setReturnView,
-    handleCloseReviewComments,
-    goToTab,
-    commitRouteState,
-  });
-
-  const mapStageActions = useAppStageActions({
-    selectedPlace: viewModels.selectedPlace,
-    selectedFestival: viewModels.selectedFestival,
-    selectedPlaceId,
-    selectedFestivalId,
-    drawerState,
-    selectedRoutePreview,
-    setSelectedRoutePreview,
-    commitRouteState,
-    goToTab,
-    handleOpenPlaceFeedWithReturn,
-    refreshCurrentPosition,
-  });
-
-  const pageStageActions = useAppPageStageActions({
-    sessionUser,
-    setFeedPlaceFilterId,
-    setCommunityRouteSort: dataState.setCommunityRouteSort,
-    handleOpenCommentWithReturn,
-    handleOpenCommunityRouteWithReturn,
-    fetchCommunityRoutes,
-    refreshMyPageForUser,
-    reportBackgroundError,
+  const stageActions = useAppCoordinatorStageActions({
+    routeState,
+    domainState,
+    dataState,
+    services,
+    refreshCurrentPosition: mutationActions.refreshCurrentPosition,
   });
 
   return {
-    handleClaimStamp,
-    reviewActions,
-    routeActions,
-    adminActions,
-    shellNavigation,
-    mapStageActions,
-    pageStageActions,
+    handleClaimStamp: mutationActions.handleClaimStamp,
+    reviewActions: mutationActions.reviewActions,
+    routeActions: mutationActions.routeActions,
+    adminActions: mutationActions.adminActions,
+    shellNavigation: stageActions.shellNavigation,
+    mapStageActions: stageActions.mapStageActions,
+    pageStageActions: stageActions.pageStageActions,
   };
-}
-
-function formatErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return '?붿껌??泥섎━?섏? 紐삵뻽?댁슂. ?좎떆 ?ㅼ뿉 ?ㅼ떆 ?쒕룄??二쇱꽭??';
-}
-
-function reportBackgroundError(error: unknown) {
-  console.error(error);
 }

--- a/src/hooks/useAppCoordinatorMutationActions.ts
+++ b/src/hooks/useAppCoordinatorMutationActions.ts
@@ -1,0 +1,133 @@
+import { useAppAdminActions } from './useAppAdminActions';
+import { useAppMapActions } from './useAppMapActions';
+import { useAppReviewActions } from './useAppReviewActions';
+import { useAppRouteActions } from './useAppRouteActions';
+import { formatCoordinatorErrorMessage } from './useAppCoordinatorActionUtils';
+import type {
+  DataState,
+  DomainState,
+  RouteState,
+  ShellRuntimeState,
+} from './useAppShellCoordinator.types';
+import type { useAppCoordinatorServices } from './useAppCoordinatorServices';
+
+type CoordinatorMutationActionsArgs = {
+  routeState: RouteState;
+  domainState: DomainState;
+  shellRuntimeState: ShellRuntimeState;
+  dataState: DataState;
+  services: ReturnType<typeof useAppCoordinatorServices>;
+};
+
+export function useAppCoordinatorMutationActions({
+  routeState,
+  domainState,
+  shellRuntimeState,
+  dataState,
+  services,
+}: CoordinatorMutationActionsArgs) {
+  const {
+    activeTab,
+    commitRouteState,
+    goToTab,
+  } = routeState;
+  const {
+    auth: { sessionUser },
+    review: {
+      activeCommentReviewId,
+      highlightedReviewId,
+    },
+  } = domainState;
+  const { setNotice } = shellRuntimeState;
+  const {
+    communityRoutesCacheRef,
+    patchCommunityRoutes,
+    patchReviewCollections,
+    placeReviewsCacheRef,
+    myPage,
+    reviews,
+    selectedPlaceReviews,
+    setAdminBusyPlaceId,
+    setAdminLoading,
+    setAdminSummary,
+    setFestivals,
+    setHasRealData,
+    setMyPage,
+    setPlaces,
+    setReviews,
+    setSelectedPlaceReviews,
+    setStampState,
+    upsertReviewCollections,
+  } = dataState;
+  const {
+    activeReviewCommentsState,
+    dataLoaders: { refreshAdminSummary, refreshMyPageForUser },
+    navigationHelpers: { handleCloseReviewComments },
+    viewModels,
+  } = services;
+
+  const { refreshCurrentPosition, handleClaimStamp } = useAppMapActions({
+    sessionUser,
+    setPlaces,
+    setStampState,
+    goToTab,
+    commitRouteState,
+    refreshMyPageForUser,
+    formatErrorMessage: formatCoordinatorErrorMessage,
+  });
+
+  const reviewActions = useAppReviewActions({
+    activeTab,
+    sessionUser,
+    selectedPlace: viewModels.selectedPlace,
+    reviews,
+    selectedPlaceReviews,
+    myPage,
+    activeCommentReviewId,
+    highlightedReviewId,
+    setSelectedPlaceReviews,
+    setReviews,
+    setMyPage,
+    setNotice,
+    goToTab,
+    commitRouteState,
+    refreshMyPageForUser,
+    patchReviewCollections,
+    upsertReviewCollections,
+    placeReviewsCacheRef,
+    handleCloseReviewComments,
+    syncReviewComments: activeReviewCommentsState.syncReviewComments,
+    clearReviewComments: activeReviewCommentsState.clearReviewComments,
+    formatErrorMessage: formatCoordinatorErrorMessage,
+  });
+
+  const routeActions = useAppRouteActions({
+    setMyPage,
+    communityRoutesCacheRef,
+    patchCommunityRoutes,
+    refreshMyPageForUser,
+    formatErrorMessage: formatCoordinatorErrorMessage,
+    goToTab,
+  });
+
+  const adminActions = useAppAdminActions({
+    sessionUser,
+    setAdminBusyPlaceId,
+    setAdminSummary,
+    setPlaces,
+    setStampState,
+    setHasRealData,
+    setAdminLoading,
+    setFestivals,
+    refreshAdminSummary,
+    formatErrorMessage: formatCoordinatorErrorMessage,
+  });
+
+  return {
+    refreshCurrentPosition,
+    handleClaimStamp,
+    reviewActions,
+    routeActions,
+    adminActions,
+  };
+}

--- a/src/hooks/useAppCoordinatorStageActions.ts
+++ b/src/hooks/useAppCoordinatorStageActions.ts
@@ -1,0 +1,112 @@
+import { useAppPageStageActions } from './useAppPageStageActions';
+import { useAppShellNavigation } from './useAppShellNavigation';
+import { useAppStageActions } from './useAppStageActions';
+import {
+  reportCoordinatorBackgroundError,
+} from './useAppCoordinatorActionUtils';
+import type {
+  DataState,
+  DomainState,
+  RouteState,
+} from './useAppShellCoordinator.types';
+import type { useAppCoordinatorServices } from './useAppCoordinatorServices';
+
+type CoordinatorStageActionsArgs = {
+  routeState: RouteState;
+  domainState: DomainState;
+  dataState: DataState;
+  services: ReturnType<typeof useAppCoordinatorServices>;
+  refreshCurrentPosition: (shouldFocusMap: boolean) => Promise<void>;
+};
+
+export function useAppCoordinatorStageActions({
+  routeState,
+  domainState,
+  dataState,
+  services,
+  refreshCurrentPosition,
+}: CoordinatorStageActionsArgs) {
+  const {
+    activeTab,
+    commitRouteState,
+    drawerState,
+    goToTab,
+    selectedFestivalId,
+    selectedPlaceId,
+  } = routeState;
+  const {
+    auth: { sessionUser },
+    map: { selectedRoutePreview, setSelectedRoutePreview },
+    myPage: { setMyPageTab },
+    returnView: { returnView, setReturnView },
+    review: {
+      activeCommentReviewId,
+      setActiveCommentReviewId,
+      setFeedPlaceFilterId,
+      setHighlightedCommentId,
+      setHighlightedReviewId,
+    },
+  } = domainState;
+  const {
+    dataLoaders: { fetchCommunityRoutes, refreshMyPageForUser },
+    navigationHelpers: {
+      handleCloseReviewComments,
+      handleOpenCommentWithReturn,
+      handleOpenCommunityRouteWithReturn,
+      handleOpenPlaceFeedWithReturn,
+    },
+    viewModels,
+  } = services;
+
+  const shellNavigation = useAppShellNavigation({
+    sessionUser,
+    returnView,
+    activeCommentReviewId,
+    activeTab,
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    selectedRoutePreview,
+    setMyPageTab,
+    setActiveCommentReviewId,
+    setHighlightedCommentId,
+    setHighlightedReviewId,
+    setFeedPlaceFilterId,
+    setSelectedRoutePreview,
+    setReturnView,
+    handleCloseReviewComments,
+    goToTab,
+    commitRouteState,
+  });
+
+  const mapStageActions = useAppStageActions({
+    selectedPlace: viewModels.selectedPlace,
+    selectedFestival: viewModels.selectedFestival,
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    selectedRoutePreview,
+    setSelectedRoutePreview,
+    commitRouteState,
+    goToTab,
+    handleOpenPlaceFeedWithReturn,
+    refreshCurrentPosition,
+  });
+
+  const pageStageActions = useAppPageStageActions({
+    sessionUser,
+    setFeedPlaceFilterId,
+    setCommunityRouteSort: dataState.setCommunityRouteSort,
+    handleOpenCommentWithReturn,
+    handleOpenCommunityRouteWithReturn,
+    fetchCommunityRoutes,
+    refreshMyPageForUser,
+    reportBackgroundError: reportCoordinatorBackgroundError,
+  });
+
+  return {
+    shellNavigation,
+    mapStageActions,
+    pageStageActions,
+  };
+}


### PR DESCRIPTION
## Summary
- split app coordinator actions into mutation and stage action hooks
- keep the top-level action coordinator as a thin composition layer
- preserve existing coordinator behavior while reducing action coupling

## Validation
- npm run typecheck
- npm run build
- npm run test:all