### PR TITLE
Refactor app navigation helper boundaries

### DIFF
--- a/src/hooks/app-navigation/navigationTypes.ts
+++ b/src/hooks/app-navigation/navigationTypes.ts
@@ -1,0 +1,48 @@
+import type { ReturnViewState } from '../../store/app-ui-store';
+import type {
+  DrawerState,
+  MyPageTabKey,
+  Review,
+  RoutePreview,
+  Tab,
+} from '../../types';
+import type { RouteStateCommitOptions } from '../useAppRouteState';
+
+export interface UseAppNavigationHelpersParams {
+  activeTab: Tab;
+  myPageTab: MyPageTabKey;
+  activeCommentReviewId: string | null;
+  highlightedCommentId: string | null;
+  highlightedReviewId: string | null;
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  drawerState: DrawerState;
+  feedPlaceFilterId: string | null;
+  reviews: Review[];
+  selectedPlaceReviews: Review[];
+  myPageReviews: Review[];
+  setActiveCommentReviewId: (reviewId: string | null) => void;
+  setHighlightedCommentId: (commentId: string | null) => void;
+  setHighlightedReviewId: (reviewId: string | null) => void;
+  setHighlightedRouteId: (routeId: string | null) => void;
+  setReturnView: (value: ReturnViewState | null) => void;
+  setSelectedRoutePreview: (route: RoutePreview | null) => void;
+  setFeedPlaceFilterId: (placeId: string | null) => void;
+  setNotice: (message: string) => void;
+  goToTab: (tab: Tab, historyMode?: 'push' | 'replace') => void;
+  commitRouteState: (
+    nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
+    historyMode?: 'push' | 'replace',
+    options?: RouteStateCommitOptions,
+  ) => void;
+  upsertReviewCollections: (review: Review) => void;
+}
+
+export type SnapshotReturnView = (overrides?: Partial<ReturnViewState>) => ReturnViewState;
+
+export function formatNavigationErrorMessage(error: unknown) {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  return '요청을 처리하지 못했어요. 잠시 뒤에 다시 시도해 주세요.';
+}

--- a/src/hooks/app-navigation/returnView.ts
+++ b/src/hooks/app-navigation/returnView.ts
@@ -1,0 +1,45 @@
+import type { ReturnViewState } from '../../store/app-ui-store';
+import type { SnapshotReturnView, UseAppNavigationHelpersParams } from './navigationTypes';
+
+type ReturnViewContext = Pick<
+  UseAppNavigationHelpersParams,
+  | 'activeTab'
+  | 'myPageTab'
+  | 'activeCommentReviewId'
+  | 'highlightedCommentId'
+  | 'highlightedReviewId'
+  | 'selectedPlaceId'
+  | 'selectedFestivalId'
+  | 'drawerState'
+  | 'feedPlaceFilterId'
+>;
+
+function createReturnView(params: ReturnViewState): ReturnViewState {
+  return params;
+}
+
+export function createReturnViewSnapshot({
+  activeTab,
+  myPageTab,
+  activeCommentReviewId,
+  highlightedCommentId,
+  highlightedReviewId,
+  selectedPlaceId,
+  selectedFestivalId,
+  drawerState,
+  feedPlaceFilterId,
+}: ReturnViewContext): SnapshotReturnView {
+  return (overrides = {}) =>
+    createReturnView({
+      tab: activeTab,
+      myPageTab,
+      activeCommentReviewId,
+      highlightedCommentId,
+      highlightedReviewId,
+      placeId: selectedPlaceId,
+      festivalId: selectedFestivalId,
+      drawerState,
+      feedPlaceFilterId,
+      ...overrides,
+    });
+}

