### PR TITLE
Refactor app route state helpers

### DIFF
--- a/src/hooks/app-route/authQueryState.ts
+++ b/src/hooks/app-route/authQueryState.ts
@@ -1,0 +1,78 @@
+import type { Tab } from '../../types';
+
+type RouteDrawerState = 'closed' | 'partial' | 'full';
+
+export type InitialRouteState = {
+  tab: Tab;
+  placeId: string | null;
+  festivalId: string | null;
+  drawerState: RouteDrawerState;
+};
+
+const validTabs: Tab[] = ['map', 'event', 'feed', 'course', 'my'];
+
+export function getInitialRouteState(): InitialRouteState {
+  if (typeof window === 'undefined') {
+    return { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const tab = params.get('tab');
+  const placeId = params.get('place');
+  const festivalId = params.get('festival');
+  const drawer = params.get('drawer');
+  const resolvedTab = tab && validTabs.includes(tab as Tab) ? (tab as Tab) : params.get('auth') ? 'my' : 'map';
+  const resolvedDrawer = drawer === 'full' || drawer === 'partial' ? drawer : placeId || festivalId ? 'partial' : 'closed';
+
+  return {
+    tab: resolvedTab,
+    placeId: placeId || null,
+    festivalId: festivalId || null,
+    drawerState: resolvedDrawer,
+  };
+}
+
+export function getInitialNotice() {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const auth = params.get('auth');
+  const reason = params.get('reason');
+  if (auth === 'naver-success') {
+    return '네이버 로그인을 완료했어요.';
+  }
+  if (auth === 'naver-linked') {
+    return '네이버 계정을 연결했어요.';
+  }
+  if (auth === 'naver-error') {
+    return reason ? `네이버 로그인에 실패했어요. (${reason})` : '네이버 로그인에 실패했어요.';
+  }
+  return null;
+}
+
+export function clearAuthQueryParams() {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  if (!params.has('auth') && !params.has('reason')) {
+    return;
+  }
+
+  params.delete('auth');
+  params.delete('reason');
+  const nextQuery = params.toString();
+  const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`;
+  window.history.replaceState(window.history.state ?? {}, '', nextUrl);
+}
+
+export function getLoginReturnUrl() {
+  if (typeof window === 'undefined') {
+    return 'http://localhost:8000/?tab=my';
+  }
+
+  return `${window.location.origin}/?tab=my`;
+}

--- a/src/hooks/app-route/mapViewportState.ts
+++ b/src/hooks/app-route/mapViewportState.ts
@@ -1,0 +1,37 @@
+export interface MapViewport {
+  lat: number;
+  lng: number;
+  zoom: number;
+}
+
+const DEFAULT_MAP_VIEWPORT: MapViewport = { lat: 36.3504, lng: 127.3845, zoom: 13 };
+
+export function getInitialMapViewport(): MapViewport {
+  if (typeof window === 'undefined') {
+    return { ...DEFAULT_MAP_VIEWPORT };
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  const lat = parseFloat(params.get('lat') ?? '');
+  const lng = parseFloat(params.get('lng') ?? '');
+  const zoom = parseInt(params.get('z') ?? '', 10);
+
+  return {
+    lat: Number.isFinite(lat) ? lat : DEFAULT_MAP_VIEWPORT.lat,
+    lng: Number.isFinite(lng) ? lng : DEFAULT_MAP_VIEWPORT.lng,
+    zoom: Number.isFinite(zoom) ? zoom : DEFAULT_MAP_VIEWPORT.zoom,
+  };
+}
+
+export function updateMapViewportInUrl(lat: number, lng: number, zoom: number) {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  params.set('lat', lat.toFixed(5));
+  params.set('lng', lng.toFixed(5));
+  params.set('z', String(zoom));
+  const nextUrl = `${window.location.pathname}?${params.toString()}`;
+  window.history.replaceState(window.history.state, '', nextUrl);
+}

--- a/src/hooks/app-route/routeHistoryState.ts
+++ b/src/hooks/app-route/routeHistoryState.ts
@@ -1,0 +1,72 @@
+import type { DrawerState, RoutePreview, Tab } from '../../types';
+
+export type RouteState = {
+  tab: Tab;
+  placeId: string | null;
+  festivalId: string | null;
+  drawerState: DrawerState;
+};
+
+export type AppHistoryState = RouteState & {
+  routePreview: RoutePreview | null;
+};
+
+export type RouteStateCommitOptions = {
+  routePreview?: RoutePreview | null;
+};
+
+function isRoutePreview(value: unknown): value is RoutePreview {
+  if (!value || typeof value !== 'object') {
+    return false;
+  }
+
+  const candidate = value as Partial<RoutePreview>;
+  return typeof candidate.id === 'string'
+    && typeof candidate.title === 'string'
+    && typeof candidate.subtitle === 'string'
+    && typeof candidate.mood === 'string'
+    && Array.isArray(candidate.placeIds)
+    && Array.isArray(candidate.placeNames);
+}
+
+export function getRoutePreviewFromHistoryState(historyState: unknown): RoutePreview | null {
+  if (!historyState || typeof historyState !== 'object') {
+    return null;
+  }
+
+  const routePreview = (historyState as Partial<AppHistoryState>).routePreview;
+  return isRoutePreview(routePreview) ? routePreview : null;
+}
+
+export function buildHistoryState(routeState: RouteState, routePreview: RoutePreview | null): AppHistoryState {
+  return {
+    ...routeState,
+    routePreview: routePreview ?? null,
+  };
+}
+
+export function buildRouteUrl(routeState: RouteState) {
+  if (typeof window === 'undefined') {
+    return '/';
+  }
+
+  const params = new URLSearchParams(window.location.search);
+  params.set('tab', routeState.tab);
+
+  if (routeState.tab === 'map' && routeState.placeId) {
+    params.set('place', routeState.placeId);
+    params.delete('festival');
+    params.set('drawer', routeState.drawerState === 'closed' ? 'partial' : routeState.drawerState);
+  } else if (routeState.tab === 'map' && routeState.festivalId) {
+    params.set('festival', routeState.festivalId);
+    params.delete('place');
+    params.set('drawer', routeState.drawerState === 'closed' ? 'partial' : routeState.drawerState);
+  } else {
+    params.delete('place');
+    params.delete('festival');
+    params.delete('drawer');
+  }
+
+  const query = params.toString();
+  return `${window.location.pathname}${query ? `?${query}` : ''}`;
+}

--- a/src/hooks/useAppRouteState.ts
+++ b/src/hooks/useAppRouteState.ts
@@ -1,184 +1,37 @@
 import { useCallback, useEffect } from 'react';
 import { useAppMapStore } from '../store/app-map-store';
 import { useAppRouteStore } from '../store/app-route-store';
-import type { DrawerState, RoutePreview, Tab } from '../types';
+import type { RoutePreview, Tab } from '../types';
+import {
+  clearAuthQueryParams,
+  getInitialNotice,
+  getInitialRouteState,
+  getLoginReturnUrl,
+} from './app-route/authQueryState';
+import {
+  getInitialMapViewport,
+  updateMapViewportInUrl,
+  type MapViewport,
+} from './app-route/mapViewportState';
+import {
+  buildHistoryState,
+  buildRouteUrl,
+  getRoutePreviewFromHistoryState,
+  type AppHistoryState,
+  type RouteState,
+  type RouteStateCommitOptions,
+} from './app-route/routeHistoryState';
 
-export type RouteState = {
-  tab: Tab;
-  placeId: string | null;
-  festivalId: string | null;
-  drawerState: DrawerState;
+export {
+  clearAuthQueryParams,
+  getInitialMapViewport,
+  getInitialNotice,
+  getInitialRouteState,
+  getLoginReturnUrl,
+  updateMapViewportInUrl,
 };
-
-export type AppHistoryState = RouteState & {
-  routePreview: RoutePreview | null;
-};
-
-export type RouteStateCommitOptions = {
-  routePreview?: RoutePreview | null;
-};
-
-const validTabs: Tab[] = ['map', 'event', 'feed', 'course', 'my'];
-
-export function getInitialRouteState(): RouteState {
-  if (typeof window === 'undefined') {
-    return { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' };
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const tab = params.get('tab');
-  const placeId = params.get('place');
-  const festivalId = params.get('festival');
-  const drawer = params.get('drawer');
-  const resolvedTab = tab && validTabs.includes(tab as Tab) ? (tab as Tab) : params.get('auth') ? 'my' : 'map';
-  const resolvedDrawer = drawer === 'full' || drawer === 'partial' ? drawer : placeId || festivalId ? 'partial' : 'closed';
-
-  return {
-    tab: resolvedTab,
-    placeId: placeId || null,
-    festivalId: festivalId || null,
-    drawerState: resolvedDrawer,
-  };
-}
-
-function isRoutePreview(value: unknown): value is RoutePreview {
-  if (!value || typeof value !== 'object') {
-    return false;
-  }
-
-  const candidate = value as Partial<RoutePreview>;
-  return typeof candidate.id === 'string'
-    && typeof candidate.title === 'string'
-    && typeof candidate.subtitle === 'string'
-    && typeof candidate.mood === 'string'
-    && Array.isArray(candidate.placeIds)
-    && Array.isArray(candidate.placeNames);
-}
-
-export function getRoutePreviewFromHistoryState(historyState: unknown): RoutePreview | null {
-  if (!historyState || typeof historyState !== 'object') {
-    return null;
-  }
-
-  const routePreview = (historyState as Partial<AppHistoryState>).routePreview;
-  return isRoutePreview(routePreview) ? routePreview : null;
-}
-
-export function buildHistoryState(routeState: RouteState, routePreview: RoutePreview | null): AppHistoryState {
-  return {
-    ...routeState,
-    routePreview: routePreview ?? null,
-  };
-}
-
-export function buildRouteUrl(routeState: RouteState) {
-  if (typeof window === 'undefined') {
-    return '/';
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  params.set('tab', routeState.tab);
-
-  if (routeState.tab === 'map' && routeState.placeId) {
-    params.set('place', routeState.placeId);
-    params.delete('festival');
-    params.set('drawer', routeState.drawerState === 'closed' ? 'partial' : routeState.drawerState);
-  } else if (routeState.tab === 'map' && routeState.festivalId) {
-    params.set('festival', routeState.festivalId);
-    params.delete('place');
-    params.set('drawer', routeState.drawerState === 'closed' ? 'partial' : routeState.drawerState);
-  } else {
-    params.delete('place');
-    params.delete('festival');
-    params.delete('drawer');
-  }
-
-  const query = params.toString();
-  return `${window.location.pathname}${query ? `?${query}` : ''}`;
-}
-
-export function getInitialNotice() {
-  if (typeof window === 'undefined') {
-    return null;
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const auth = params.get('auth');
-  const reason = params.get('reason');
-  if (auth === 'naver-success') {
-    return '네이버 로그인을 연결했어요.';
-  }
-  if (auth === 'naver-linked') {
-    return '네이버 계정을 연결했어요.';
-  }
-  if (auth === 'naver-error') {
-    return reason ? `네이버 로그인에 실패했어요. (${reason})` : '네이버 로그인에 실패했어요.';
-  }
-  return null;
-}
-
-export function clearAuthQueryParams() {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  if (!params.has('auth') && !params.has('reason')) {
-    return;
-  }
-
-  params.delete('auth');
-  params.delete('reason');
-  const nextQuery = params.toString();
-  const nextUrl = `${window.location.pathname}${nextQuery ? `?${nextQuery}` : ''}`;
-  window.history.replaceState(window.history.state ?? {}, '', nextUrl);
-}
-
-export function getLoginReturnUrl() {
-  if (typeof window === 'undefined') {
-    return 'http://localhost:8000/?tab=my';
-  }
-
-  return `${window.location.origin}/?tab=my`;
-}
-
-export interface MapViewport {
-  lat: number;
-  lng: number;
-  zoom: number;
-}
-
-const DEFAULT_MAP_VIEWPORT: MapViewport = { lat: 36.3504, lng: 127.3845, zoom: 13 };
-
-export function getInitialMapViewport(): MapViewport {
-  if (typeof window === 'undefined') {
-    return { ...DEFAULT_MAP_VIEWPORT };
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  const lat = parseFloat(params.get('lat') ?? '');
-  const lng = parseFloat(params.get('lng') ?? '');
-  const zoom = parseInt(params.get('z') ?? '', 10);
-
-  return {
-    lat: Number.isFinite(lat) ? lat : DEFAULT_MAP_VIEWPORT.lat,
-    lng: Number.isFinite(lng) ? lng : DEFAULT_MAP_VIEWPORT.lng,
-    zoom: Number.isFinite(zoom) ? zoom : DEFAULT_MAP_VIEWPORT.zoom,
-  };
-}
-
-export function updateMapViewportInUrl(lat: number, lng: number, zoom: number) {
-  if (typeof window === 'undefined') {
-    return;
-  }
-
-  const params = new URLSearchParams(window.location.search);
-  params.set('lat', lat.toFixed(5));
-  params.set('lng', lng.toFixed(5));
-  params.set('z', String(zoom));
-  const nextUrl = `${window.location.pathname}?${params.toString()}`;
-  window.history.replaceState(window.history.state, '', nextUrl);
-}
+export type { AppHistoryState, MapViewport, RouteState, RouteStateCommitOptions };
+export { buildHistoryState, buildRouteUrl, getRoutePreviewFromHistoryState };
 
 let routeStoreInitialized = false;
 
@@ -186,6 +39,7 @@ function initializeRouteStore() {
   if (routeStoreInitialized || typeof window === 'undefined') {
     return;
   }
+
   const routeState = getInitialRouteState();
   useAppRouteStore.setState({
     activeTab: routeState.tab,

--- a/test/unit/useAppRouteState.test.ts
+++ b/test/unit/useAppRouteState.test.ts
@@ -15,7 +15,7 @@ const routeState: RouteState = {
 
 const routePreview: RoutePreview = {
   id: 'route-1',
-  title: '빵집 산책 코스',
+  title: '봄빛 산책 코스',
   subtitle: 'tester / 04. 05. 12:00',
   mood: '데이트',
   placeIds: ['place-1', 'place-2'],


### PR DESCRIPTION
## Summary
- split route-state helpers into auth query, viewport, and history modules
- keep useAppRouteState as the store wiring and history sync hook
- repair broken auth notice text and route-state test fixture encoding

## Validation
- python .tmp/check_utf8_integrity.py --staged
- npm run typecheck
- npm run build
- npm run test:unit -- useAppRouteState