### PR TITLE
Refactor global notification center boundaries

### DIFF
--- a/src/components/GlobalNotificationCenter.tsx
+++ b/src/components/GlobalNotificationCenter.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
-import type { MyPageResponse } from '../types';
-
-type NotificationItem = NonNullable<MyPageResponse>['notifications'][number];
+import { NotificationPanel } from './notifications/NotificationPanel';
+import { useNotificationPanelActions } from './notifications/useNotificationPanelActions';
+import type { NotificationItem } from './notifications/notificationTypes';
 
 interface GlobalNotificationCenterProps {
   sessionUserName: string | null;
@@ -34,21 +34,6 @@ function BellIcon() {
   );
 }
 
-function getNotificationLabel(notification: NotificationItem) {
-  switch (notification.type) {
-    case 'review-created':
-      return '피드';
-    case 'route-published':
-      return '코스';
-    case 'review-comment':
-      return '댓글';
-    case 'comment-reply':
-      return '답글';
-    default:
-      return '알림';
-  }
-}
-
 export function GlobalNotificationCenter({
   sessionUserName,
   notifications,
@@ -58,47 +43,12 @@ export function GlobalNotificationCenter({
   onDeleteNotification,
 }: GlobalNotificationCenterProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [busyId, setBusyId] = useState<string | null>(null);
-  const [busyAll, setBusyAll] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-
-  async function handleOpenNotification(notification: NotificationItem) {
-    try {
-      setBusyId(notification.id);
-      setError(null);
-      await onOpenNotification(notification);
-      setIsOpen(false);
-    } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : '알림을 열지 못했어요.');
-    } finally {
-      setBusyId(null);
-    }
-  }
-
-  async function handleMarkAll() {
-    try {
-      setBusyAll(true);
-      setError(null);
-      await onMarkAllNotificationsRead();
-    } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : '알림 상태를 바꾸지 못했어요.');
-    } finally {
-      setBusyAll(false);
-    }
-  }
-
-  async function handleDelete(event: React.MouseEvent<HTMLButtonElement>, notificationId: string) {
-    event.stopPropagation();
-    try {
-      setBusyId(notificationId);
-      setError(null);
-      await onDeleteNotification(notificationId);
-    } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : '알림을 삭제하지 못했어요.');
-    } finally {
-      setBusyId(null);
-    }
-  }
+  const actions = useNotificationPanelActions({
+    onOpenNotification,
+    onMarkAllNotificationsRead,
+    onDeleteNotification,
+    onClose: () => setIsOpen(false),
+  });
 
   return (
     <div className="global-notification-center">
@@ -111,55 +61,7 @@ export function GlobalNotificationCenter({
         <BellIcon />
         {unreadCount > 0 && <span className="notification-bell__dot" aria-hidden="true" />}
       </button>
-      {isOpen && (
-        <section className="global-notification-panel">
-          <div className="notification-panel__header">
-            <div>
-              <p className="eyebrow">ALERT</p>
-              <h3>{sessionUserName ? `${sessionUserName}님의 새 알림` : '새 알림'}</h3>
-              <p className="section-copy">어느 탭에 있든 여기서 바로 확인하고 이동할 수 있어요.</p>
-            </div>
-            <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAll()} disabled={busyAll || unreadCount === 0}>
-              {busyAll ? '처리 중' : '모두 읽음'}
-            </button>
-          </div>
-          {error && <p className="form-error-copy">{error}</p>}
-          <div className="notification-list">
-            {notifications.map((notification) => (
-              <article
-                key={notification.id}
-                className={notification.isRead ? 'notification-item' : 'notification-item is-unread'}
-              >
-                <button
-                  type="button"
-                  className="notification-item__content"
-                  onClick={() => void handleOpenNotification(notification)}
-                  disabled={busyId === notification.id}
-                >
-                  <div className="notification-item__top">
-                    <span className="soft-tag">{getNotificationLabel(notification)}</span>
-                    <span className="notification-item__time">
-                      {notification.actorName ? `${notification.actorName} · ${notification.createdAt}` : notification.createdAt}
-                    </span>
-                  </div>
-                  <strong>{notification.title}</strong>
-                  <p>{notification.body}</p>
-                </button>
-                <button
-                  type="button"
-                  className="notification-item__delete"
-                  aria-label="알림 삭제"
-                  onClick={(event) => void handleDelete(event, notification.id)}
-                  disabled={busyId === notification.id}
-                >
-                  ×
-                </button>
-              </article>
-            ))}
-            {notifications.length === 0 && <p className="empty-copy">새로운 알림이 아직 없어요.</p>}
-          </div>
-        </section>
-      )}
+      {isOpen && <NotificationPanel sessionUserName={sessionUserName} notifications={notifications} unreadCount={unreadCount} actions={actions} />}
     </div>
   );
 }

