### PR TITLE
Refactor page stage view contracts

### DIFF
--- a/src/components/AppPageStage.tsx
+++ b/src/components/AppPageStage.tsx
@@ -1,8 +1,8 @@
 import { memo } from 'react';
-import { CourseTab } from './CourseTab';
 import { EventTab } from './EventTab';
-import { FeedTab } from './FeedTab';
-import { MyPagePanel } from './MyPagePanel';
+import { PageStageCourseView } from './page-stage/PageStageCourseView';
+import { PageStageFeedView } from './page-stage/PageStageFeedView';
+import { PageStageMyView } from './page-stage/PageStageMyView';
 import type {
   AdminSummaryResponse,
   ApiStatus,
@@ -21,7 +21,7 @@ import type {
   UserRoute,
 } from '../types';
 
-interface AppPageStageProps {
+export interface AppPageStageProps {
   activeTab: Exclude<Tab, 'map'>;
   sharedData: {
     sessionUser: SessionUser | null;
@@ -119,110 +119,31 @@ export const AppPageStage = memo(function AppPageStage({
   return (
     <div className="page-stage">
       {activeTab === 'feed' && (
-        <FeedTab
-          feedData={{
-            reviews: feedData.reviews,
-            placeFilterId: feedData.feedPlaceFilterId,
-            placeFilterName: feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null,
-            highlightedReviewId: feedData.highlightedReviewId,
-            reviewLikeUpdatingId: feedData.reviewLikeUpdatingId,
-            hasMore: feedData.feedHasMore && !feedData.feedPlaceFilterId,
-            loadingMore: feedData.feedLoadingMore,
-          }}
-          commentSheetData={{
-            activeCommentReviewId: feedData.activeCommentReviewId,
-            activeCommentReviewComments: feedData.activeCommentReviewComments,
-            activeCommentReviewStatus: feedData.activeCommentReviewStatus,
-            highlightedCommentId: feedData.highlightedCommentId,
-            commentSubmittingReviewId: feedData.commentSubmittingReviewId,
-            commentMutatingId: feedData.commentMutatingId,
-            deletingReviewId: feedData.deletingReviewId,
-          }}
-          sharedData={{
-            sessionUser: sharedData.sessionUser,
-          }}
-          feedActions={{
-            onLoadMore: feedActions.onLoadMoreFeed,
-            onToggleReviewLike: feedActions.onToggleReviewLike,
-            onCreateComment: feedActions.onCreateComment,
-            onUpdateComment: feedActions.onUpdateComment,
-            onDeleteComment: feedActions.onDeleteComment,
-            onDeleteReview: feedActions.onDeleteReview,
-            onClearPlaceFilter: feedActions.onClearPlaceFilter,
-            onOpenComments: feedActions.onOpenComments,
-            onCloseComments: feedActions.onCloseComments,
-          }}
-          sharedActions={{
-            onRequestLogin: sharedActions.onRequestLogin,
-            onOpenPlace: sharedActions.onOpenPlace,
-          }}
+        <PageStageFeedView
+          sharedData={sharedData}
+          feedData={feedData}
+          sharedActions={sharedActions}
+          feedActions={feedActions}
         />
       )}
 
       {activeTab === 'event' && <EventTab festivals={sharedData.festivals} />}
 
       {activeTab === 'course' && (
-        <CourseTab
-          courses={courseData.courses}
-          communityRoutes={courseData.communityRoutes}
-          sort={courseData.communityRouteSort}
-          sessionUser={sharedData.sessionUser}
-          routeLikeUpdatingId={courseData.routeLikeUpdatingId}
-          highlightedRouteId={courseData.highlightedRouteId}
-          placeNameById={sharedData.placeNameById}
-          onChangeSort={courseActions.onChangeRouteSort}
-          onToggleLike={courseActions.onToggleRouteLike}
-          onOpenPlace={sharedActions.onOpenPlace}
-          onOpenRoutePreview={courseActions.onOpenRoutePreview}
-          onRequestLogin={sharedActions.onRequestLogin}
+        <PageStageCourseView
+          sharedData={sharedData}
+          courseData={courseData}
+          sharedActions={sharedActions}
+          courseActions={courseActions}
         />
       )}
 
       {activeTab === 'my' && (
-        <MyPagePanel
-          sessionData={{
-            sessionUser: sharedData.sessionUser,
-            myPage: myPageData.myPage,
-            providers: myPageData.providers,
-            myPageError: myPageData.myPageError,
-          }}
-          panelState={{
-            activeTab: myPageData.myPageTab,
-            isLoggingOut: myPageData.isLoggingOut,
-            profileSaving: myPageData.profileSaving,
-            profileError: myPageData.profileError,
-            routeSubmitting: myPageData.routeSubmitting,
-            routeError: myPageData.routeError,
-            commentsHasMore: myPageData.commentsHasMore,
-            commentsLoadingMore: myPageData.commentsLoadingMore,
-          }}
-          reviewActions={{
-            onOpenPlace: sharedActions.onOpenPlace,
-            onOpenComment: myPageActions.onOpenCommentFromMyPage,
-            onOpenRoute: myPageActions.onOpenRouteFromMyPage,
-            onOpenReview: myPageActions.onOpenReview,
-            onUpdateReview: myPageActions.onUpdateReview,
-            onDeleteReview: myPageActions.onDeleteReview,
-            onLoadMoreComments: myPageActions.onLoadMoreComments,
-          }}
-          panelActions={{
-            onChangeTab: myPageActions.onChangeMyPageTab,
-            onLogin: myPageActions.onLogin,
-            onRetry: myPageActions.onRetryMyPage,
-            onLogout: myPageActions.onLogout,
-            onSaveNickname: myPageActions.onSaveNickname,
-            onPublishRoute: myPageActions.onPublishRoute,
-          }}
-          adminData={{
-            adminSummary: myPageData.adminSummary,
-            adminBusyPlaceId: myPageData.adminBusyPlaceId,
-            adminLoading: myPageData.adminLoading,
-          }}
-          adminActions={{
-            onRefreshAdmin: myPageActions.onRefreshAdmin,
-            onToggleAdminPlace: myPageActions.onToggleAdminPlace,
-            onToggleAdminManualOverride: myPageActions.onToggleAdminManualOverride,
-          }}
+        <PageStageMyView
+          sharedData={sharedData}
+          myPageData={myPageData}
+          sharedActions={sharedActions}
+          myPageActions={myPageActions}
         />
       )}
     </div>

--- a/src/components/MapTabStage.tsx
+++ b/src/components/MapTabStage.tsx
@@ -1,8 +1,10 @@
-import { categoryInfo, categoryItems } from '../lib/categories';
-import jamissueLogo from '../assets/jamissue-logo.png';
 import { FestivalDetailSheet } from './FestivalDetailSheet';
 import { NaverMap } from './NaverMap';
 import { PlaceDetailSheet } from './PlaceDetailSheet';
+import { MapStageBrandHeader } from './map-stage/MapStageBrandHeader';
+import { MapStageCategoryStrip } from './map-stage/MapStageCategoryStrip';
+import { MapStageDrawerTeaser } from './map-stage/MapStageDrawerTeaser';
+import { MapStageRoutePreviewCard } from './map-stage/MapStageRoutePreviewCard';
 import type {
   ApiStatus,
   BootstrapResponse,
@@ -81,47 +83,15 @@ export function MapTabStage({
   festivalSheet,
   mapActions,
 }: MapTabStageProps) {
+  const showRoutePreview = !placeSheet.selectedPlace && !festivalSheet.selectedFestival;
+
   return (
     <div className="map-stage">
-      <header className="map-stage__header map-stage__header--brand-only">
-        <div className="map-stage__brand map-stage__brand--row">
-          <div className="map-stage__brand-mark">
-            <img src={jamissueLogo} alt="Jam Issue logo" className="map-stage__brand-mark-image" />
-          </div>
-          <div className="map-stage__brand-copy">
-            <p className="map-stage__brand-kicker">DAEJEON LOCAL GUIDE</p>
-            <h1 className="map-stage__brand-title">JAM ISSUE</h1>
-          </div>
-        </div>
-      </header>
-
-      <div className="map-filter-strip">
-        <div className="chip-row compact-gap">
-          {categoryItems.map((item) => {
-            const isActive = item.key === mapData.activeCategory;
-            const info = item.key === 'all' ? null : categoryInfo[item.key];
-            return (
-              <button
-                key={item.key}
-                type="button"
-                className={isActive ? 'chip is-active map-filter-chip' : 'chip map-filter-chip'}
-                onClick={() => mapActions.setActiveCategory(item.key)}
-                style={
-                  info
-                    ? {
-                        background: isActive ? info.color : 'rgba(255,255,255,0.94)',
-                        borderColor: info.jamColor,
-                        color: '#4a3140',
-                      }
-                    : undefined
-                }
-              >
-                {info ? String(info.icon) + ' ' + item.label : item.label}
-              </button>
-            );
-          })}
-        </div>
-      </div>
+      <MapStageBrandHeader />
+      <MapStageCategoryStrip
+        activeCategory={mapData.activeCategory}
+        onSelectCategory={mapActions.setActiveCategory}
+      />
 
       <NaverMap
         places={mapData.filteredPlaces}
@@ -142,52 +112,15 @@ export function MapTabStage({
         height="100%"
       />
 
-      {!placeSheet.selectedPlace && !festivalSheet.selectedFestival && routePreviewData.routePreview && (
-        <section className="map-route-preview-card">
-          <div className="map-route-preview-card__top">
-            <div>
-              <p className="eyebrow">ROUTE PREVIEW</p>
-              <h3>{routePreviewData.routePreview.title}</h3>
-              <p className="section-copy">{routePreviewData.routePreview.subtitle}</p>
-            </div>
-            <button
-              type="button"
-              className="map-route-preview-card__close"
-              onClick={routePreviewData.onClearRoutePreview}
-              aria-label="경로 미리보기 닫기"
-            >
-              <span aria-hidden="true">{'\u00D7'}</span>
-            </button>
-          </div>
-          <div className="course-card__places community-route-places map-route-preview-card__places">
-            {routePreviewData.routePreview.placeIds.map((placeId, index) => (
-              <button
-                key={routePreviewData.routePreview!.id + '-' + placeId}
-                type="button"
-                className="soft-tag soft-tag--button course-card__place"
-                onClick={() => routePreviewData.onOpenRoutePreviewPlace(placeId)}
-              >
-                {index + 1}. {routePreviewData.routePreview!.placeNames[index] ?? placeId}
-              </button>
-            ))}
-          </div>
-        </section>
+      {showRoutePreview && (
+        <MapStageRoutePreviewCard
+          routePreview={routePreviewData.routePreview}
+          onClearRoutePreview={routePreviewData.onClearRoutePreview}
+          onOpenRoutePreviewPlace={routePreviewData.onOpenRoutePreviewPlace}
+        />
       )}
 
-      {!placeSheet.selectedPlace && !festivalSheet.selectedFestival && (
-        <section className="map-drawer-teaser">
-          <span className="map-drawer-teaser__handle" aria-hidden="true" />
-          <div className="map-drawer-teaser__peek" aria-hidden="true">
-            <div className="map-drawer-teaser__line" />
-            <div className="map-drawer-teaser__line map-drawer-teaser__line--short" />
-            <div className="map-drawer-teaser__chips">
-              <span className="map-drawer-teaser__chip" />
-              <span className="map-drawer-teaser__chip" />
-              <span className="map-drawer-teaser__chip map-drawer-teaser__chip--wide" />
-            </div>
-          </div>
-        </section>
-      )}
+      {showRoutePreview && <MapStageDrawerTeaser />}
 
       <PlaceDetailSheet
         place={placeSheet.selectedPlace}

--- a/src/components/map-stage/MapStageBrandHeader.tsx
+++ b/src/components/map-stage/MapStageBrandHeader.tsx
@@ -1,0 +1,17 @@
+import jamissueLogo from '../../assets/jamissue-logo.png';
+
+export function MapStageBrandHeader() {
+  return (
+    <header className="map-stage__header map-stage__header--brand-only">
+      <div className="map-stage__brand map-stage__brand--row">
+        <div className="map-stage__brand-mark">
+          <img src={jamissueLogo} alt="Jam Issue logo" className="map-stage__brand-mark-image" />
+        </div>
+        <div className="map-stage__brand-copy">
+          <p className="map-stage__brand-kicker">DAEJEON LOCAL GUIDE</p>
+          <h1 className="map-stage__brand-title">JAM ISSUE</h1>
+        </div>
+      </div>
+    </header>
+  );
+}

--- a/src/components/map-stage/MapStageCategoryStrip.tsx
+++ b/src/components/map-stage/MapStageCategoryStrip.tsx
@@ -1,0 +1,42 @@
+import { categoryInfo, categoryItems } from '../../lib/categories';
+import type { Category } from '../../types';
+
+type MapStageCategoryStripProps = {
+  activeCategory: Category;
+  onSelectCategory: (category: Category) => void;
+};
+
+export function MapStageCategoryStrip({
+  activeCategory,
+  onSelectCategory,
+}: MapStageCategoryStripProps) {
+  return (
+    <div className="map-filter-strip">
+      <div className="chip-row compact-gap">
+        {categoryItems.map((item) => {
+          const isActive = item.key === activeCategory;
+          const info = item.key === 'all' ? null : categoryInfo[item.key];
+          return (
+            <button
+              key={item.key}
+              type="button"
+              className={isActive ? 'chip is-active map-filter-chip' : 'chip map-filter-chip'}
+              onClick={() => onSelectCategory(item.key)}
+              style={
+                info
+                  ? {
+                      background: isActive ? info.color : 'rgba(255,255,255,0.94)',
+                      borderColor: info.jamColor,
+                      color: '#4a3140',
+                    }
+                  : undefined
+              }
+            >
+              {info ? String(info.icon) + ' ' + item.label : item.label}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/map-stage/MapStageDrawerTeaser.tsx
+++ b/src/components/map-stage/MapStageDrawerTeaser.tsx
@@ -1,0 +1,16 @@
+export function MapStageDrawerTeaser() {
+  return (
+    <section className="map-drawer-teaser">
+      <span className="map-drawer-teaser__handle" aria-hidden="true" />
+      <div className="map-drawer-teaser__peek" aria-hidden="true">
+        <div className="map-drawer-teaser__line" />
+        <div className="map-drawer-teaser__line map-drawer-teaser__line--short" />
+        <div className="map-drawer-teaser__chips">
+          <span className="map-drawer-teaser__chip" />
+          <span className="map-drawer-teaser__chip" />
+          <span className="map-drawer-teaser__chip map-drawer-teaser__chip--wide" />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/map-stage/MapStageRoutePreviewCard.tsx
+++ b/src/components/map-stage/MapStageRoutePreviewCard.tsx
@@ -1,0 +1,49 @@
+import type { RoutePreview } from '../../types';
+
+type MapStageRoutePreviewCardProps = {
+  routePreview: RoutePreview | null;
+  onClearRoutePreview: () => void;
+  onOpenRoutePreviewPlace: (placeId: string) => void;
+};
+
+export function MapStageRoutePreviewCard({
+  routePreview,
+  onClearRoutePreview,
+  onOpenRoutePreviewPlace,
+}: MapStageRoutePreviewCardProps) {
+  if (!routePreview) {
+    return null;
+  }
+
+  return (
+    <section className="map-route-preview-card">
+      <div className="map-route-preview-card__top">
+        <div>
+          <p className="eyebrow">ROUTE PREVIEW</p>
+          <h3>{routePreview.title}</h3>
+          <p className="section-copy">{routePreview.subtitle}</p>
+        </div>
+        <button
+          type="button"
+          className="map-route-preview-card__close"
+          onClick={onClearRoutePreview}
+          aria-label="경로 미리보기 닫기"
+        >
+          <span aria-hidden="true">{'\u00D7'}</span>
+        </button>
+      </div>
+      <div className="course-card__places community-route-places map-route-preview-card__places">
+        {routePreview.placeIds.map((placeId, index) => (
+          <button
+            key={routePreview.id + '-' + placeId}
+            type="button"
+            className="soft-tag soft-tag--button course-card__place"
+            onClick={() => onOpenRoutePreviewPlace(placeId)}
+          >
+            {index + 1}. {routePreview.placeNames[index] ?? placeId}
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/page-stage/PageStageCourseView.tsx
+++ b/src/components/page-stage/PageStageCourseView.tsx
@@ -1,0 +1,28 @@
+import { CourseTab } from '../CourseTab';
+import type { AppPageStageProps } from '../AppPageStage';
+
+type PageStageCourseViewProps = Pick<AppPageStageProps, 'sharedData' | 'courseData' | 'sharedActions' | 'courseActions'>;
+
+export function PageStageCourseView({
+  sharedData,
+  courseData,
+  sharedActions,
+  courseActions,
+}: PageStageCourseViewProps) {
+  return (
+    <CourseTab
+      courses={courseData.courses}
+      communityRoutes={courseData.communityRoutes}
+      sort={courseData.communityRouteSort}
+      sessionUser={sharedData.sessionUser}
+      routeLikeUpdatingId={courseData.routeLikeUpdatingId}
+      highlightedRouteId={courseData.highlightedRouteId}
+      placeNameById={sharedData.placeNameById}
+      onChangeSort={courseActions.onChangeRouteSort}
+      onToggleLike={courseActions.onToggleRouteLike}
+      onOpenPlace={sharedActions.onOpenPlace}
+      onOpenRoutePreview={courseActions.onOpenRoutePreview}
+      onRequestLogin={sharedActions.onRequestLogin}
+    />
+  );
+}

--- a/src/components/page-stage/PageStageFeedView.tsx
+++ b/src/components/page-stage/PageStageFeedView.tsx
@@ -1,0 +1,52 @@
+import { FeedTab } from '../FeedTab';
+import type { AppPageStageProps } from '../AppPageStage';
+
+type PageStageFeedViewProps = Pick<AppPageStageProps, 'sharedData' | 'feedData' | 'sharedActions' | 'feedActions'>;
+
+export function PageStageFeedView({
+  sharedData,
+  feedData,
+  sharedActions,
+  feedActions,
+}: PageStageFeedViewProps) {
+  return (
+    <FeedTab
+      feedData={{
+        reviews: feedData.reviews,
+        placeFilterId: feedData.feedPlaceFilterId,
+        placeFilterName: feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null,
+        highlightedReviewId: feedData.highlightedReviewId,
+        reviewLikeUpdatingId: feedData.reviewLikeUpdatingId,
+        hasMore: feedData.feedHasMore && !feedData.feedPlaceFilterId,
+        loadingMore: feedData.feedLoadingMore,
+      }}
+      commentSheetData={{
+        activeCommentReviewId: feedData.activeCommentReviewId,
+        activeCommentReviewComments: feedData.activeCommentReviewComments,
+        activeCommentReviewStatus: feedData.activeCommentReviewStatus,
+        highlightedCommentId: feedData.highlightedCommentId,
+        commentSubmittingReviewId: feedData.commentSubmittingReviewId,
+        commentMutatingId: feedData.commentMutatingId,
+        deletingReviewId: feedData.deletingReviewId,
+      }}
+      sharedData={{
+        sessionUser: sharedData.sessionUser,
+      }}
+      feedActions={{
+        onLoadMore: feedActions.onLoadMoreFeed,
+        onToggleReviewLike: feedActions.onToggleReviewLike,
+        onCreateComment: feedActions.onCreateComment,
+        onUpdateComment: feedActions.onUpdateComment,
+        onDeleteComment: feedActions.onDeleteComment,
+        onDeleteReview: feedActions.onDeleteReview,
+        onClearPlaceFilter: feedActions.onClearPlaceFilter,
+        onOpenComments: feedActions.onOpenComments,
+        onCloseComments: feedActions.onCloseComments,
+      }}
+      sharedActions={{
+        onRequestLogin: sharedActions.onRequestLogin,
+        onOpenPlace: sharedActions.onOpenPlace,
+      }}
+    />
+  );
+}

--- a/src/components/page-stage/PageStageMyView.tsx
+++ b/src/components/page-stage/PageStageMyView.tsx
@@ -1,0 +1,59 @@
+import { MyPagePanel } from '../MyPagePanel';
+import type { AppPageStageProps } from '../AppPageStage';
+
+type PageStageMyViewProps = Pick<AppPageStageProps, 'sharedData' | 'myPageData' | 'sharedActions' | 'myPageActions'>;
+
+export function PageStageMyView({
+  sharedData,
+  myPageData,
+  sharedActions,
+  myPageActions,
+}: PageStageMyViewProps) {
+  return (
+    <MyPagePanel
+      sessionData={{
+        sessionUser: sharedData.sessionUser,
+        myPage: myPageData.myPage,
+        providers: myPageData.providers,
+        myPageError: myPageData.myPageError,
+      }}
+      panelState={{
+        activeTab: myPageData.myPageTab,
+        isLoggingOut: myPageData.isLoggingOut,
+        profileSaving: myPageData.profileSaving,
+        profileError: myPageData.profileError,
+        routeSubmitting: myPageData.routeSubmitting,
+        routeError: myPageData.routeError,
+        commentsHasMore: myPageData.commentsHasMore,
+        commentsLoadingMore: myPageData.commentsLoadingMore,
+      }}
+      reviewActions={{
+        onOpenPlace: sharedActions.onOpenPlace,
+        onOpenComment: myPageActions.onOpenCommentFromMyPage,
+        onOpenRoute: myPageActions.onOpenRouteFromMyPage,
+        onOpenReview: myPageActions.onOpenReview,
+        onUpdateReview: myPageActions.onUpdateReview,
+        onDeleteReview: myPageActions.onDeleteReview,
+        onLoadMoreComments: myPageActions.onLoadMoreComments,
+      }}
+      panelActions={{
+        onChangeTab: myPageActions.onChangeMyPageTab,
+        onLogin: myPageActions.onLogin,
+        onRetry: myPageActions.onRetryMyPage,
+        onLogout: myPageActions.onLogout,
+        onSaveNickname: myPageActions.onSaveNickname,
+        onPublishRoute: myPageActions.onPublishRoute,
+      }}
+      adminData={{
+        adminSummary: myPageData.adminSummary,
+        adminBusyPlaceId: myPageData.adminBusyPlaceId,
+        adminLoading: myPageData.adminLoading,
+      }}
+      adminActions={{
+        onRefreshAdmin: myPageActions.onRefreshAdmin,
+        onToggleAdminPlace: myPageActions.onToggleAdminPlace,
+        onToggleAdminManualOverride: myPageActions.onToggleAdminManualOverride,
+      }}
+    />
+  );
+}


### PR DESCRIPTION
## Summary
- split MapTabStage chrome blocks into dedicated stage components
- split AppPageStage feed/course/my rendering into focused page-stage view components
- keep the existing stage contracts intact while reducing rendering responsibility per file

## Validation
- npm run typecheck
- npm run build
- npm run test:all