### PR TITLE
Refactor review write repository boundaries

### DIFF
--- a/backend/app/repositories/review_repository.py
+++ b/backend/app/repositories/review_repository.py
@@ -2,13 +2,7 @@ from sqlalchemy.orm import Session
 
 from ..models import CommentCreate, ReviewCreate
 from .review_query_repository import get_review_comments, list_reviews
-from ..repository_normalized import (
-    create_comment_with_notifications,
-    create_review,
-    delete_comment,
-    delete_review,
-    toggle_review_like,
-)
+from .review_write_repository import create_comment_with_notifications, create_review, delete_comment, delete_review, toggle_review_like
 
 
 def list_review_entries(

--- a/backend/app/repositories/review_write_repository.py
+++ b/backend/app/repositories/review_write_repository.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta
+
+from sqlalchemy import func, select
+from sqlalchemy.orm import Session, joinedload
+
+from ..db_models import Feed, FeedLike, MapPlace, TravelSession, UserComment, UserStamp
+from ..models import CommentCreate, CommentOut, ReviewCreate, ReviewLikeResponse, ReviewOut, UserNotificationOut
+from ..repository_support import BADGE_BY_MOOD, format_visit_label, parse_comment_id, parse_review_id, parse_stamp_id, to_seoul_date, utcnow_naive
+from .notification_data_repository import create_user_notification
+from .review_query_repository import get_review_comments, to_review_out
+from .user_data_repository import get_or_create_user
+
+
+def create_review(db: Session, payload: ReviewCreate, user_id: str, nickname: str) -> ReviewOut:
+    body = payload.body.strip()
+    if not body:
+        raise ValueError("리뷰 본문을 적어 주세요.")
+
+    place = db.scalars(select(MapPlace).where(MapPlace.slug == payload.place_id, MapPlace.is_active.is_(True))).first()
+    if not place:
+        raise ValueError("장소를 찾을 수 없어요.")
+
+    stamp = db.scalars(
+        select(UserStamp)
+        .options(joinedload(UserStamp.place))
+        .where(UserStamp.stamp_id == parse_stamp_id(payload.stamp_id))
+    ).first()
+    if not stamp or stamp.user_id != user_id:
+        raise ValueError("해당 방문 스탬프를 찾을 수 없어요.")
+    if stamp.position_id != place.position_id:
+        raise ValueError("선택한 장소와 스탬프가 일치하지 않아요.")
+
+    existing_feed = db.scalars(select(Feed).where(Feed.stamp_id == stamp.stamp_id)).first()
+    if existing_feed:
+        raise ValueError("같은 방문 기록으로는 피드를 한 번만 작성할 수 있어요.")
+
+    now = utcnow_naive()
+    today = to_seoul_date(now)
+    day_start = datetime.combine(today, time.min)
+    day_end = day_start + timedelta(days=1)
+    existing_daily_feed = db.scalars(
+        select(Feed.feed_id).where(Feed.user_id == user_id, Feed.position_id == place.position_id, Feed.created_at >= day_start, Feed.created_at < day_end)
+    ).first()
+    if existing_daily_feed:
+        raise ValueError("같은 장소에는 하루에 한 번만 피드를 작성할 수 있어요.")
+
+    user = get_or_create_user(db, user_id, nickname)
+    feed = Feed(
+        position_id=place.position_id,
+        user_id=user.user_id,
+        stamp_id=stamp.stamp_id,
+        body=body,
+        mood=payload.mood,
+        badge=BADGE_BY_MOOD.get(payload.mood, format_visit_label(stamp.visit_ordinal)),
+        image_url=payload.image_url,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(feed)
+    db.commit()
+
+    stored_feed = db.scalars(
+        select(Feed)
+        .options(
+            joinedload(Feed.user),
+            joinedload(Feed.place),
+            joinedload(Feed.stamp).joinedload(UserStamp.travel_session).joinedload(TravelSession.routes),
+            joinedload(Feed.likes),
+            joinedload(Feed.comments).joinedload(UserComment.user),
+        )
+        .where(Feed.feed_id == feed.feed_id)
+    ).unique().one()
+    return to_review_out(stored_feed, current_user_id=user.user_id)
+
+
+def toggle_review_like(db: Session, review_id: str, user_id: str, nickname: str) -> ReviewLikeResponse:
+    review_key = parse_review_id(review_id)
+    feed = db.scalars(select(Feed).options(joinedload(Feed.likes)).where(Feed.feed_id == review_key)).unique().first()
+    if not feed:
+        raise ValueError("리뷰를 찾지 못했어요.")
+    if feed.user_id == user_id:
+        raise ValueError("내 리뷰에는 좋아요를 누를 수 없어요.")
+
+    user = get_or_create_user(db, user_id, nickname)
+    existing_like = db.scalars(
+        select(FeedLike).where(FeedLike.feed_id == feed.feed_id, FeedLike.user_id == user.user_id)
+    ).first()
+    if existing_like:
+        db.delete(existing_like)
+        liked_by_me = False
+    else:
+        db.add(FeedLike(feed_id=feed.feed_id, user_id=user.user_id, created_at=utcnow_naive()))
+        liked_by_me = True
+    db.commit()
+    like_count = db.scalar(select(func.count()).select_from(FeedLike).where(FeedLike.feed_id == feed.feed_id)) or 0
+    return ReviewLikeResponse(reviewId=str(feed.feed_id), likeCount=int(like_count), likedByMe=liked_by_me)
+
+
+def create_comment_with_notifications(
+    db: Session,
+    review_id: str,
+    payload: CommentCreate,
+    user_id: str,
+    nickname: str,
+) -> tuple[list[CommentOut], list[tuple[str, UserNotificationOut]]]:
+    body = payload.body.strip()
+    if not body:
+        raise ValueError("댓글 내용을 적어 주세요.")
+
+    review_key = parse_review_id(review_id)
+    feed = db.get(Feed, review_key)
+    if not feed:
+        raise ValueError("리뷰를 찾을 수 없어요.")
+
+    parent_id: int | None = None
+    parent_comment: UserComment | None = None
+    if payload.parent_id:
+        parent_id = parse_comment_id(payload.parent_id)
+        parent_comment = db.get(UserComment, parent_id)
+        if not parent_comment or parent_comment.feed_id != review_key:
+            raise ValueError("같은 리뷰 안의 댓글에만 답글을 달 수 있어요.")
+        if parent_comment.parent_id is not None:
+            parent_id = parent_comment.parent_id
+            parent_comment = db.get(UserComment, parent_comment.parent_id)
+
+    user = get_or_create_user(db, user_id, nickname)
+    now = utcnow_naive()
+    comment = UserComment(
+        feed_id=review_key,
+        user_id=user.user_id,
+        parent_id=parent_id,
+        body=body,
+        is_deleted=False,
+        created_at=now,
+        updated_at=now,
+    )
+    db.add(comment)
+    db.flush()
+
+    notifications: list[tuple[str, UserNotificationOut]] = []
+    if parent_comment and parent_comment.user_id != user.user_id:
+        notification = create_user_notification(
+            db,
+            user_id=parent_comment.user_id,
+            actor_user_id=user.user_id,
+            notification_type="comment-reply",
+            title=f"{user.nickname}님이 내 댓글에 답글을 남겼어요.",
+            body=body[:255],
+            review_id=feed.feed_id,
+            comment_id=comment.comment_id,
+            payload_metadata={"reviewId": str(feed.feed_id), "commentId": str(comment.comment_id)},
+        )
+        if notification:
+            notifications.append((parent_comment.user_id, notification))
+
+    if feed.user_id != user.user_id and feed.user_id != (parent_comment.user_id if parent_comment else None):
+        notification = create_user_notification(
+            db,
+            user_id=feed.user_id,
+            actor_user_id=user.user_id,
+            notification_type="review-comment",
+            title=f"{user.nickname}님이 내 피드에 댓글을 남겼어요.",
+            body=body[:255],
+            review_id=feed.feed_id,
+            comment_id=comment.comment_id,
+            payload_metadata={"reviewId": str(feed.feed_id), "commentId": str(comment.comment_id)},
+        )
+        if notification:
+            notifications.append((feed.user_id, notification))
+    db.commit()
+    return get_review_comments(db, review_id), notifications
+
+
+def delete_comment(
+    db: Session,
+    review_id: str,
+    comment_id: str,
+    user_id: str,
+    *,
+    is_admin: bool = False,
+) -> list[CommentOut]:
+    review_key = parse_review_id(review_id)
+    comment_key = parse_comment_id(comment_id)
+    comment = db.scalars(
+        select(UserComment).where(UserComment.comment_id == comment_key, UserComment.feed_id == review_key)
+    ).first()
+    if not comment:
+        raise ValueError("댓글을 찾지 못했어요.")
+    if comment.user_id != user_id and not is_admin:
+        raise PermissionError("내 댓글만 삭제할 수 있어요.")
+    if not comment.is_deleted:
+        comment.is_deleted = True
+        comment.body = ""
+        comment.updated_at = utcnow_naive()
+        db.commit()
+    return get_review_comments(db, review_id)
+
+
+def delete_review(db: Session, review_id: str, user_id: str, *, is_admin: bool = False) -> None:
+    review_key = parse_review_id(review_id)
+    feed = db.get(Feed, review_key)
+    if not feed:
+        raise ValueError("리뷰를 찾지 못했어요.")
+    if feed.user_id != user_id and not is_admin:
+        raise PermissionError("내 리뷰만 삭제할 수 있어요.")
+    db.delete(feed)
+    db.commit()

--- a/backend/app/repository_normalized.py
+++ b/backend/app/repository_normalized.py
@@ -2,13 +2,11 @@
 
 from __future__ import annotations
 
-from datetime import datetime, time, timedelta
-
 from sqlalchemy import func, select
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session
 
 from .config import Settings
-from .db_models import Course, Feed, FeedLike, MapPlace, TravelSession, User, UserComment, UserNotification, UserStamp
+from .db_models import Course, Feed, MapPlace, User, UserComment, UserNotification, UserStamp
 from .models import (
     AdminPlaceOut,
     AdminSummaryResponse,
@@ -39,6 +37,7 @@ from .repositories.content_query_repository import (
     list_places as list_places_entry,
     to_course_out as to_course_out_entry,
 )
+from .repositories.account_data_repository import delete_account as delete_account_entry
 from .repositories.my_page_data_repository import build_my_comments as build_my_comments_entry, get_my_page as get_my_page_entry
 from .repositories.notification_data_repository import (
     create_user_notification as create_user_notification_entry,
@@ -69,16 +68,17 @@ from .repositories.review_query_repository import (
     list_reviews as list_reviews_entry,
     to_review_out as to_review_out_entry,
 )
+from .repositories.review_write_repository import (
+    create_comment_with_notifications as create_comment_with_notifications_entry,
+    create_review as create_review_entry,
+    delete_comment as delete_comment_entry,
+    delete_review as delete_review_entry,
+    toggle_review_like as toggle_review_like_entry,
+)
 from .repositories.stamp_data_repository import get_stamps as get_stamps_entry, toggle_stamp as toggle_stamp_entry
 from .repositories.user_data_repository import get_or_create_user as get_or_create_user_entry
 from .repository_support import (
-    BADGE_BY_MOOD,
-    format_visit_label,
-    parse_comment_id,
-    parse_review_id,
-    parse_stamp_id,
     to_admin_place_out,
-    to_seoul_date,
     utcnow_naive,
 )
 
@@ -202,88 +202,11 @@ def get_review_comments(db: Session, review_id: str) -> list[CommentOut]:
 
 
 def create_review(db: Session, payload: ReviewCreate, user_id: str, nickname: str) -> ReviewOut:
-    body = payload.body.strip()
-    if not body:
-        raise ValueError("리뷰 본문을 적어 주세요.")
-
-    place = db.scalars(select(MapPlace).where(MapPlace.slug == payload.place_id, MapPlace.is_active.is_(True))).first()
-    if not place:
-        raise ValueError("장소를 찾을 수 없어요.")
-
-    stamp = db.scalars(
-        select(UserStamp)
-        .options(joinedload(UserStamp.place))
-        .where(UserStamp.stamp_id == parse_stamp_id(payload.stamp_id))
-    ).first()
-    if not stamp or stamp.user_id != user_id:
-        raise ValueError("해당 방문 스탬프를 찾을 수 없어요.")
-    if stamp.position_id != place.position_id:
-        raise ValueError("선택한 장소와 스탬프가 일치하지 않아요.")
-
-    existing_feed = db.scalars(select(Feed).where(Feed.stamp_id == stamp.stamp_id)).first()
-    if existing_feed:
-        raise ValueError("같은 방문 기록으로는 피드를 한 번만 작성할 수 있어요.")
-
-    now = utcnow_naive()
-    today = to_seoul_date(now)
-    day_start = datetime.combine(today, time.min)
-    day_end = day_start + timedelta(days=1)
-    existing_daily_feed = db.scalars(
-        select(Feed.feed_id).where(Feed.user_id == user_id, Feed.position_id == place.position_id, Feed.created_at >= day_start, Feed.created_at < day_end)
-    ).first()
-    if existing_daily_feed:
-        raise ValueError("같은 장소에는 하루에 한 번만 피드를 작성할 수 있어요.")
-
-    user = get_or_create_user(db, user_id, nickname)
-    feed = Feed(
-        position_id=place.position_id,
-        user_id=user.user_id,
-        stamp_id=stamp.stamp_id,
-        body=body,
-        mood=payload.mood,
-        badge=BADGE_BY_MOOD.get(payload.mood, format_visit_label(stamp.visit_ordinal)),
-        image_url=payload.image_url,
-        created_at=now,
-        updated_at=now,
-    )
-    db.add(feed)
-    db.commit()
-
-    stored_feed = db.scalars(
-        select(Feed)
-        .options(
-            joinedload(Feed.user),
-            joinedload(Feed.place),
-            joinedload(Feed.stamp).joinedload(UserStamp.travel_session).joinedload(TravelSession.routes),
-            joinedload(Feed.likes),
-            joinedload(Feed.comments).joinedload(UserComment.user),
-        )
-        .where(Feed.feed_id == feed.feed_id)
-    ).unique().one()
-    return to_review_out(stored_feed, current_user_id=user.user_id)
+    return create_review_entry(db, payload, user_id, nickname)
 
 
 def toggle_review_like(db: Session, review_id: str, user_id: str, nickname: str) -> ReviewLikeResponse:
-    review_key = parse_review_id(review_id)
-    feed = db.scalars(select(Feed).options(joinedload(Feed.likes)).where(Feed.feed_id == review_key)).unique().first()
-    if not feed:
-        raise ValueError("리뷰를 찾지 못했어요.")
-    if feed.user_id == user_id:
-        raise ValueError("내 리뷰에는 좋아요를 누를 수 없어요.")
-
-    user = get_or_create_user(db, user_id, nickname)
-    existing_like = db.scalars(
-        select(FeedLike).where(FeedLike.feed_id == feed.feed_id, FeedLike.user_id == user.user_id)
-    ).first()
-    if existing_like:
-        db.delete(existing_like)
-        liked_by_me = False
-    else:
-        db.add(FeedLike(feed_id=feed.feed_id, user_id=user.user_id, created_at=utcnow_naive()))
-        liked_by_me = True
-    db.commit()
-    like_count = db.scalar(select(func.count()).select_from(FeedLike).where(FeedLike.feed_id == feed.feed_id)) or 0
-    return ReviewLikeResponse(reviewId=str(feed.feed_id), likeCount=int(like_count), likedByMe=liked_by_me)
+    return toggle_review_like_entry(db, review_id, user_id, nickname)
 
 def create_comment_with_notifications(
     db: Session,
@@ -292,73 +215,7 @@ def create_comment_with_notifications(
     user_id: str,
     nickname: str,
 ) -> tuple[list[CommentOut], list[tuple[str, UserNotificationOut]]]:
-    body = payload.body.strip()
-    if not body:
-        raise ValueError("댓글 내용을 적어 주세요.")
-
-    review_key = parse_review_id(review_id)
-    feed = db.get(Feed, review_key)
-    if not feed:
-        raise ValueError("리뷰를 찾을 수 없어요.")
-
-    parent_id: int | None = None
-    parent_comment: UserComment | None = None
-    if payload.parent_id:
-        parent_id = parse_comment_id(payload.parent_id)
-        parent_comment = db.get(UserComment, parent_id)
-        if not parent_comment or parent_comment.feed_id != review_key:
-            raise ValueError("같은 리뷰 안의 댓글에만 답글을 달 수 있어요.")
-        # Enforce 2-level depth: if parent is itself a reply, use its root comment instead
-        if parent_comment.parent_id is not None:
-            parent_id = parent_comment.parent_id
-            parent_comment = db.get(UserComment, parent_comment.parent_id)
-
-    user = get_or_create_user(db, user_id, nickname)
-    now = utcnow_naive()
-    comment = UserComment(
-        feed_id=review_key,
-        user_id=user.user_id,
-        parent_id=parent_id,
-        body=body,
-        is_deleted=False,
-        created_at=now,
-        updated_at=now,
-    )
-    db.add(comment)
-    db.flush()
-
-    notifications: list[tuple[str, UserNotificationOut]] = []
-    if parent_comment and parent_comment.user_id != user.user_id:
-        notification = create_user_notification(
-            db,
-            user_id=parent_comment.user_id,
-            actor_user_id=user.user_id,
-            notification_type="comment-reply",
-            title=f"{user.nickname}님이 내 댓글에 답글을 남겼어요.",
-            body=body[:255],
-            review_id=feed.feed_id,
-            comment_id=comment.comment_id,
-            payload_metadata={"reviewId": str(feed.feed_id), "commentId": str(comment.comment_id)},
-        )
-        if notification:
-            notifications.append((parent_comment.user_id, notification))
-
-    if feed.user_id != user.user_id and feed.user_id != (parent_comment.user_id if parent_comment else None):
-        notification = create_user_notification(
-            db,
-            user_id=feed.user_id,
-            actor_user_id=user.user_id,
-            notification_type="review-comment",
-            title=f"{user.nickname}님이 내 피드에 댓글을 남겼어요.",
-            body=body[:255],
-            review_id=feed.feed_id,
-            comment_id=comment.comment_id,
-            payload_metadata={"reviewId": str(feed.feed_id), "commentId": str(comment.comment_id)},
-        )
-        if notification:
-            notifications.append((feed.user_id, notification))
-    db.commit()
-    return get_review_comments(db, review_id), notifications
+    return create_comment_with_notifications_entry(db, review_id, payload, user_id, nickname)
 
 
 def create_comment(
@@ -380,40 +237,15 @@ def delete_comment(
     *,
     is_admin: bool = False,
 ) -> list[CommentOut]:
-    review_key = parse_review_id(review_id)
-    comment_key = parse_comment_id(comment_id)
-    comment = db.scalars(
-        select(UserComment).where(UserComment.comment_id == comment_key, UserComment.feed_id == review_key)
-    ).first()
-    if not comment:
-        raise ValueError("댓글을 찾지 못했어요.")
-    if comment.user_id != user_id and not is_admin:
-        raise PermissionError("내 댓글만 삭제할 수 있어요.")
-    if not comment.is_deleted:
-        comment.is_deleted = True
-        comment.body = ""
-        comment.updated_at = utcnow_naive()
-        db.commit()
-    return get_review_comments(db, review_id)
+    return delete_comment_entry(db, review_id, comment_id, user_id, is_admin=is_admin)
 
 
 def delete_review(db: Session, review_id: str, user_id: str, *, is_admin: bool = False) -> None:
-    review_key = parse_review_id(review_id)
-    feed = db.get(Feed, review_key)
-    if not feed:
-        raise ValueError("리뷰를 찾지 못했어요.")
-    if feed.user_id != user_id and not is_admin:
-        raise PermissionError("내 리뷰만 삭제할 수 있어요.")
-    db.delete(feed)
-    db.commit()
+    delete_review_entry(db, review_id, user_id, is_admin=is_admin)
 
 
 def delete_account(db: Session, user_id: str) -> None:
-    user = db.get(User, user_id)
-    if not user:
-        raise ValueError("사용자 정보를 찾지 못했어요.")
-    db.delete(user)
-    db.commit()
+    delete_account_entry(db, user_id)
 
 def list_courses(db: Session, mood: CourseMood | None = None) -> list[CourseOut]:
     return list_courses_entry(db, mood)


### PR DESCRIPTION
## Summary
- move review write flows out of repository_normalized into a dedicated review_write_repository
- update review_repository to depend on write/query repositories instead of repository_normalized
- keep repository_normalized as a thinner compatibility layer for remaining callers

## Validation
- python backend targeted pytest
- python -m compileall backend/app
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py