### PR TITLE
Add repository error contracts

### DIFF
--- a/backend/app/repositories/account_data_repository.py
+++ b/backend/app/repositories/account_data_repository.py
@@ -1,11 +1,12 @@
 from sqlalchemy.orm import Session
 
 from ..db_models import User
+from .errors import RepositoryNotFoundError
 
 
 def delete_account(db: Session, user_id: str) -> None:
     user = db.get(User, user_id)
     if not user:
-        raise ValueError("사용자 정보를 찾지 못했어요.")
+        raise RepositoryNotFoundError("사용자 정보를 찾지 못했어요.")
     db.delete(user)
     db.commit()

--- a/backend/app/repositories/errors.py
+++ b/backend/app/repositories/errors.py
@@ -1,0 +1,10 @@
+class RepositoryError(ValueError):
+    """Base repository contract error."""
+
+
+class RepositoryNotFoundError(RepositoryError):
+    """Raised when a requested entity is not present."""
+
+
+class RepositoryValidationError(RepositoryError):
+    """Raised when repository input or identifier validation fails."""

--- a/backend/app/repositories/my_page_data_repository.py
+++ b/backend/app/repositories/my_page_data_repository.py
@@ -6,6 +6,7 @@ from sqlalchemy.orm import Session, joinedload
 from ..db_models import Feed, MapPlace, User, UserComment
 from ..models import MyCommentOut, MyPageResponse, MyStatsOut
 from ..repository_support import format_datetime, to_place_out, to_session_user
+from .errors import RepositoryNotFoundError
 from .notification_data_repository import get_unread_notification_count, list_user_notifications
 from .review_query_repository import list_reviews
 from .stamp_data_repository import get_stamps
@@ -38,7 +39,7 @@ def build_my_comments(db: Session, user_id: str) -> list[MyCommentOut]:
 def get_my_page(db: Session, user_id: str, is_admin: bool) -> MyPageResponse:
     user = db.get(User, user_id)
     if not user:
-        raise ValueError("사용자 정보를 찾을 수 없어요.")
+        raise RepositoryNotFoundError("사용자 정보를 찾을 수 없어요.")
 
     reviews = list_reviews(db, user_id=user_id, current_user_id=user_id, include_comments=False)
     stamp_state = get_stamps(db, user_id)

--- a/backend/app/repositories/notification_data_repository.py
+++ b/backend/app/repositories/notification_data_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session, joinedload
 from ..db_models import UserNotification
 from ..models import NotificationDeleteResponse, NotificationReadResponse, UserNotificationOut
 from ..repository_support import format_datetime, utcnow_naive
+from .errors import RepositoryNotFoundError, RepositoryValidationError
 
 
 def to_notification_out(notification: UserNotification) -> UserNotificationOut:
@@ -104,7 +105,7 @@ def mark_notification_read(db: Session, notification_id: str, user_id: str) -> N
     try:
         notification_key = int(notification_id)
     except ValueError as error:
-        raise ValueError("알림 ID 형식이 올바르지 않아요.") from error
+        raise RepositoryValidationError("알림 ID 형식이 올바르지 않아요.") from error
 
     notification = db.scalars(
         select(UserNotification).where(
@@ -113,7 +114,7 @@ def mark_notification_read(db: Session, notification_id: str, user_id: str) -> N
         )
     ).first()
     if not notification:
-        raise ValueError("알림을 찾지 못했어요.")
+        raise RepositoryNotFoundError("알림을 찾지 못했어요.")
     if not notification.is_read:
         notification.is_read = True
         notification.read_at = utcnow_naive()
@@ -141,7 +142,7 @@ def delete_notification(db: Session, notification_id: str, user_id: str) -> Noti
     try:
         notification_key = int(notification_id)
     except ValueError as error:
