### PR TITLE
Build pytest security bump

### DIFF
--- a/backend/requirements.local.txt
+++ b/backend/requirements.local.txt
@@ -9,4 +9,4 @@ itsdangerous==2.2.0
 cryptography==46.0.7
 PyJWT==2.12.0
 python-multipart==0.0.26
-pytest==8.3.4
+pytest==9.0.3


### PR DESCRIPTION
## Summary
- bump pytest from 8.3.4 to 9.0.3 to address the tmpdir vulnerability
- verify backend tests under pytest 9.0.3

## Validation
- py -3.14 -m pytest tests
- npm run build
- npm run typecheck