### PR TITLE
Refactor Daejeon event sync fetch and normalize boundaries

### DIFF
--- a/scripts/daejeon-event-sync/constants.ts
+++ b/scripts/daejeon-event-sync/constants.ts
@@ -1,0 +1,3 @@
+export const SEARCH_URL = 'https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504';
+export const DETAIL_BASE_URL = 'https://www.daejeon.go.kr/fvu/FvuEventView.do';
+export const SOURCE_NAME = 'Daejeon Official Event Search';

--- a/scripts/daejeon-event-sync/fetch.ts
+++ b/scripts/daejeon-event-sync/fetch.ts
@@ -1,0 +1,65 @@
+import { SEARCH_URL } from './constants';
+import { normalizeCollectedEvents, parseEventRows, parseMaxPage } from './normalize';
+import type { CollectedEvents, EventSyncRange, ImportedEvent } from './types';
+
+type EventListPageRequest = EventSyncRange & {
+  pageIndex: number;
+};
+
+export async function fetchEventListPage({ from, to, pageIndex }: EventListPageRequest) {
+  const body = new URLSearchParams({
+    menuSeq: '504',
+    pageIndex: String(pageIndex),
+    beginDt: from,
+    endDt: to,
+    themeCd: '',
+    placeCd: '',
+    targetCd: '',
+    managementCd: '',
+    searchKeyword: '',
+    eventSeq: '',
+  });
+
+  const response = await fetch(SEARCH_URL, {
+    method: 'POST',
+    headers: {
+      Accept: 'text/html',
+      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+    },
+    body: body.toString(),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Failed to fetch Daejeon event list (${response.status}).`);
+  }
+
+  return response.text();
+}
+
+function collectUniqueItems(pages: Array<{ html: string }>) {
+  const uniqueItems = new Map<string, ImportedEvent>();
+  for (const page of pages) {
+    for (const item of parseEventRows(page.html)) {
+      uniqueItems.set(item.externalId, item);
+    }
+  }
+  return [...uniqueItems.values()];
+}
+
+export async function collectEvents(range: EventSyncRange): Promise<CollectedEvents> {
+  const firstPageHtml = await fetchEventListPage({ ...range, pageIndex: 1 });
+  const maxPage = parseMaxPage(firstPageHtml);
+  const pages = [{ pageIndex: 1, html: firstPageHtml }];
+
+  for (let pageIndex = 2; pageIndex <= maxPage; pageIndex += 1) {
+    pages.push({
+      pageIndex,
+      html: await fetchEventListPage({ ...range, pageIndex }),
+    });
+  }
+
+  return {
+    pageCount: maxPage,
+    items: normalizeCollectedEvents(collectUniqueItems(pages)),
+  };
+}

--- a/scripts/daejeon-event-sync/normalize.ts
+++ b/scripts/daejeon-event-sync/normalize.ts
@@ -1,0 +1,234 @@
+import { DETAIL_BASE_URL } from './constants';
+import type { ImportedEvent } from './types';
+
+function escapeHtml(text: string) {
+  return String(text || '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+function stripHtml(text: string) {
+  return escapeHtml(String(text || '').replace(/<[^>]+>/g, ' '))
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function toStartOfDayIso(dateKey: string) {
+  return `${dateKey}T00:00:00+09:00`;
+}
+
+function toEndOfDayIso(dateKey: string) {
+  return `${dateKey}T23:59:59+09:00`;
+}
+
+function normalizeSeriesKeyPart(value: string | null | undefined) {
+  return String(value || '')
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[&_·/|]+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function toSeoulDateKey(value: string) {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+  return new Intl.DateTimeFormat('en-CA', {
+    timeZone: 'Asia/Seoul',
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  }).format(date);
+}
+
+function parseSeoulDateKey(dateKey: string) {
+  return new Date(`${dateKey}T00:00:00+09:00`);
+}
+
+function buildSeriesGroupingKey(item: ImportedEvent) {
+  return [
+    normalizeSeriesKeyPart(item.title),
+    normalizeSeriesKeyPart(item.venueName || item.roadAddress || ''),
+  ].join('|');
+}
+
+function areSeriesDatesAdjacent(leftEnd: string, rightStart: string) {
+  const leftKey = toSeoulDateKey(leftEnd);
+  const rightKey = toSeoulDateKey(rightStart);
+  if (!leftKey || !rightKey) {
+    return false;
+  }
+  const nextDate = parseSeoulDateKey(leftKey);
+  nextDate.setDate(nextDate.getDate() + 1);
+  return parseSeoulDateKey(rightKey).getTime() <= nextDate.getTime();
+}
+
+function areSeriesPeriodsMergeable(left: ImportedEvent, right: ImportedEvent) {
+  const leftStartTime = new Date(left.startsAt).getTime();
+  const leftEndTime = new Date(left.endsAt).getTime();
+  const rightStartTime = new Date(right.startsAt).getTime();
+  const rightEndTime = new Date(right.endsAt).getTime();
+  if (!Number.isFinite(leftStartTime) || !Number.isFinite(leftEndTime) || !Number.isFinite(rightStartTime) || !Number.isFinite(rightEndTime)) {
+    return false;
+  }
+  if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
+    return true;
+  }
+  return areSeriesDatesAdjacent(left.endsAt, right.startsAt);
+}
+
+function createSeriesExternalId(title: string, startsAt: string, venueName: string | null, roadAddress: string | null) {
+  const seed = `${normalizeSeriesKeyPart(title)}|${toSeoulDateKey(startsAt)}|${normalizeSeriesKeyPart(venueName || roadAddress || '')}`;
+  return `festival-${Buffer.from(seed).toString('base64url').slice(0, 22)}`;
+}
+
+function mergeRawPayload(left: ImportedEvent['rawPayload'], right: ImportedEvent['rawPayload']) {
+  return {
+    eventSeq: left.eventSeq,
+    theme: left.theme || right.theme,
+    venueName: left.venueName || right.venueName,
+    startDate: left.startDate || right.startDate,
+    endDate: left.endDate || right.endDate,
+    mergedEventSeqs: [...new Set([...(left.mergedEventSeqs || [left.eventSeq].filter(Boolean)), right.eventSeq].filter(Boolean))],
+  };
+}
+
+function mergeEventSeries(items: ImportedEvent[]) {
+  const sorted = [...items].sort((left, right) => {
+    const startDiff = new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime();
+    if (startDiff !== 0) {
+      return startDiff;
+    }
+    return left.title.localeCompare(right.title, 'ko');
+  });
+
+  const merged: ImportedEvent[] = [];
+  for (const item of sorted) {
+    const previous = merged[merged.length - 1];
+    if (
+      previous &&
+      buildSeriesGroupingKey(previous) === buildSeriesGroupingKey(item) &&
+      areSeriesPeriodsMergeable(previous, item)
+    ) {
+      if (new Date(item.endsAt).getTime() > new Date(previous.endsAt).getTime()) {
+        previous.endsAt = item.endsAt;
+      }
+      previous.summary = previous.summary || item.summary;
+      previous.rawPayload = mergeRawPayload(previous.rawPayload, item.rawPayload);
+      previous.externalId = createSeriesExternalId(
+        previous.title,
+        previous.startsAt,
+        previous.venueName || null,
+        previous.roadAddress || null,
+      );
+      continue;
+    }
+    merged.push({
+      ...item,
+      externalId: createSeriesExternalId(item.title, item.startsAt, item.venueName || null, item.roadAddress || null),
+      rawPayload: {
+        ...item.rawPayload,
+        mergedEventSeqs: [item.rawPayload.eventSeq].filter(Boolean),
+      },
+    });
+  }
+
+  return merged;
+}
+
+function deduplicateSeriesByExternalId(items: ImportedEvent[]) {
+  const grouped = new Map<string, ImportedEvent>();
+  for (const item of items) {
+    const key = String(item.externalId || '');
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { ...item });
+      continue;
+    }
+    if (new Date(item.startsAt).getTime() < new Date(existing.startsAt).getTime()) {
+      existing.startsAt = item.startsAt;
+    }
+    if (new Date(item.endsAt).getTime() > new Date(existing.endsAt).getTime()) {
+      existing.endsAt = item.endsAt;
+    }
+    if (!existing.summary && item.summary) {
+      existing.summary = item.summary;
+    }
+    existing.rawPayload = mergeRawPayload(existing.rawPayload, item.rawPayload);
+  }
+  return [...grouped.values()];
+}
+
+export function parseMaxPage(html: string) {
+  const pageNumbers = [...html.matchAll(/fn_link_page\((\d+)\)/g)].map((match) => Number(match[1]));
+  return pageNumbers.length > 0 ? Math.max(...pageNumbers) : 1;
+}
+
+export function parseEventRows(html: string) {
+  const tbodyMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
+  if (!tbodyMatch) {
+    return [];
+  }
+
+  const items: ImportedEvent[] = [];
+  const rowMatches = tbodyMatch[1].matchAll(/<tr>([\s\S]*?)<\/tr>/gi);
+  for (const rowMatch of rowMatches) {
+    const rowHtml = rowMatch[1];
+    const eventSeqMatch = rowHtml.match(/eventSeq=(\d+)/);
+    if (!eventSeqMatch) {
+      continue;
+    }
+
+    const cellMatches = [...rowHtml.matchAll(/<td\b[^>]*class="([^"]*)"[^>]*>([\s\S]*?)<\/td>/gi)];
+    const subjectCell = cellMatches.find((match) => match[1].includes('subject'));
+    const themeCell = cellMatches.find((match) => match[1].includes('theme'));
+    const locationCell = cellMatches.find((match) => match[1].includes('location'));
+    const dateCells = cellMatches.filter((match) => match[1].includes('date3'));
+
+    const title = stripHtml(subjectCell?.[2] ?? '');
+    const theme = stripHtml(themeCell?.[2] ?? '').replace(/^주제\s*:\s*/u, '').trim();
+    const venueName = stripHtml(locationCell?.[2] ?? '');
+    const startDate = stripHtml(dateCells[0]?.[2] ?? '');
+    const endDate = stripHtml(dateCells[1]?.[2] ?? '');
+    const eventSeq = eventSeqMatch[1];
+
+    if (!title || !startDate || !endDate) {
+      continue;
+    }
+
+    items.push({
+      externalId: `daejeon-event-${eventSeq}`,
+      title,
+      venueName: venueName || null,
+      district: '대전',
+      address: venueName || null,
+      roadAddress: venueName || null,
+      startsAt: toStartOfDayIso(startDate),
+      endsAt: toEndOfDayIso(endDate),
+      homepageUrl: `${DETAIL_BASE_URL}?eventSeq=${eventSeq}&menuSeq=504`,
+      latitude: null,
+      longitude: null,
+      summary: [theme, venueName].filter(Boolean).join(' · ') || '대전시 공식 행사안내 일정입니다.',
+      rawPayload: {
+        eventSeq,
+        theme,
+        venueName,
+        startDate,
+        endDate,
+      },
+    });
+  }
+
+  return items;
+}
+
+export function normalizeCollectedEvents(items: ImportedEvent[]) {
+  return deduplicateSeriesByExternalId(mergeEventSeries(items));
+}

--- a/scripts/daejeon-event-sync/types.ts
+++ b/scripts/daejeon-event-sync/types.ts
@@ -1,0 +1,34 @@
+export type EventSyncRange = {
+  from: string;
+  to: string;
+};
+
+export type DaejeonEventRawPayload = {
+  eventSeq: string;
+  theme: string;
+  venueName: string;
+  startDate: string;
+  endDate: string;
+  mergedEventSeqs?: string[];
+};
+
+export type ImportedEvent = {
+  externalId: string;
+  title: string;
+  venueName: string | null;
+  district: string;
+  address: string | null;
+  roadAddress: string | null;
+  startsAt: string;
+  endsAt: string;
+  homepageUrl: string;
+  latitude: null;
+  longitude: null;
+  summary: string;
+  rawPayload: DaejeonEventRawPayload;
+};
+
+export type CollectedEvents = {
+  pageCount: number;
+  items: ImportedEvent[];
+};

--- a/scripts/sync-daejeon-events.ts
+++ b/scripts/sync-daejeon-events.ts
@@ -1,12 +1,12 @@
-const SEARCH_URL = 'https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504';
-const DETAIL_BASE_URL = 'https://www.daejeon.go.kr/fvu/FvuEventView.do';
-const SOURCE_NAME = 'Daejeon Official Event Search';
+import { SEARCH_URL, SOURCE_NAME } from './daejeon-event-sync/constants';
+import { collectEvents } from './daejeon-event-sync/fetch';
+import type { EventSyncRange, ImportedEvent } from './daejeon-event-sync/types';
 
-function parseArgs(argv) {
+function parseArgs(argv: string[]) {
   const options = {
     dryRun: false,
-    from: null,
-    to: null,
+    from: null as string | null,
+    to: null as string | null,
   };
 
   for (let index = 0; index < argv.length; index += 1) {
@@ -46,14 +46,14 @@ function getSeoulDateParts(date = new Date()) {
   };
 }
 
-function formatUtcDateKey(date) {
+function formatUtcDateKey(date: Date) {
   const year = date.getUTCFullYear();
   const month = String(date.getUTCMonth() + 1).padStart(2, '0');
   const day = String(date.getUTCDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
 }
 
-function getDefaultRange() {
+function getDefaultRange(): EventSyncRange {
   const todayParts = getSeoulDateParts();
   const start = new Date(Date.UTC(todayParts.year, todayParts.month - 1, todayParts.day));
   const end = new Date(start);
@@ -64,285 +64,7 @@ function getDefaultRange() {
   };
 }
 
-function escapeHtml(text) {
-  return String(text || '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
-}
-
-function stripHtml(text) {
-  return escapeHtml(String(text || '').replace(/<[^>]+>/g, ' '))
-    .replace(/\s+/g, ' ')
-    .trim();
-}
-
-function toStartOfDayIso(dateKey) {
-  return `${dateKey}T00:00:00+09:00`;
-}
-
-function toEndOfDayIso(dateKey) {
-  return `${dateKey}T23:59:59+09:00`;
-}
-
-function normalizeSeriesKeyPart(value) {
-  return String(value || '')
-    .replace(/\[[^\]]*\]/g, ' ')
-    .replace(/\([^)]*\)/g, ' ')
-    .replace(/[&_·/|]+/g, ' ')
-    .replace(/\s{2,}/g, ' ')
-    .trim()
-    .toLowerCase();
-}
-
-function toSeoulDateKey(value) {
-  const date = new Date(value);
-  if (Number.isNaN(date.getTime())) {
-    return '';
-  }
-  return new Intl.DateTimeFormat('en-CA', {
-    timeZone: 'Asia/Seoul',
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).format(date);
-}
-
-function parseSeoulDateKey(dateKey) {
-  return new Date(`${dateKey}T00:00:00+09:00`);
-}
-
-function buildSeriesGroupingKey(item) {
-  return [
-    normalizeSeriesKeyPart(item.title),
-    normalizeSeriesKeyPart(item.venueName || item.roadAddress || ''),
-  ].join('|');
-}
-
-function areSeriesDatesAdjacent(leftEnd, rightStart) {
-  const leftKey = toSeoulDateKey(leftEnd);
-  const rightKey = toSeoulDateKey(rightStart);
-  if (!leftKey || !rightKey) {
-    return false;
-  }
-  const nextDate = parseSeoulDateKey(leftKey);
-  nextDate.setDate(nextDate.getDate() + 1);
-  return parseSeoulDateKey(rightKey).getTime() <= nextDate.getTime();
-}
-
-function areSeriesPeriodsMergeable(left, right) {
-  const leftStartTime = new Date(left.startsAt).getTime();
-  const leftEndTime = new Date(left.endsAt).getTime();
-  const rightStartTime = new Date(right.startsAt).getTime();
-  const rightEndTime = new Date(right.endsAt).getTime();
-  if (!Number.isFinite(leftStartTime) || !Number.isFinite(leftEndTime) || !Number.isFinite(rightStartTime) || !Number.isFinite(rightEndTime)) {
-    return false;
-  }
-  if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
-    return true;
-  }
-  return areSeriesDatesAdjacent(left.endsAt, right.startsAt);
-}
-
-function createSeriesExternalId(title, startsAt, venueName, roadAddress) {
-  const seed = `${normalizeSeriesKeyPart(title)}|${toSeoulDateKey(startsAt)}|${normalizeSeriesKeyPart(venueName || roadAddress || '')}`;
-  return `festival-${Buffer.from(seed).toString('base64url').slice(0, 22)}`;
-}
-
-function mergeEventSeries(items) {
-  const sorted = [...items].sort((left, right) => {
-    const startDiff = new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime();
-    if (startDiff !== 0) {
-      return startDiff;
-    }
-    return left.title.localeCompare(right.title, 'ko');
-  });
-
-  const merged = [];
-  for (const item of sorted) {
-    const previous = merged[merged.length - 1];
-    if (
-      previous &&
-      buildSeriesGroupingKey(previous) === buildSeriesGroupingKey(item) &&
-      areSeriesPeriodsMergeable(previous, item)
-    ) {
-      if (new Date(item.endsAt).getTime() > new Date(previous.endsAt).getTime()) {
-        previous.endsAt = item.endsAt;
-      }
-      previous.summary = previous.summary || item.summary;
-      previous.rawPayload = {
-        ...(previous.rawPayload || {}),
-        mergedEventSeqs: [...new Set([...(previous.rawPayload?.mergedEventSeqs || [previous.rawPayload?.eventSeq].filter(Boolean)), item.rawPayload?.eventSeq].filter(Boolean))],
-      };
-      previous.externalId = createSeriesExternalId(
-        previous.title,
-        previous.startsAt,
-        previous.venueName || null,
-        previous.roadAddress || null,
-      );
-      continue;
-    }
-    merged.push({
-      ...item,
-      externalId: createSeriesExternalId(item.title, item.startsAt, item.venueName || null, item.roadAddress || null),
-      rawPayload: {
-        ...(item.rawPayload || {}),
-        mergedEventSeqs: [item.rawPayload?.eventSeq].filter(Boolean),
-      },
-    });
-  }
-
-  return merged;
-}
-
-function deduplicateSeriesByExternalId(items) {
-  const grouped = new Map();
-  for (const item of items) {
-    const key = String(item.externalId || '');
-    const existing = grouped.get(key);
-    if (!existing) {
-      grouped.set(key, { ...item });
-      continue;
-    }
-    if (new Date(item.startsAt).getTime() < new Date(existing.startsAt).getTime()) {
-      existing.startsAt = item.startsAt;
-    }
-    if (new Date(item.endsAt).getTime() > new Date(existing.endsAt).getTime()) {
-      existing.endsAt = item.endsAt;
-    }
-    if (!existing.summary && item.summary) {
-      existing.summary = item.summary;
-    }
-    existing.rawPayload = {
-      ...(existing.rawPayload || {}),
-      mergedEventSeqs: [...new Set([...(existing.rawPayload?.mergedEventSeqs || []), ...(item.rawPayload?.mergedEventSeqs || []), item.rawPayload?.eventSeq].filter(Boolean))],
-    };
-  }
-  return [...grouped.values()];
-}
-
-function parseMaxPage(html) {
-  const pageNumbers = [...html.matchAll(/fn_link_page\((\d+)\)/g)].map((match) => Number(match[1]));
-  return pageNumbers.length > 0 ? Math.max(...pageNumbers) : 1;
-}
-
-function parseEventRows(html) {
-  const tbodyMatch = html.match(/<tbody>([\s\S]*?)<\/tbody>/i);
-  if (!tbodyMatch) {
-    return [];
-  }
-
-  const items = [];
-  const rowMatches = tbodyMatch[1].matchAll(/<tr>([\s\S]*?)<\/tr>/gi);
-  for (const rowMatch of rowMatches) {
-    const rowHtml = rowMatch[1];
-    const eventSeqMatch = rowHtml.match(/eventSeq=(\d+)/);
-    if (!eventSeqMatch) {
-      continue;
-    }
-
-    const cellMatches = [...rowHtml.matchAll(/<td\b[^>]*class="([^"]*)"[^>]*>([\s\S]*?)<\/td>/gi)];
-    const subjectCell = cellMatches.find((match) => match[1].includes('subject'));
-    const themeCell = cellMatches.find((match) => match[1].includes('theme'));
-    const locationCell = cellMatches.find((match) => match[1].includes('location'));
-    const dateCells = cellMatches.filter((match) => match[1].includes('date3'));
-
-    const title = stripHtml(subjectCell?.[2] ?? '');
-    const theme = stripHtml(themeCell?.[2] ?? '').replace(/^추천\s*:\s*/u, '').trim();
-    const venueName = stripHtml(locationCell?.[2] ?? '');
-    const startDate = stripHtml(dateCells[0]?.[2] ?? '');
-    const endDate = stripHtml(dateCells[1]?.[2] ?? '');
-    const eventSeq = eventSeqMatch[1];
-
-    if (!title || !startDate || !endDate) {
-      continue;
-    }
-
-    items.push({
-      externalId: `daejeon-event-${eventSeq}`,
-      title,
-      venueName: venueName || null,
-      district: '대전',
-      address: venueName || null,
-      roadAddress: venueName || null,
-      startsAt: toStartOfDayIso(startDate),
-      endsAt: toEndOfDayIso(endDate),
-      homepageUrl: `${DETAIL_BASE_URL}?eventSeq=${eventSeq}&menuSeq=504`,
-      latitude: null,
-      longitude: null,
-      summary: [theme, venueName].filter(Boolean).join(' · ') || '대전시 공식 행사안내 일정입니다.',
-      rawPayload: {
-        eventSeq,
-        theme,
-        venueName,
-        startDate,
-        endDate,
-      },
-    });
-  }
-
-  return items;
-}
-
-async function fetchEventListPage({ from, to, pageIndex }) {
-  const body = new URLSearchParams({
-    menuSeq: '504',
-    pageIndex: String(pageIndex),
-    beginDt: from,
-    endDt: to,
-    themeCd: '',
-    placeCd: '',
-    targetCd: '',
-    managementCd: '',
-    searchKeyword: '',
-    eventSeq: '',
-  });
-
-  const response = await fetch(SEARCH_URL, {
-    method: 'POST',
-    headers: {
-      Accept: 'text/html',
-      'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
-    },
-    body: body.toString(),
-  });
-
-  if (!response.ok) {
-    throw new Error(`Failed to fetch Daejeon event list (${response.status}).`);
-  }
-
-  return response.text();
-}
-
-async function collectEvents(range) {
-  const firstPageHtml = await fetchEventListPage({ ...range, pageIndex: 1 });
-  const maxPage = parseMaxPage(firstPageHtml);
-  const pages = [{ pageIndex: 1, html: firstPageHtml }];
-
-  for (let pageIndex = 2; pageIndex <= maxPage; pageIndex += 1) {
-    pages.push({
-      pageIndex,
-      html: await fetchEventListPage({ ...range, pageIndex }),
-    });
-  }
-
-  const uniqueItems = new Map();
-  for (const page of pages) {
-    for (const item of parseEventRows(page.html)) {
-      uniqueItems.set(item.externalId, item);
-    }
-  }
-
-  return {
-    pageCount: maxPage,
-    items: deduplicateSeriesByExternalId(mergeEventSeries([...uniqueItems.values()])),
-  };
-}
-
-async function uploadEvents(items, range) {
+async function uploadEvents(items: ImportedEvent[], range: EventSyncRange) {
   const importUrl = String(process.env.PUBLIC_EVENT_IMPORT_URL || '').trim();
   const token = String(process.env.EVENT_IMPORT_TOKEN || '').trim();
 
@@ -377,7 +99,7 @@ async function uploadEvents(items, range) {
 async function main() {
   const options = parseArgs(process.argv.slice(2));
   const defaultRange = getDefaultRange();
-  const range = {
+  const range: EventSyncRange = {
     from: options.from || defaultRange.from,
     to: options.to || defaultRange.to,
   };


### PR DESCRIPTION
## Summary
- split Daejeon event sync page fetching into a dedicated fetch module
- move row parsing and series normalization into dedicated normalization helpers
- keep the entry script focused on args, range selection, and upload orchestration

## Validation
- npm run lint -- scripts/sync-daejeon-events.ts scripts/daejeon-event-sync
- npm run typecheck
- npm run build
- npm run test:unit -- smoke-checks
- python .tmp/check_utf8_integrity.py