### PR TITLE
Split startup seed policy

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -6,14 +6,12 @@ from fastapi.responses import JSONResponse
 from starlette.middleware.sessions import SessionMiddleware
 
 from .config import get_settings
-from .db import Base, get_engine, get_session_factory
 from .public_event_api import router as public_event_router
 from .routers.admin import router as admin_router
 from .routers.auth import router as auth_router
 from .routers.content import router as content_router
 from .routers.my import router as my_router
 from .routers.reviews import router as reviews_router
-from .seed import seed_database
 from .storage import (
     FileTooLargeError,
     InvalidFileTypeError,
@@ -21,6 +19,7 @@ from .storage import (
     StorageUploadError,
     mount_storage_backend,
 )
+from .startup import run_startup_bootstrap
 
 settings = get_settings()
 app = FastAPI(
@@ -74,9 +73,4 @@ async def handle_storage_errors(_: Request, exc: ValueError) -> JSONResponse:
 def on_startup() -> None:
     """로컬 개발 환경에서는 업로드 경로와 데이터베이스를 준비합니다."""
 
-    if settings.env == "worker":
-        return
-
-    Base.metadata.create_all(bind=get_engine(settings))
-    with get_session_factory(settings)() as db:
-        seed_database(db, settings)
+    run_startup_bootstrap(settings)

--- a/backend/app/startup.py
+++ b/backend/app/startup.py
@@ -1,0 +1,28 @@
+"""Application startup policy helpers."""
+
+from __future__ import annotations
+
+from .config import Settings
+from .db import Base, get_engine, get_session_factory
+from .seed import seed_database
+
+
+def should_bootstrap_database(settings: Settings) -> bool:
+    return settings.env != "worker"
+
+
+def initialize_database_schema(settings: Settings) -> None:
+    Base.metadata.create_all(bind=get_engine(settings))
+
+
+def seed_application_data(settings: Settings) -> None:
+    with get_session_factory(settings)() as db:
+        seed_database(db, settings)
+
+
+def run_startup_bootstrap(settings: Settings) -> bool:
+    if not should_bootstrap_database(settings):
+        return False
+    initialize_database_schema(settings)
+    seed_application_data(settings)
+    return True

--- a/backend/tests/test_startup.py
+++ b/backend/tests/test_startup.py
@@ -1,0 +1,71 @@
+from app.config import Settings
+from app import startup as startup_module
+
+
+class DummySessionContext:
+    def __init__(self, session):
+        self._session = session
+
+    def __enter__(self):
+        return self._session
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+class DummySessionFactory:
+    def __init__(self, session):
+        self._session = session
+
+    def __call__(self):
+        return DummySessionContext(self._session)
+
+
+def test_run_startup_bootstrap_skips_worker_env(monkeypatch):
+    settings = Settings(env='worker')
+    called = {'create_all': False, 'seed': False}
+
+    monkeypatch.setattr(startup_module, 'initialize_database_schema', lambda _settings: called.__setitem__('create_all', True))
+    monkeypatch.setattr(startup_module, 'seed_application_data', lambda _settings: called.__setitem__('seed', True))
+
+    ran = startup_module.run_startup_bootstrap(settings)
+
+    assert ran is False
+    assert called == {'create_all': False, 'seed': False}
+
+
+def test_run_startup_bootstrap_initializes_schema_and_seed(monkeypatch):
+    settings = Settings()
+    calls: list[tuple[str, object]] = []
+    session = object()
+
+    def fake_get_engine(app_settings):
+        calls.append(('get_engine', app_settings))
+        return 'engine'
+
+    def fake_create_all(*, bind):
+        calls.append(('create_all', bind))
+
+    def fake_get_session_factory(app_settings):
+        calls.append(('get_session_factory', app_settings))
+        return DummySessionFactory(session)
+
+    def fake_seed_database(db, app_settings):
+        calls.append(('seed_database', db))
+        calls.append(('seed_settings', app_settings))
+
+    monkeypatch.setattr(startup_module, 'get_engine', fake_get_engine)
+    monkeypatch.setattr(startup_module.Base.metadata, 'create_all', fake_create_all)
+    monkeypatch.setattr(startup_module, 'get_session_factory', fake_get_session_factory)
+    monkeypatch.setattr(startup_module, 'seed_database', fake_seed_database)
+
+    ran = startup_module.run_startup_bootstrap(settings)
+
+    assert ran is True
+    assert calls == [
+        ('get_engine', settings),
+        ('create_all', 'engine'),
+        ('get_session_factory', settings),
+        ('seed_database', session),
+        ('seed_settings', settings),
+    ]


### PR DESCRIPTION
## Summary
- move startup database bootstrap policy into a dedicated startup module
- keep main.py focused on app wiring
- add tests for worker skip and schema+seed ordering

## Validation
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py
- backend pytest tests
- backend pytest tests/test_startup.py tests/test_storage.py tests/test_config_db.py
- backend ruff check app tests --select F401,F821