-        raise ValueError("알림 ID 형식이 올바르지 않아요.") from error
+        raise RepositoryValidationError("알림 ID 형식이 올바르지 않아요.") from error
 
     notification = db.scalars(
         select(UserNotification).where(
@@ -150,7 +151,7 @@ def delete_notification(db: Session, notification_id: str, user_id: str) -> Noti
         )
     ).first()
     if not notification:
-        raise ValueError("알림을 찾지 못했어요.")
+        raise RepositoryNotFoundError("알림을 찾지 못했어요.")
     db.delete(notification)
     db.commit()
     return NotificationDeleteResponse(notificationId=str(notification_key), deleted=True)

--- a/backend/app/services/account_service.py
+++ b/backend/app/services/account_service.py
@@ -2,11 +2,12 @@ from fastapi import HTTPException, status
 from sqlalchemy.orm import Session
 
 from ..repositories.account_data_repository import delete_account as delete_account_entry
+from ..repositories.errors import RepositoryNotFoundError
 
 ACCOUNT_NOT_FOUND_MESSAGE = "사용자 정보를 찾지 못했어요."
 
 
-def _map_account_not_found(_: ValueError) -> HTTPException:
+def _map_account_not_found(_: RepositoryNotFoundError) -> HTTPException:
     return HTTPException(
         status_code=status.HTTP_404_NOT_FOUND,
         detail=ACCOUNT_NOT_FOUND_MESSAGE,
@@ -16,5 +17,5 @@ def _map_account_not_found(_: ValueError) -> HTTPException:
 def delete_my_account_service(db: Session, user_id: str) -> None:
     try:
         delete_account_entry(db, user_id)
-    except ValueError as error:
+    except RepositoryNotFoundError as error:
         raise _map_account_not_found(error) from error

--- a/backend/app/services/my_page_service.py
+++ b/backend/app/services/my_page_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from ..config import Settings
 from ..models import SessionUser
+from ..repositories.errors import RepositoryNotFoundError
 from ..repositories.my_page_data_repository import get_my_page as read_my_page_entry
 
 
@@ -15,7 +16,7 @@ def _raise_not_found(detail: str) -> None:
 def _run_not_found_policy(action: Callable[[], object]):
     try:
         return action()
-    except ValueError as error:
+    except RepositoryNotFoundError as error:
         _raise_not_found(str(error))
 
 

--- a/backend/app/services/notification_service.py
+++ b/backend/app/services/notification_service.py
@@ -5,6 +5,7 @@ from sqlalchemy.orm import Session
 
 from ..models import NotificationDeleteResponse, NotificationReadResponse, SessionUser, UserNotificationOut
 from ..notification_broker import notification_broker
+from ..repositories.errors import RepositoryNotFoundError, RepositoryValidationError
 from ..repositories.notification_repository import (
     delete_notification_entry,
     list_user_notification_entries,
@@ -14,8 +15,12 @@ from ..repositories.notification_repository import (
 )
 
 
-def _map_notification_not_found(error: ValueError) -> HTTPException:
+def _map_notification_not_found(error: RepositoryNotFoundError) -> HTTPException:
     return HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(error))
+
+
+def _map_notification_validation_error(error: RepositoryValidationError) -> HTTPException:
+    return HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(error))
 
 
 def _publish_notification_event(user_id: str, payload: dict[str, object]) -> None:
@@ -29,7 +34,9 @@ def read_notifications_service(db: Session, session_user: SessionUser) -> list[U
 def mark_notification_read_service(db: Session, notification_id: str, session_user: SessionUser) -> NotificationReadResponse:
     try:
         response = mark_notification_read_entry(db, notification_id, session_user.id)
-    except ValueError as error:
+    except RepositoryValidationError as error:
+        raise _map_notification_validation_error(error) from error
+    except RepositoryNotFoundError as error:
         raise _map_notification_not_found(error) from error
     unread_count = read_unread_notification_count(db, session_user.id)
     _publish_notification_event(
@@ -59,7 +66,9 @@ def mark_all_notifications_read_service(db: Session, session_user: SessionUser) 
 def delete_notification_service(db: Session, notification_id: str, session_user: SessionUser) -> NotificationDeleteResponse:
     try:
         response = delete_notification_entry(db, notification_id, session_user.id)
-    except ValueError as error:
+    except RepositoryValidationError as error:
+        raise _map_notification_validation_error(error) from error
+    except RepositoryNotFoundError as error:
         raise _map_notification_not_found(error) from error
     unread_count = read_unread_notification_count(db, session_user.id)
     _publish_notification_event(

--- a/backend/tests/test_account_service.py
+++ b/backend/tests/test_account_service.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException
 
+from app.repositories.errors import RepositoryNotFoundError
 from app.services import account_service
 
 
@@ -16,7 +17,7 @@ def test_delete_my_account_service_maps_value_error(monkeypatch):
     monkeypatch.setattr(
         account_service,
         "delete_account_entry",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("missing")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RepositoryNotFoundError("missing")),
     )
 
     try:

--- a/backend/tests/test_my_page_service.py
+++ b/backend/tests/test_my_page_service.py
@@ -5,6 +5,7 @@ from fastapi import HTTPException, status
 
 from app.config import Settings
 from app.models import SessionUser
+from app.repositories.errors import RepositoryNotFoundError
 from app.services import my_page_service
 
 
@@ -22,7 +23,7 @@ def build_session_user() -> SessionUser:
 
 def test_read_my_page_service_maps_missing_user_to_404(monkeypatch):
     def failing_read_my_page(*_args, **_kwargs):
-        raise ValueError("사용자를 찾을 수 없어요.")
+        raise RepositoryNotFoundError("사용자를 찾을 수 없어요.")
 
     monkeypatch.setattr(my_page_service, "read_my_page_entry", failing_read_my_page)
 

--- a/backend/tests/test_notification_service.py
+++ b/backend/tests/test_notification_service.py
@@ -1,5 +1,6 @@
 from fastapi import HTTPException
 
+from app.repositories.errors import RepositoryNotFoundError, RepositoryValidationError
 from app.services import notification_service
 
 
@@ -40,7 +41,7 @@ def test_delete_notification_service_maps_value_error(monkeypatch):
     monkeypatch.setattr(
         notification_service,
         "delete_notification_entry",
-        lambda *_args, **_kwargs: (_ for _ in ()).throw(ValueError("알림을 찾을 수 없어요.")),
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RepositoryNotFoundError("알림을 찾을 수 없어요.")),
     )
 
     try:
@@ -48,5 +49,22 @@ def test_delete_notification_service_maps_value_error(monkeypatch):
     except HTTPException as error:
         assert error.status_code == 404
         assert error.detail == "알림을 찾을 수 없어요."
+    else:
+        raise AssertionError("Expected HTTPException")
+
+
+def test_mark_notification_read_service_maps_validation_error(monkeypatch):
+    session_user = type("SessionUserLike", (), {"id": "user-1"})()
+    monkeypatch.setattr(
+        notification_service,
+        "mark_notification_read_entry",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(RepositoryValidationError("알림 ID 형식이 올바르지 않아요.")),
+    )
+
+    try:
+        notification_service.mark_notification_read_service("db-session", "bad-id", session_user)
+    except HTTPException as error:
+        assert error.status_code == 400
+        assert error.detail == "알림 ID 형식이 올바르지 않아요."
     else:
         raise AssertionError("Expected HTTPException")


### PR DESCRIPTION
## Summary
- add explicit repository error types for not-found and validation cases
- update account, my-page, and notification services to catch contract errors instead of generic ValueError
- add regression coverage for the new notification validation mapping

## Validation
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py
- backend pytest tests
- backend pytest tests/test_account_service.py tests/test_my_page_service.py tests/test_notification_service.py tests/test_repository.py
- backend ruff check app tests --select F401,F821