--- a/src/hooks/app-navigation/reviewNavigation.ts
+++ b/src/hooks/app-navigation/reviewNavigation.ts
@@ -1,0 +1,111 @@
+import { getReviewDetail } from '../../api/reviewsClient';
+import type { SnapshotReturnView, UseAppNavigationHelpersParams } from './navigationTypes';
+import { formatNavigationErrorMessage } from './navigationTypes';
+
+interface ReviewNavigationParams
+  extends Pick<
+    UseAppNavigationHelpersParams,
+    | 'activeTab'
+    | 'reviews'
+    | 'selectedPlaceReviews'
+    | 'myPageReviews'
+    | 'goToTab'
+    | 'setActiveCommentReviewId'
+    | 'setHighlightedCommentId'
+    | 'setHighlightedReviewId'
+    | 'setFeedPlaceFilterId'
+    | 'setReturnView'
+    | 'setNotice'
+    | 'upsertReviewCollections'
+  > {
+  snapshotReturnView: SnapshotReturnView;
+}
+
+export function createReviewNavigationHelpers({
+  activeTab,
+  reviews,
+  selectedPlaceReviews,
+  myPageReviews,
+  goToTab,
+  setActiveCommentReviewId,
+  setHighlightedCommentId,
+  setHighlightedReviewId,
+  setFeedPlaceFilterId,
+  setReturnView,
+  setNotice,
+  upsertReviewCollections,
+  snapshotReturnView,
+}: ReviewNavigationParams) {
+  function handleOpenReviewComments(reviewId: string, commentId: string | null = null) {
+    goToTab('feed');
+    setHighlightedReviewId(reviewId ?? null);
+    setActiveCommentReviewId(reviewId);
+    setHighlightedCommentId(commentId);
+  }
+
+  function handleCloseReviewComments() {
+    setActiveCommentReviewId(null);
+    setHighlightedCommentId(null);
+  }
+
+  async function ensureReviewLoadedById(reviewId: string | null) {
+    if (!reviewId) {
+      return null;
+    }
+
+    const existing =
+      [...reviews, ...selectedPlaceReviews, ...myPageReviews].find((review) => review.id === reviewId) ?? null;
+    if (existing) {
+      upsertReviewCollections(existing);
+      return existing;
+    }
+
+    try {
+      const loaded = await getReviewDetail(reviewId);
+      upsertReviewCollections(loaded);
+      return loaded;
+    } catch (error) {
+      setNotice(formatNavigationErrorMessage(error));
+      return null;
+    }
+  }
+
+  async function handleOpenReviewWithReturn(reviewId: string | null) {
+    await ensureReviewLoadedById(reviewId);
+    if (activeTab !== 'feed') {
+      setReturnView(snapshotReturnView());
+    }
+    setFeedPlaceFilterId(null);
+    setHighlightedReviewId(reviewId);
+    setHighlightedCommentId(null);
+    setActiveCommentReviewId(null);
+    goToTab('feed');
+  }
+
+  function handleOpenPlaceFeedWithReturn(placeId: string) {
+    if (activeTab !== 'feed') {
+      setReturnView(snapshotReturnView());
+    }
+    setFeedPlaceFilterId(placeId);
+    setHighlightedReviewId(null);
+    setHighlightedCommentId(null);
+    setActiveCommentReviewId(null);
+    goToTab('feed');
+  }
+
+  async function handleOpenCommentWithReturn(reviewId: string, commentId: string | null = null) {
+    if (activeTab !== 'feed') {
+      setReturnView(snapshotReturnView());
+    }
+    await ensureReviewLoadedById(reviewId);
+    handleOpenReviewComments(reviewId, commentId);
+  }
+
+  return {
+    handleOpenReviewComments,
+    handleCloseReviewComments,
+    handleOpenReviewWithReturn,
+    handleOpenPlaceFeedWithReturn,
+    handleOpenCommentWithReturn,
+  };
+}