--- a/src/components/notifications/NotificationListItem.tsx
+++ b/src/components/notifications/NotificationListItem.tsx
@@ -1,0 +1,45 @@
+import { getNotificationLabel } from './notificationTypes';
+import type { NotificationItem } from './notificationTypes';
+
+interface NotificationListItemProps {
+  notification: NotificationItem;
+  busyId: string | null;
+  onOpenNotification: (notification: NotificationItem) => Promise<void>;
+  onDelete: (event: React.MouseEvent<HTMLButtonElement>, notificationId: string) => Promise<void>;
+}
+
+export function NotificationListItem({
+  notification,
+  busyId,
+  onOpenNotification,
+  onDelete,
+}: NotificationListItemProps) {
+  return (
+    <article className={notification.isRead ? 'notification-item' : 'notification-item is-unread'}>
+      <button
+        type="button"
+        className="notification-item__content"
+        onClick={() => void onOpenNotification(notification)}
+        disabled={busyId === notification.id}
+      >
+        <div className="notification-item__top">
+          <span className="soft-tag">{getNotificationLabel(notification)}</span>
+          <span className="notification-item__time">
+            {notification.actorName ? `${notification.actorName} · ${notification.createdAt}` : notification.createdAt}
+          </span>
+        </div>
+        <strong>{notification.title}</strong>
+        <p>{notification.body}</p>
+      </button>
+      <button
+        type="button"
+        className="notification-item__delete"
+        aria-label="알림 삭제"
+        onClick={(event) => void onDelete(event, notification.id)}
+        disabled={busyId === notification.id}
+      >
+        ×
+      </button>
+    </article>
+  );
+}

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -1,0 +1,54 @@
+import { NotificationListItem } from './NotificationListItem';
+import type { NotificationItem } from './notificationTypes';
+import type { NotificationPanelActions } from './notificationTypes';
+
+interface NotificationPanelProps {
+  sessionUserName: string | null;
+  notifications: NotificationItem[];
+  unreadCount: number;
+  actions: NotificationPanelActions;
+}
+
+export function NotificationPanel({
+  sessionUserName,
+  notifications,
+  unreadCount,
+  actions,
+}: NotificationPanelProps) {
+  const {
+    busyAll,
+    busyId,
+    error,
+    handleDelete,
+    handleMarkAll,
+    handleOpenNotification,
+  } = actions;
+
+  return (
+    <section className="global-notification-panel">
+      <div className="notification-panel__header">
+        <div>
+          <p className="eyebrow">ALERT</p>
+          <h3>{sessionUserName ? `${sessionUserName}님의 새 알림` : '새 알림'}</h3>
+          <p className="section-copy">어느 탭에 있든 여기서 바로 확인하고 이동할 수 있어요.</p>
+        </div>
+        <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAll()} disabled={busyAll || unreadCount === 0}>
+          {busyAll ? '처리 중' : '모두 읽음'}
+        </button>
+      </div>
+      {error && <p className="form-error-copy">{error}</p>}
+      <div className="notification-list">
+        {notifications.map((notification) => (
+          <NotificationListItem
+            key={notification.id}
+            notification={notification}
+            busyId={busyId}
+            onOpenNotification={handleOpenNotification}
+            onDelete={handleDelete}
+          />
+        ))}
+        {notifications.length === 0 && <p className="empty-copy">새로운 알림이 아직 없어요.</p>}
+      </div>
+    </section>
+  );
+}

--- a/src/components/notifications/notificationTypes.ts
+++ b/src/components/notifications/notificationTypes.ts
@@ -1,0 +1,27 @@
+import type { MyPageResponse } from '../../types';
+
+export type NotificationItem = NonNullable<MyPageResponse>['notifications'][number];
+
+export interface NotificationPanelActions {
+  busyAll: boolean;
+  busyId: string | null;
+  error: string | null;
+  handleDelete: (event: React.MouseEvent<HTMLButtonElement>, notificationId: string) => Promise<void>;
+  handleMarkAll: () => Promise<void>;
+  handleOpenNotification: (notification: NotificationItem) => Promise<void>;
+}
+
+export function getNotificationLabel(notification: NotificationItem) {
+  switch (notification.type) {
+    case 'review-created':
+      return '피드';
+    case 'route-published':
+      return '코스';
+    case 'review-comment':
+      return '댓글';
+    case 'comment-reply':
+      return '답글';
+    default:
+      return '알림';
+  }
+}

--- a/src/components/notifications/useNotificationPanelActions.ts
+++ b/src/components/notifications/useNotificationPanelActions.ts
@@ -1,0 +1,67 @@
+import { useState } from 'react';
+import type { NotificationItem } from './notificationTypes';
+
+interface UseNotificationPanelActionsParams {
+  onOpenNotification: (notification: NotificationItem) => Promise<void>;
+  onMarkAllNotificationsRead: () => Promise<void>;
+  onDeleteNotification: (notificationId: string) => Promise<void>;
+  onClose: () => void;
+}
+
+export function useNotificationPanelActions({
+  onOpenNotification,
+  onMarkAllNotificationsRead,
+  onDeleteNotification,
+  onClose,
+}: UseNotificationPanelActionsParams) {
+  const [busyId, setBusyId] = useState<string | null>(null);
+  const [busyAll, setBusyAll] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleOpenNotification(notification: NotificationItem) {
+    try {
+      setBusyId(notification.id);
+      setError(null);
+      await onOpenNotification(notification);
+      onClose();
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림을 열지 못했어요.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  async function handleMarkAll() {
+    try {
+      setBusyAll(true);
+      setError(null);
+      await onMarkAllNotificationsRead();
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림 상태를 바꾸지 못했어요.');
+    } finally {
+      setBusyAll(false);
+    }
+  }
+
+  async function handleDelete(event: React.MouseEvent<HTMLButtonElement>, notificationId: string) {
+    event.stopPropagation();
+    try {
+      setBusyId(notificationId);
+      setError(null);
+      await onDeleteNotification(notificationId);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : '알림을 삭제하지 못했어요.');
+    } finally {
+      setBusyId(null);
+    }
+  }
+
+  return {
+    busyId,
+    busyAll,
+    error,
+    handleOpenNotification,
+    handleMarkAll,
+    handleDelete,
+  };
+}


### PR DESCRIPTION
## Summary
- split global notification center into panel, list item, and action hook modules
- keep the bell toggle entrypoint focused on open state and composition
- preserve existing notification behavior and copy

## Validation
- npm run typecheck
- npm run lint -- src/components/GlobalNotificationCenter.tsx src/components/notifications
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py