### PR TITLE
Fix broken UTF-8 copy

### DIFF
--- a/backend/app/repositories/admin_data_repository.py
+++ b/backend/app/repositories/admin_data_repository.py
@@ -39,7 +39,7 @@ def update_place_visibility(
 ) -> AdminPlaceOut:
     place = db.scalars(select(MapPlace).where(MapPlace.slug == place_id)).first()
     if not place:
-        raise ValueError("?μ냼瑜?李얠쓣 ???놁뼱??")
+        raise ValueError("장소를 찾을 수 없어요.")
 
     changed = False
     if is_active is not None and place.is_active != is_active:
@@ -58,4 +58,3 @@ def update_place_visibility(
 
 def import_public_bundle(db: Session, settings: Settings) -> PublicImportResponse:
     return sync_public_bundle(db, settings)
-

--- a/backend/app/repositories/notification_data_repository.py
+++ b/backend/app/repositories/notification_data_repository.py
@@ -104,7 +104,7 @@ def mark_notification_read(db: Session, notification_id: str, user_id: str) -> N
     try:
         notification_key = int(notification_id)
     except ValueError as error:
-        raise ValueError("?뚮┝ ID ?뺤떇???щ컮瑜댁? ?딆븘??") from error
+        raise ValueError("알림 ID 형식이 올바르지 않아요.") from error
 
     notification = db.scalars(
         select(UserNotification).where(
@@ -113,7 +113,7 @@ def mark_notification_read(db: Session, notification_id: str, user_id: str) -> N
         )
     ).first()
     if not notification:
-        raise ValueError("?뚮┝??李얠? 紐삵뻽?댁슂.")
+        raise ValueError("알림을 찾지 못했어요.")
     if not notification.is_read:
         notification.is_read = True
         notification.read_at = utcnow_naive()
@@ -141,7 +141,7 @@ def delete_notification(db: Session, notification_id: str, user_id: str) -> Noti
     try:
         notification_key = int(notification_id)
     except ValueError as error:
-        raise ValueError("?뚮┝ ID ?뺤떇???щ컮瑜댁? ?딆븘??") from error
+        raise ValueError("알림 ID 형식이 올바르지 않아요.") from error
 
     notification = db.scalars(
         select(UserNotification).where(
@@ -150,8 +150,7 @@ def delete_notification(db: Session, notification_id: str, user_id: str) -> Noti
         )
     ).first()
     if not notification:
-        raise ValueError("?뚮┝??李얠? 紐삵뻽?댁슂.")
+        raise ValueError("알림을 찾지 못했어요.")
     db.delete(notification)
     db.commit()
     return NotificationDeleteResponse(notificationId=str(notification_key), deleted=True)
-

--- a/src/components/CommentThread.tsx
+++ b/src/components/CommentThread.tsx
@@ -20,7 +20,7 @@ export function CommentThread({
       <CommentComposer
         key={reviewId}
         canWriteComment={canWriteComment}
-        placeholder="?볤? ?댁슜???곸뼱 蹂댁꽭??"
+        placeholder="댓글 내용을 적어 보세요."
         reviewId={reviewId}
         submittingReviewId={submittingReviewId}
         onRequestLogin={onRequestLogin}

--- a/src/components/comment-thread/CommentComposer.tsx
+++ b/src/components/comment-thread/CommentComposer.tsx
@@ -35,7 +35,7 @@ export const CommentComposer = memo(function CommentComposer({
     <form className="comment-thread__reply-form" onSubmit={handleSubmit}>
       <input value={body} onChange={(event) => setBody(event.target.value)} placeholder={placeholder} />
       <button type="submit" className="comment-thread__submit" disabled={isSubmitting || body.trim().length < 2}>
-        {isSubmitting ? "?깅줉 以?" : "?깅줉"}
+        {isSubmitting ? '등록 중' : '등록'}
       </button>
     </form>
   );

--- a/src/components/comment-thread/CommentThreadItem.tsx
+++ b/src/components/comment-thread/CommentThreadItem.tsx
@@ -52,7 +52,7 @@ export const CommentThreadItem = memo(function CommentThreadItem({
   }
 
   async function handleDelete() {
-    if (!window.confirm('?볤?????젣?좉퉴??')) {
+    if (!window.confirm('댓글을 삭제할까요?')) {
       return;
     }
 
@@ -72,7 +72,7 @@ export const CommentThreadItem = memo(function CommentThreadItem({
     <li ref={itemRef} className={isReply ? 'comment-thread__item comment-thread__item--reply' : 'comment-thread__item'}>
       {isReply && (
         <span className="comment-thread__reply-indent" aria-hidden="true">
-          ??
+          ㄴ
         </span>
       )}
 
@@ -88,30 +88,30 @@ export const CommentThreadItem = memo(function CommentThreadItem({
               <input
                 value={editingBody}
                 onChange={(event) => setEditingBody(event.target.value)}
-                placeholder="?볤? ?댁슜???섏젙??蹂댁꽭??"
+                placeholder="댓글 내용을 수정해 보세요."
               />
               <button type="submit" className="comment-thread__submit" disabled={isMutating || editingBody.trim().length < 2}>
-                {isMutating ? "?섏젙 以?" : "?섏젙"}
+                {isMutating ? '수정 중' : '수정'}
               </button>
             </form>
           ) : (
-            <p>{comment.isDeleted ? '??젣???볤??낅땲??' : comment.body}</p>
+            <p>{comment.isDeleted ? '삭제된 댓글입니다.' : comment.body}</p>
           )}
 
           {!comment.isDeleted && (
             <div className="comment-thread__actions">
               {canWriteComment && (
                 <button type="button" className="comment-thread__reply-toggle" onClick={handleReplyToggle}>
-                  ?듦? ?ш린
+                  답글 달기
                 </button>
               )}
               {isMine && !editing && (
                 <>
                   <button type="button" className="comment-thread__reply-toggle" onClick={() => setEditing(true)}>
-                    ?섏젙
+                    수정
                   </button>
                   <button type="button" className="comment-thread__reply-toggle" onClick={() => void handleDelete()} disabled={isMutating}>
-                    ??젣
+                    삭제
                   </button>
                 </>
               )}
@@ -124,7 +124,7 @@ export const CommentThreadItem = memo(function CommentThreadItem({
                     setEditingBody(comment.body);
                   }}
                 >
-                  痍⑥냼
+                  취소
                 </button>
               )}
             </div>
@@ -134,7 +134,7 @@ export const CommentThreadItem = memo(function CommentThreadItem({
         {!isReply && replyOpen && (
           <CommentComposer
             canWriteComment={canWriteComment}
-            placeholder="?듦? ?댁슜???곸뼱 蹂댁꽭??"
+            placeholder="답글 내용을 적어 보세요."
             reviewId={reviewId}
             submittingReviewId={submittingReviewId}
             onRequestLogin={onRequestLogin}


### PR DESCRIPTION
## Summary
- restore broken UTF-8 copy in comment-thread components
- restore broken UTF-8 copy in admin and notification repositories

## Validation
- npm run typecheck
- npm run build
- npm run test:all