--- a/src/hooks/app-navigation/tabNavigation.ts
+++ b/src/hooks/app-navigation/tabNavigation.ts
@@ -1,0 +1,89 @@
+import type { SnapshotReturnView, UseAppNavigationHelpersParams } from './navigationTypes';
+
+interface TabNavigationParams
+  extends Pick<
+    UseAppNavigationHelpersParams,
+    | 'activeTab'
+    | 'activeCommentReviewId'
+    | 'highlightedCommentId'
+    | 'highlightedReviewId'
+    | 'setHighlightedRouteId'
+    | 'setReturnView'
+    | 'setSelectedRoutePreview'
+    | 'commitRouteState'
+    | 'goToTab'
+  > {
+  snapshotReturnView: SnapshotReturnView;
+  handleCloseReviewComments: () => void;
+}
+
+export function createTabNavigationHelpers({
+  activeTab,
+  activeCommentReviewId,
+  highlightedCommentId,
+  highlightedReviewId,
+  setHighlightedRouteId,
+  setReturnView,
+  setSelectedRoutePreview,
+  commitRouteState,
+  goToTab,
+  snapshotReturnView,
+  handleCloseReviewComments,
+}: TabNavigationParams) {
+  function handleOpenRoutePreview(route: UseAppNavigationHelpersParams['setSelectedRoutePreview'] extends (
+    route: infer T,
+  ) => void
+    ? Exclude<T, null>
+    : never) {
+    if (activeTab !== 'map') {
+      setReturnView(snapshotReturnView());
+    }
+    setSelectedRoutePreview(route);
+    handleCloseReviewComments();
+    commitRouteState(
+      { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' },
+      activeTab === 'map' ? 'replace' : 'push',
+      { routePreview: route },
+    );
+  }
+
+  function handleOpenPlaceWithReturn(placeId: string) {
+    if (activeTab !== 'map') {
+      const preserveFeedFocus = activeTab !== 'feed';
+      setReturnView(
+        snapshotReturnView({
+          activeCommentReviewId: preserveFeedFocus ? activeCommentReviewId : null,
+          highlightedCommentId: preserveFeedFocus ? highlightedCommentId : null,
+          highlightedReviewId: preserveFeedFocus ? highlightedReviewId : null,
+        }),
+      );
+    }
+    setSelectedRoutePreview(null);
+    commitRouteState({ tab: 'map', placeId, festivalId: null, drawerState: 'partial' }, 'push', { routePreview: null });
+  }
+
+  function handleOpenFestivalWithReturn(festivalId: string) {
+    if (activeTab !== 'map') {
+      setReturnView(snapshotReturnView());
+    }
+    setSelectedRoutePreview(null);
+    commitRouteState({ tab: 'map', placeId: null, festivalId, drawerState: 'partial' }, 'push', { routePreview: null });
+  }
+
+  function handleOpenCommunityRouteWithReturn(routeId: string) {
+    if (activeTab !== 'course') {
+      setReturnView(snapshotReturnView());
+    }
+    setHighlightedRouteId(routeId);
+    setSelectedRoutePreview(null);
+    handleCloseReviewComments();
+    goToTab('course');
+  }
+
+  return {
+    handleOpenRoutePreview,
+    handleOpenPlaceWithReturn,
+    handleOpenFestivalWithReturn,
+    handleOpenCommunityRouteWithReturn,
+  };
+}

--- a/src/hooks/useAppNavigationHelpers.ts
+++ b/src/hooks/useAppNavigationHelpers.ts
@@ -1,54 +1,7 @@
-import { getReviewDetail } from '../api/reviewsClient';
-import type { ReturnViewState } from '../store/app-ui-store';
-import type {
-  DrawerState,
-  MyPageTabKey,
-  Review,
-  RoutePreview,
-  Tab,
-} from '../types';
-import type { RouteStateCommitOptions } from './useAppRouteState';
-
-interface UseAppNavigationHelpersParams {
-  activeTab: Tab;
-  myPageTab: MyPageTabKey;
-  activeCommentReviewId: string | null;
-  highlightedCommentId: string | null;
-  highlightedReviewId: string | null;
-  selectedPlaceId: string | null;
-  selectedFestivalId: string | null;
-  drawerState: DrawerState;
-  feedPlaceFilterId: string | null;
-  reviews: Review[];
-  selectedPlaceReviews: Review[];
-  myPageReviews: Review[];
-  setActiveCommentReviewId: (reviewId: string | null) => void;
-  setHighlightedCommentId: (commentId: string | null) => void;
-  setHighlightedReviewId: (reviewId: string | null) => void;
-  setHighlightedRouteId: (routeId: string | null) => void;
-  setReturnView: (value: ReturnViewState | null) => void;
-  setSelectedRoutePreview: (route: RoutePreview | null) => void;
-  setFeedPlaceFilterId: (placeId: string | null) => void;
-  setNotice: (message: string) => void;
-  goToTab: (tab: Tab, historyMode?: 'push' | 'replace') => void;
-  commitRouteState: (
-    nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
-    historyMode?: 'push' | 'replace',
-    options?: RouteStateCommitOptions,
-  ) => void;
-  upsertReviewCollections: (review: Review) => void;
-}
-
-function formatErrorMessage(error: unknown) {
-  if (error instanceof Error) {
-    return error.message;
-  }
-  return '요청을 처리하지 못했어요. 잠시 뒤에 다시 시도해 주세요.';
-}
-
-function createReturnView(params: ReturnViewState): ReturnViewState {
-  return params;
-}
+import { createReviewNavigationHelpers } from './app-navigation/reviewNavigation';
+import { createReturnViewSnapshot } from './app-navigation/returnView';
+import { createTabNavigationHelpers } from './app-navigation/tabNavigation';
+import type { UseAppNavigationHelpersParams } from './app-navigation/navigationTypes';
 
 export function useAppNavigationHelpers({
   activeTab,
@@ -75,141 +28,50 @@ export function useAppNavigationHelpers({
   commitRouteState,
   upsertReviewCollections,
 }: UseAppNavigationHelpersParams) {
-  function snapshotReturnView(overrides: Partial<ReturnViewState> = {}) {
-    return createReturnView({
-      tab: activeTab,
-      myPageTab,
-      activeCommentReviewId,
-      highlightedCommentId,
-      highlightedReviewId,
-      placeId: selectedPlaceId,
-      festivalId: selectedFestivalId,
-      drawerState,
-      feedPlaceFilterId,
-      ...overrides,
-    });
-  }
+  const snapshotReturnView = createReturnViewSnapshot({
+    activeTab,
+    myPageTab,
+    activeCommentReviewId,
+    highlightedCommentId,
+    highlightedReviewId,
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    feedPlaceFilterId,
+  });
 
-  function handleOpenReviewComments(reviewId: string, commentId: string | null = null) {
-    goToTab('feed');
-    setHighlightedReviewId(reviewId ?? null);
-    setActiveCommentReviewId(reviewId);
-    setHighlightedCommentId(commentId);
-  }
+  const reviewNavigation = createReviewNavigationHelpers({
+    activeTab,
+    reviews,
+    selectedPlaceReviews,
+    myPageReviews,
+    goToTab,
+    setActiveCommentReviewId,
+    setHighlightedCommentId,
+    setHighlightedReviewId,
+    setFeedPlaceFilterId,
+    setReturnView,
+    setNotice,
+    upsertReviewCollections,
+    snapshotReturnView,
+  });
 
-  function handleCloseReviewComments() {
-    setActiveCommentReviewId(null);
-    setHighlightedCommentId(null);
-  }
-
-  function handleOpenRoutePreview(route: RoutePreview) {
-    if (activeTab !== 'map') {
-      setReturnView(snapshotReturnView());
-    }
-    setSelectedRoutePreview(route);
-    handleCloseReviewComments();
-    commitRouteState(
-      { tab: 'map', placeId: null, festivalId: null, drawerState: 'closed' },
-      activeTab === 'map' ? 'replace' : 'push',
-      { routePreview: route },
-    );
-  }
-
-  function handleOpenPlaceWithReturn(placeId: string) {
-    if (activeTab !== 'map') {
-      const preserveFeedFocus = activeTab !== 'feed';
-      setReturnView(snapshotReturnView({
-        activeCommentReviewId: preserveFeedFocus ? activeCommentReviewId : null,
-        highlightedCommentId: preserveFeedFocus ? highlightedCommentId : null,
-        highlightedReviewId: preserveFeedFocus ? highlightedReviewId : null,
-      }));
-    }
-    setSelectedRoutePreview(null);
-    commitRouteState({ tab: 'map', placeId, festivalId: null, drawerState: 'partial' }, 'push', { routePreview: null });
-  }
-
-  function handleOpenFestivalWithReturn(festivalId: string) {
-    if (activeTab !== 'map') {
-      setReturnView(snapshotReturnView());
-    }
-    setSelectedRoutePreview(null);
-    commitRouteState({ tab: 'map', placeId: null, festivalId, drawerState: 'partial' }, 'push', { routePreview: null });
-  }
-
-  async function ensureReviewLoadedById(reviewId: string | null) {
-    if (!reviewId) {
-      return null;
-    }
-
-    const existing = [...reviews, ...selectedPlaceReviews, ...myPageReviews].find((review) => review.id === reviewId) ?? null;
-    if (existing) {
-      upsertReviewCollections(existing);
-      return existing;
-    }
-
-    try {
-      const loaded = await getReviewDetail(reviewId);
-      upsertReviewCollections(loaded);
-      return loaded;
-    } catch (error) {
-      setNotice(formatErrorMessage(error));
-      return null;
-    }
-  }
-
-  async function handleOpenReviewWithReturn(reviewId: string | null) {
-    await ensureReviewLoadedById(reviewId);
-    if (activeTab !== 'feed') {
-      setReturnView(snapshotReturnView());
-    }
-    setFeedPlaceFilterId(null);
-    setHighlightedReviewId(reviewId);
-    setHighlightedCommentId(null);
-    setActiveCommentReviewId(null);
-    goToTab('feed');
-  }
-
-  function handleOpenPlaceFeedWithReturn(placeId: string) {
-    if (activeTab !== 'feed') {
-      setReturnView(snapshotReturnView());
-    }
-    setSelectedRoutePreview(null);
-    setFeedPlaceFilterId(placeId);
-    setHighlightedReviewId(null);
-    setHighlightedCommentId(null);
-    setActiveCommentReviewId(null);
-    goToTab('feed');
-  }
-
-  async function handleOpenCommentWithReturn(reviewId: string, commentId: string | null = null) {
-    if (activeTab !== 'feed') {
-      setReturnView(snapshotReturnView());
-    }
-    await ensureReviewLoadedById(reviewId);
-    handleOpenReviewComments(reviewId, commentId);
-  }
-
-  function handleOpenCommunityRouteWithReturn(routeId: string) {
-    if (activeTab !== 'course') {
-      setReturnView(snapshotReturnView());
-    }
-    setHighlightedRouteId(routeId);
-    setSelectedRoutePreview(null);
-    setHighlightedReviewId(null);
-    setHighlightedCommentId(null);
-    setActiveCommentReviewId(null);
-    goToTab('course');
-  }
+  const tabNavigation = createTabNavigationHelpers({
+    activeTab,
+    activeCommentReviewId,
+    highlightedCommentId,
+    highlightedReviewId,
+    setHighlightedRouteId,
+    setReturnView,
+    setSelectedRoutePreview,
+    commitRouteState,
+    goToTab,
+    snapshotReturnView,
+    handleCloseReviewComments: reviewNavigation.handleCloseReviewComments,
+  });
 
   return {
-    handleOpenReviewComments,
-    handleCloseReviewComments,
-    handleOpenRoutePreview,
-    handleOpenPlaceWithReturn,
-    handleOpenFestivalWithReturn,
-    handleOpenReviewWithReturn,
-    handleOpenPlaceFeedWithReturn,
-    handleOpenCommentWithReturn,
-    handleOpenCommunityRouteWithReturn,
+    ...reviewNavigation,
+    ...tabNavigation,
   };
 }


### PR DESCRIPTION
## Summary
- split return-view snapshot creation out of useAppNavigationHelpers
- isolate review-loading navigation helpers from tab and route transitions
- keep the public helper surface unchanged for coordinator consumers

## Validation
- npm run typecheck
- npm run lint -- src/hooks/useAppNavigationHelpers.ts src/hooks/app-navigation
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py