### PR TITLE
Refactor app bootstrap lifecycle boundaries

### DIFF
--- a/src/hooks/useAppBootstrapEffects.ts
+++ b/src/hooks/useAppBootstrapEffects.ts
@@ -1,0 +1,169 @@
+import { useEffect } from 'react';
+import type { Dispatch, SetStateAction } from 'react';
+import { getFestivals, getMapBootstrap } from '../api/bootstrapClient';
+import type {
+  FestivalItem,
+  MyPageResponse,
+  Place,
+  SessionUser,
+  StampState,
+} from '../types';
+import { clearAuthQueryParams } from './useAppRouteState';
+import type { AppBootstrapSharedRefs } from './useAppBootstrapSharedRefs';
+
+type SetProviders = (providers: Array<{ key: 'naver' | 'kakao'; label: string; isEnabled: boolean; loginUrl: string | null }>) => void;
+
+interface UseMapBootstrapEffectParams extends AppBootstrapSharedRefs {
+  setBootstrapStatus: (status: 'idle' | 'loading' | 'ready' | 'error') => void;
+  setBootstrapError: (message: string | null) => void;
+  setPlaces: Dispatch<SetStateAction<Place[]>>;
+  setStampState: Dispatch<SetStateAction<StampState>>;
+  setHasRealData: Dispatch<SetStateAction<boolean>>;
+  setSessionUser: (user: SessionUser | null) => void;
+  setFeedNextCursor: (cursor: string | null) => void;
+  setFeedHasMore: (value: boolean) => void;
+  setFeedLoadingMore: (value: boolean) => void;
+  setMyCommentsNextCursor: (cursor: string | null) => void;
+  setMyCommentsHasMore: (value: boolean) => void;
+  setMyCommentsLoadingMore: (value: boolean) => void;
+  setMyCommentsLoadedOnce: (value: boolean) => void;
+  setProviders: SetProviders;
+  setSelectedPlaceId: (updater: (current: string | null) => string | null) => void;
+  setSelectedFestivalId: (updater: (current: string | null) => string | null) => void;
+  setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
+  setNotice: (message: string | null) => void;
+}
+
+export function useMapBootstrapEffect({
+  refreshMyPageForUserRef,
+  resetReviewCachesRef,
+  goToTabRef,
+  formatErrorMessageRef,
+  setBootstrapStatus,
+  setBootstrapError,
+  setPlaces,
+  setStampState,
+  setHasRealData,
+  setSessionUser,
+  setFeedNextCursor,
+  setFeedHasMore,
+  setFeedLoadingMore,
+  setMyCommentsNextCursor,
+  setMyCommentsHasMore,
+  setMyCommentsLoadingMore,
+  setMyCommentsLoadedOnce,
+  setProviders,
+  setSelectedPlaceId,
+  setSelectedFestivalId,
+  setMyPage,
+  setNotice,
+}: UseMapBootstrapEffectParams) {
+  useEffect(() => {
+    let active = true;
+
+    void (async () => {
+      const authParams = typeof window === 'undefined' ? null : new URLSearchParams(window.location.search);
+      const authState = authParams?.get('auth');
+
+      setBootstrapStatus('loading');
+      setBootstrapError(null);
+
+      try {
+        const bootstrap = await getMapBootstrap();
+        if (!active) {
+          return;
+        }
+
+        setPlaces(bootstrap.places);
+        setStampState(bootstrap.stamps);
+        setHasRealData(bootstrap.hasRealData);
+        setSessionUser(bootstrap.auth.user);
+        resetReviewCachesRef.current();
+        setFeedNextCursor(null);
+        setFeedHasMore(false);
+        setFeedLoadingMore(false);
+        setMyCommentsNextCursor(null);
+        setMyCommentsHasMore(false);
+        setMyCommentsLoadingMore(false);
+        setMyCommentsLoadedOnce(false);
+        setProviders(bootstrap.auth.providers);
+        setSelectedPlaceId((current) => (current && bootstrap.places.some((place) => place.id === current) ? current : null));
+        setSelectedFestivalId(() => null);
+
+        if (bootstrap.auth.user) {
+          await refreshMyPageForUserRef.current(bootstrap.auth.user, true);
+          if (!active) {
+            return;
+          }
+        } else {
+          setMyPage(null);
+        }
+
+        setBootstrapStatus('ready');
+        if ((authState === 'naver-success' || authState === 'kakao-success') && bootstrap.auth.user?.profileCompletedAt === null) {
+          goToTabRef.current('my');
+          setNotice('닉네임을 먼저 정하면 같은 계정으로 스탬프와 리뷰를 이어서 쌓을 수 있어요.');
+        }
+      } catch (error) {
+        setBootstrapError(formatErrorMessageRef.current(error));
+        setBootstrapStatus('error');
+      } finally {
+        clearAuthQueryParams();
+      }
+    })();
+
+    return () => {
+      active = false;
+    };
+  }, [
+    formatErrorMessageRef,
+    goToTabRef,
+    refreshMyPageForUserRef,
+    resetReviewCachesRef,
+    setBootstrapError,
+    setBootstrapStatus,
+    setFeedHasMore,
+    setFeedLoadingMore,
+    setFeedNextCursor,
+    setHasRealData,
+    setMyCommentsHasMore,
+    setMyCommentsLoadedOnce,
+    setMyCommentsLoadingMore,
+    setMyCommentsNextCursor,
+    setMyPage,
+    setNotice,
+    setPlaces,
+    setProviders,
+    setSelectedFestivalId,
+    setSelectedPlaceId,
+    setSessionUser,
+    setStampState,
+  ]);
+}
+
+export function useFestivalBootstrapEffect({
+  reportBackgroundErrorRef,
+  setFestivals,
+  setSelectedFestivalId,
+}: Pick<AppBootstrapSharedRefs, 'reportBackgroundErrorRef'> & {
+  setFestivals: Dispatch<SetStateAction<FestivalItem[]>>;
+  setSelectedFestivalId: (updater: (current: string | null) => string | null) => void;
+}) {
+  useEffect(() => {
+    let active = true;
+
+    void getFestivals()
+      .then((festivalResult) => {
+        if (!active) {
+          return;
+        }
+        setFestivals(festivalResult);
+        setSelectedFestivalId((current) => (current && festivalResult.some((festival) => festival.id === current) ? current : null));
+      })
+      .catch((error) => reportBackgroundErrorRef.current(error));
+
+    return () => {
+      active = false;
+    };
+  }, [reportBackgroundErrorRef, setFestivals, setSelectedFestivalId]);
+}

