### PR TITLE
Centralize storage backend wiring

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -3,7 +3,6 @@
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
-from fastapi.staticfiles import StaticFiles
 from starlette.middleware.sessions import SessionMiddleware
 
 from .config import get_settings
@@ -15,7 +14,13 @@ from .routers.content import router as content_router
 from .routers.my import router as my_router
 from .routers.reviews import router as reviews_router
 from .seed import seed_database
-from .storage import FileTooLargeError, InvalidFileTypeError, StorageConfigurationError, StorageUploadError
+from .storage import (
+    FileTooLargeError,
+    InvalidFileTypeError,
+    StorageConfigurationError,
+    StorageUploadError,
+    mount_storage_backend,
+)
 
 settings = get_settings()
 app = FastAPI(
@@ -39,9 +44,7 @@ app.add_middleware(
     max_age=60 * 60,
 )
 
-if settings.storage_backend == "local":
-    settings.upload_path.mkdir(parents=True, exist_ok=True)
-    app.mount(settings.upload_base_url, StaticFiles(directory=settings.upload_path), name="uploads")
+mount_storage_backend(app, settings)
 
 app.include_router(public_event_router)
 app.include_router(auth_router)
@@ -70,9 +73,6 @@ async def handle_storage_errors(_: Request, exc: ValueError) -> JSONResponse:
 @app.on_event("startup")
 def on_startup() -> None:
     """로컬 개발 환경에서는 업로드 경로와 데이터베이스를 준비합니다."""
-
-    if settings.storage_backend == "local":
-        settings.upload_path.mkdir(parents=True, exist_ok=True)
 
     if settings.env == "worker":
         return

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -9,6 +9,9 @@ from urllib.parse import quote
 from urllib.request import Request, urlopen
 from uuid import uuid4
 
+from fastapi import FastAPI
+from fastapi.staticfiles import StaticFiles
+
 from .config import Settings
 
 
@@ -236,8 +239,25 @@ class ReviewImageUploadService:
         )
 
 
+def uses_local_storage(settings: Settings) -> bool:
+    return settings.storage_backend == "local"
+
+
+def prepare_storage_backend(settings: Settings) -> None:
+    if uses_local_storage(settings):
+        settings.upload_path.mkdir(parents=True, exist_ok=True)
+
+
+def mount_storage_backend(app: FastAPI, settings: Settings) -> bool:
+    if not uses_local_storage(settings):
+        return False
+    prepare_storage_backend(settings)
+    app.mount(settings.upload_base_url, StaticFiles(directory=settings.upload_path), name="uploads")
+    return True
+
+
 def get_storage_adapter(settings: Settings):
-    if settings.storage_backend == "supabase":
+    if not uses_local_storage(settings):
         return SupabaseStorageAdapter(settings)
     return LocalStorageAdapter(settings)
 

--- a/backend/tests/test_storage.py
+++ b/backend/tests/test_storage.py
@@ -1,4 +1,6 @@
-﻿from pathlib import Path
+from pathlib import Path
+
+from fastapi import FastAPI
 
 from app import storage as storage_module
 from app.config import Settings
@@ -10,6 +12,8 @@ from app.storage import (
     SupabaseStorageAdapter,
     derive_review_thumbnail_url,
     get_storage_adapter,
+    mount_storage_backend,
+    prepare_storage_backend,
 )
 
 
@@ -139,3 +143,37 @@ def test_review_image_upload_service_saves_thumbnail_variant(tmp_path: Path):
     assert stored.thumbnail_url == derive_review_thumbnail_url(stored.url)
     assert (tmp_path / 'uploads' / stored.file_name).read_bytes() == b'original-bytes'
     assert (tmp_path / 'uploads' / stored.thumbnail_file_name).read_bytes() == b'thumb-bytes'
+
+
+def test_prepare_storage_backend_creates_local_upload_dir(tmp_path: Path):
+    settings = Settings(storage_backend='local', upload_dir=str(tmp_path / 'uploads'))
+
+    prepare_storage_backend(settings)
+
+    assert settings.upload_path.exists()
+    assert settings.upload_path.is_dir()
+
+
+def test_mount_storage_backend_mounts_uploads_for_local_storage(tmp_path: Path):
+    app = FastAPI()
+    settings = Settings(storage_backend='local', upload_dir=str(tmp_path / 'uploads'))
+
+    mounted = mount_storage_backend(app, settings)
+
+    assert mounted is True
+    assert settings.upload_path.exists()
+    assert any(getattr(route, 'name', None) == 'uploads' for route in app.routes)
+
+
+def test_mount_storage_backend_skips_non_local_storage():
+    app = FastAPI()
+    settings = Settings(
+        storage_backend='supabase',
+        supabase_url='https://project.supabase.co',
+        supabase_service_role_key='service-role-key',
+    )
+
+    mounted = mount_storage_backend(app, settings)
+
+    assert mounted is False
+    assert not any(getattr(route, 'name', None) == 'uploads' for route in app.routes)


### PR DESCRIPTION
## Summary
- centralize local storage mount and preparation in the storage module
- remove storage backend branching from app startup wiring
- add storage tests for local mount/skip behavior

## Validation
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py
- backend pytest tests
- backend pytest tests/test_storage.py tests/test_config_db.py
- backend ruff check backend/app backend/tests --select F401,F821