--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -1,13 +1,12 @@
-import { useEffect, useRef } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import { getFestivals, getMapBootstrap } from '../api/bootstrapClient';
 import { useAuthStore } from '../store/auth-store';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
 import { useAppRouteStore } from '../store/app-route-store';
 import { useAppTabWarmup } from './useAppTabWarmup';
 import { useSelectedPlaceReviewSync } from './useSelectedPlaceReviewSync';
-import { clearAuthQueryParams } from './useAppRouteState';
+import { useAppBootstrapSharedRefs } from './useAppBootstrapSharedRefs';
+import { useFestivalBootstrapEffect, useMapBootstrapEffect } from './useAppBootstrapEffects';
 import type {
   AdminSummaryResponse,
   FestivalItem,
@@ -87,31 +86,13 @@ export function useAppBootstrapLifecycle({
   const setMyCommentsLoadingMore = useAppPageRuntimeStore((state) => state.setMyCommentsLoadingMore);
   const setMyCommentsLoadedOnce = useAppPageRuntimeStore((state) => state.setMyCommentsLoadedOnce);
 
-  const refreshMyPageForUserRef = useRef(refreshMyPageForUser);
-  const resetReviewCachesRef = useRef(resetReviewCaches);
-  const goToTabRef = useRef(goToTab);
-  const formatErrorMessageRef = useRef(formatErrorMessage);
-  const reportBackgroundErrorRef = useRef(reportBackgroundError);
-
-  useEffect(() => {
-    refreshMyPageForUserRef.current = refreshMyPageForUser;
-  }, [refreshMyPageForUser]);
-
-  useEffect(() => {
-    resetReviewCachesRef.current = resetReviewCaches;
-  }, [resetReviewCaches]);
-
-  useEffect(() => {
-    goToTabRef.current = goToTab;
-  }, [goToTab]);
-
-  useEffect(() => {
-    formatErrorMessageRef.current = formatErrorMessage;
-  }, [formatErrorMessage]);
-
-  useEffect(() => {
-    reportBackgroundErrorRef.current = reportBackgroundError;
-  }, [reportBackgroundError]);
+  const sharedRefs = useAppBootstrapSharedRefs({
+    refreshMyPageForUser,
+    resetReviewCaches,
+    goToTab,
+    formatErrorMessage,
+    reportBackgroundError,
+  });
 
   useSelectedPlaceReviewSync({
     activeTab,
@@ -137,92 +118,31 @@ export function useAppBootstrapLifecycle({
     reportBackgroundError,
   });
 
-  useEffect(() => {
-    let active = true;
-
-    void (async () => {
-      const authParams = typeof window === 'undefined' ? null : new URLSearchParams(window.location.search);
-      const authState = authParams?.get('auth');
-
-      setBootstrapStatus('loading');
-      setBootstrapError(null);
-
-      try {
-        const bootstrap = await getMapBootstrap();
-        if (!active) {
-          return;
-        }
-
-        setPlaces(bootstrap.places);
-        setStampState(bootstrap.stamps);
-        setHasRealData(bootstrap.hasRealData);
-        setSessionUser(bootstrap.auth.user);
-        resetReviewCachesRef.current();
-        setFeedNextCursor(null);
-        setFeedHasMore(false);
-        setFeedLoadingMore(false);
-        setMyCommentsNextCursor(null);
-        setMyCommentsHasMore(false);
-        setMyCommentsLoadingMore(false);
-        setMyCommentsLoadedOnce(false);
-        setProviders(bootstrap.auth.providers);
-        setSelectedPlaceId((current) => (current && bootstrap.places.some((place) => place.id === current) ? current : null));
-        setSelectedFestivalId(null);
-
-        if (bootstrap.auth.user) {
-          await refreshMyPageForUserRef.current(bootstrap.auth.user, true);
-          if (!active) {
-            return;
-          }
-        } else {
-          setMyPage(null);
-        }
-
-        setBootstrapStatus('ready');
-        if ((authState === 'naver-success' || authState === 'kakao-success') && bootstrap.auth.user?.profileCompletedAt === null) {
-          goToTabRef.current('my');
-          setNotice('닉네임을 먼저 정하면 같은 계정으로 스탬프와 피드를 이어서 남길 수 있어요.');
-        }
-      } catch (error) {
-        setBootstrapError(formatErrorMessageRef.current(error));
-        setBootstrapStatus('error');
-      } finally {
-        clearAuthQueryParams();
-      }
-    })();
-
-    void getFestivals()
-      .then((festivalResult) => {
-        if (!active) {
-          return;
-        }
-        setFestivals(festivalResult);
-        setSelectedFestivalId((current) => (current && festivalResult.some((festival) => festival.id === current) ? current : null));
-      })
-      .catch((error) => reportBackgroundErrorRef.current(error));
-
-    return () => {
-      active = false;
-    };
-  }, [
-    setBootstrapError,
+  useMapBootstrapEffect({
+    ...sharedRefs,
     setBootstrapStatus,
+    setBootstrapError,
+    setPlaces,
+    setStampState,
+    setHasRealData,
+    setSessionUser,
+    setFeedNextCursor,
     setFeedHasMore,
     setFeedLoadingMore,
-    setFeedNextCursor,
-    setFestivals,
-    setHasRealData,
-    setMyCommentsHasMore,
-    setMyCommentsLoadedOnce,
-    setMyCommentsLoadingMore,
     setMyCommentsNextCursor,
+    setMyCommentsHasMore,
+    setMyCommentsLoadingMore,
+    setMyCommentsLoadedOnce,
+    setProviders,
+    setSelectedPlaceId,
+    setSelectedFestivalId,
     setMyPage,
     setNotice,
-    setPlaces,
-    setProviders,
+  });
+
+  useFestivalBootstrapEffect({
+    reportBackgroundErrorRef: sharedRefs.reportBackgroundErrorRef,
+    setFestivals,
     setSelectedFestivalId,
-    setSelectedPlaceId,
-    setSessionUser,
-    setStampState,
-  ]);
+  });
 }

--- a/src/hooks/useAppBootstrapSharedRefs.ts
+++ b/src/hooks/useAppBootstrapSharedRefs.ts
@@ -1,0 +1,65 @@
+import { useEffect, useRef } from 'react';
+import type { MutableRefObject } from 'react';
+import type { MyPageResponse, SessionUser, Tab } from '../types';
+
+type RefreshMyPageForUser = (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
+type ResetReviewCaches = () => void;
+type GoToTab = (tab: Tab, historyMode?: 'push' | 'replace') => void;
+type FormatErrorMessage = (error: unknown) => string;
+type ReportBackgroundError = (error: unknown) => void;
+
+export interface AppBootstrapSharedRefs {
+  refreshMyPageForUserRef: MutableRefObject<RefreshMyPageForUser>;
+  resetReviewCachesRef: MutableRefObject<ResetReviewCaches>;
+  goToTabRef: MutableRefObject<GoToTab>;
+  formatErrorMessageRef: MutableRefObject<FormatErrorMessage>;
+  reportBackgroundErrorRef: MutableRefObject<ReportBackgroundError>;
+}
+
+export function useAppBootstrapSharedRefs({
+  refreshMyPageForUser,
+  resetReviewCaches,
+  goToTab,
+  formatErrorMessage,
+  reportBackgroundError,
+}: {
+  refreshMyPageForUser: RefreshMyPageForUser;
+  resetReviewCaches: ResetReviewCaches;
+  goToTab: GoToTab;
+  formatErrorMessage: FormatErrorMessage;
+  reportBackgroundError: ReportBackgroundError;
+}): AppBootstrapSharedRefs {
+  const refreshMyPageForUserRef = useRef(refreshMyPageForUser);
+  const resetReviewCachesRef = useRef(resetReviewCaches);
+  const goToTabRef = useRef(goToTab);
+  const formatErrorMessageRef = useRef(formatErrorMessage);
+  const reportBackgroundErrorRef = useRef(reportBackgroundError);
+
+  useEffect(() => {
+    refreshMyPageForUserRef.current = refreshMyPageForUser;
+  }, [refreshMyPageForUser]);
+
+  useEffect(() => {
+    resetReviewCachesRef.current = resetReviewCaches;
+  }, [resetReviewCaches]);
+
+  useEffect(() => {
+    goToTabRef.current = goToTab;
+  }, [goToTab]);
+
+  useEffect(() => {
+    formatErrorMessageRef.current = formatErrorMessage;
+  }, [formatErrorMessage]);
+
+  useEffect(() => {
+    reportBackgroundErrorRef.current = reportBackgroundError;
+  }, [reportBackgroundError]);
+
+  return {
+    refreshMyPageForUserRef,
+    resetReviewCachesRef,
+    goToTabRef,
+    formatErrorMessageRef,
+    reportBackgroundErrorRef,
+  };
+}


### PR DESCRIPTION
## Summary
- split bootstrap ref synchronization into a dedicated shared-refs hook
- split initial map bootstrap and festival bootstrap into dedicated effect hooks
- keep useAppBootstrapLifecycle focused on orchestration with the existing warmup and review-sync hooks

## Validation
- npm run lint -- src/hooks/useAppBootstrapLifecycle.ts src/hooks/useAppBootstrapSharedRefs.ts src/hooks/useAppBootstrapEffects.ts
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py