### PR TITLE
Refactor my feed tab editing

### DIFF
--- a/src/components/ReviewComposer.tsx
+++ b/src/components/ReviewComposer.tsx
@@ -52,9 +52,9 @@ export function ReviewComposer({
   const actionLabel = !loggedIn
     ? '로그인하고 작성'
     : isDailyLimitReached
-      ? '오늘 피드 작성 완료'
+      ? '오늘 리뷰 작성 완료'
       : canSubmit
-        ? '피드 올리기'
+        ? '리뷰 올리기'
         : '오늘 스탬프 먼저 찍기';
   const actionHandler = !loggedIn ? onRequestLogin : canSubmit || isDailyLimitReached ? undefined : onRequestProof;
 
@@ -62,7 +62,7 @@ export function ReviewComposer({
     <section className="sheet-card stack-gap review-composer">
       <div>
         <p className="eyebrow">WRITE FEED</p>
-        <h3>{placeName} 피드 남기기</h3>
+        <h3>{placeName} 리뷰 남기기</h3>
         <p className="section-copy">{proofMessage}</p>
       </div>
 

--- a/src/components/my-page/MyFeedReviewCard.tsx
+++ b/src/components/my-page/MyFeedReviewCard.tsx
@@ -1,0 +1,122 @@
+import { ReviewFormFields } from '../ReviewFormFields';
+import { ReviewFeedCardHeader } from '../review/ReviewFeedCardHeader';
+import { ReviewTagRow } from '../review/ReviewTagRow';
+import type { MyReview, ReviewUpdatePayload } from './myFeedTabTypes';
+import { reviewMoodOptions } from './myFeedTabTypes';
+
+interface MyFeedReviewCardProps {
+  review: MyReview;
+  editingReviewId: string | null;
+  editingReviewBody: string;
+  editingReviewMood: MyReview['mood'];
+  editingReviewFile: File | null;
+  editingReviewRemoveImage: boolean;
+  reviewUpdatingId: string | null;
+  reviewEditError: string | null;
+  setEditingReviewBody: (body: string) => void;
+  setEditingReviewMood: (mood: MyReview['mood']) => void;
+  setEditingReviewFile: (file: File | null) => void;
+  setEditingReviewRemoveImage: (next: boolean | ((current: boolean) => boolean)) => void;
+  startEditingReview: (review: MyReview) => void;
+  cancelEditingReview: () => void;
+  handleSaveReview: (reviewId: string) => Promise<void>;
+  onOpenPlace: (placeId: string) => void;
+  onOpenReview: (reviewId: string) => void;
+  onDeleteReview: (reviewId: string) => Promise<void>;
+  onUpdateReview: (reviewId: string, payload: ReviewUpdatePayload) => Promise<void>;
+}
+
+export function MyFeedReviewCard({
+  review,
+  editingReviewId,
+  editingReviewBody,
+  editingReviewMood,
+  editingReviewFile,
+  editingReviewRemoveImage,
+  reviewUpdatingId,
+  reviewEditError,
+  setEditingReviewBody,
+  setEditingReviewMood,
+  setEditingReviewFile,
+  setEditingReviewRemoveImage,
+  startEditingReview,
+  cancelEditingReview,
+  handleSaveReview,
+  onOpenPlace,
+  onOpenReview,
+  onDeleteReview,
+  onUpdateReview,
+}: MyFeedReviewCardProps) {
+  void onUpdateReview;
+
+  return (
+    <article className="review-card review-card--my-feed">
+      <ReviewFeedCardHeader
+        title={(
+          <button type="button" className="review-card__place-anchor" onClick={() => onOpenPlace(review.placeId)}>
+            <strong className="review-card__title">{review.placeName}</strong>
+          </button>
+        )}
+        mood={review.mood}
+        meta={review.visitedAt}
+      />
+      <ReviewTagRow visitLabel={review.visitLabel} badge={review.badge} hasPublishedRoute={review.hasPublishedRoute} />
+      {editingReviewId === review.id ? (
+        <div className="route-builder-form review-edit-form">
+          <ReviewFormFields
+            moodOptions={reviewMoodOptions}
+            mood={editingReviewMood}
+            onMoodChange={setEditingReviewMood}
+            body={editingReviewBody}
+            onBodyChange={setEditingReviewBody}
+            file={editingReviewFile}
+            onFileChange={(nextFile) => {
+              setEditingReviewFile(nextFile);
+              if (nextFile) {
+                setEditingReviewRemoveImage(false);
+              }
+            }}
+            disabled={reviewUpdatingId === review.id}
+            bodyLabel="리뷰 내용"
+            fileLabel="리뷰 이미지"
+            existingImageUrl={review.imageUrl}
+            existingImageAlt={`${review.placeName} 기존 리뷰 이미지`}
+            removeImage={editingReviewRemoveImage}
+            onToggleRemoveImage={review.imageUrl ? (() => {
+              setEditingReviewRemoveImage((current) => !current);
+              setEditingReviewFile(null);
+            }) : undefined}
+          />
+          {reviewEditError ? <p className="form-error-copy">{reviewEditError}</p> : null}
+          <div className="review-card__actions review-card__actions--my-feed review-card__actions--my-feed-links">
+            <button
+              type="button"
+              className="secondary-button"
+              onClick={cancelEditingReview}
+              disabled={reviewUpdatingId === review.id}
+            >
+              취소
+            </button>
+            <button
+              type="button"
+              className="primary-button"
+              disabled={reviewUpdatingId === review.id || editingReviewBody.trim().length < 4}
+              onClick={() => void handleSaveReview(review.id)}
+            >
+              {reviewUpdatingId === review.id ? '저장 중' : '수정 저장'}
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <p className="review-card__body">{review.body}</p>
+          <div className="review-card__actions review-card__actions--my-feed">
+            <button type="button" className="review-card__place-link" onClick={() => onOpenReview(review.id)}>내 리뷰 보기</button>
+            <button type="button" className="review-card__place-link" onClick={() => startEditingReview(review)}>수정</button>
+            <button type="button" className="review-card__place-link review-card__place-link--danger" onClick={() => void onDeleteReview(review.id)}>삭제</button>
+          </div>
+        </>
+      )}
+    </article>
+  );
+}

--- a/src/components/my-page/MyFeedTabSection.tsx
+++ b/src/components/my-page/MyFeedTabSection.tsx
@@ -1,18 +1,13 @@
-import { useState } from 'react';
-import { ReviewFormFields } from '../ReviewFormFields';
-import { ReviewFeedCardHeader } from '../review/ReviewFeedCardHeader';
-import { ReviewTagRow } from '../review/ReviewTagRow';
-import type { MyPageResponse, ReviewMood } from '../../types';
-
-const reviewMoodOptions: ReviewMood[] = ['혼자서', '친구랑', '데이트', '야경 맛집'];
-
-type MyReview = NonNullable<MyPageResponse>['reviews'][number];
+import type { ReviewUpdatePayload } from './myFeedTabTypes';
+import type { MyReview } from './myFeedTabTypes';
+import { MyFeedReviewCard } from './MyFeedReviewCard';
+import { useMyFeedReviewEditor } from './useMyFeedReviewEditor';
 
 interface MyFeedTabSectionProps {
   reviews: MyReview[];
   onOpenPlace: (placeId: string) => void;
   onOpenReview: (reviewId: string) => void;
-  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
+  onUpdateReview: (reviewId: string, payload: ReviewUpdatePayload) => Promise<void>;
   onDeleteReview: (reviewId: string) => Promise<void>;
 }
 
@@ -23,123 +18,22 @@ export function MyFeedTabSection({
   onUpdateReview,
   onDeleteReview,
 }: MyFeedTabSectionProps) {
-  const [editingReviewId, setEditingReviewId] = useState<string | null>(null);
-  const [editingReviewBody, setEditingReviewBody] = useState('');
-  const [editingReviewMood, setEditingReviewMood] = useState<ReviewMood>('혼자서');
-  const [editingReviewFile, setEditingReviewFile] = useState<File | null>(null);
-  const [editingReviewRemoveImage, setEditingReviewRemoveImage] = useState(false);
-  const [reviewUpdatingId, setReviewUpdatingId] = useState<string | null>(null);
-  const [reviewEditError, setReviewEditError] = useState<string | null>(null);
-
-  function startEditingReview(review: MyReview) {
-    setEditingReviewId(review.id);
-    setEditingReviewBody(review.body);
-    setEditingReviewMood(review.mood);
-    setEditingReviewFile(null);
-    setEditingReviewRemoveImage(false);
-    setReviewEditError(null);
-  }
-
-  function cancelEditingReview() {
-    setEditingReviewId(null);
-    setEditingReviewBody('');
-    setEditingReviewMood('혼자서');
-    setEditingReviewFile(null);
-    setEditingReviewRemoveImage(false);
-    setReviewEditError(null);
-  }
-
-  async function handleSaveReview(reviewId: string) {
-    try {
-      setReviewUpdatingId(reviewId);
-      setReviewEditError(null);
-      await onUpdateReview(reviewId, {
-        body: editingReviewBody.trim(),
-        mood: editingReviewMood,
-        file: editingReviewFile,
-        removeImage: editingReviewRemoveImage,
-      });
-      cancelEditingReview();
-    } catch (error) {
-      setReviewEditError(error instanceof Error ? error.message : '피드를 수정하지 못했어요.');
-    } finally {
-      setReviewUpdatingId(null);
-    }
-  }
+  const reviewEditor = useMyFeedReviewEditor(onUpdateReview);
 
   return (
     <div className="review-stack">
       {reviews.map((review) => (
-        <article key={review.id} className="review-card review-card--my-feed">
-          <ReviewFeedCardHeader
-            title={
-              <button type="button" className="review-card__place-anchor" onClick={() => onOpenPlace(review.placeId)}>
-                <strong className="review-card__title">{review.placeName}</strong>
-              </button>
-            }
-            mood={review.mood}
-            meta={review.visitedAt}
-          />
-          <ReviewTagRow visitLabel={review.visitLabel} badge={review.badge} hasPublishedRoute={review.hasPublishedRoute} />
-          {editingReviewId === review.id ? (
-            <div className="route-builder-form review-edit-form">
-              <ReviewFormFields
-                moodOptions={reviewMoodOptions}
-                mood={editingReviewMood}
-                onMoodChange={setEditingReviewMood}
-                body={editingReviewBody}
-                onBodyChange={setEditingReviewBody}
-                file={editingReviewFile}
-                onFileChange={(nextFile) => {
-                  setEditingReviewFile(nextFile);
-                  if (nextFile) {
-                    setEditingReviewRemoveImage(false);
-                  }
-                }}
-                disabled={reviewUpdatingId === review.id}
-                bodyLabel="피드 내용"
-                fileLabel="피드 이미지"
-                existingImageUrl={review.imageUrl}
-                existingImageAlt={`${review.placeName} 기존 피드 이미지`}
-                removeImage={editingReviewRemoveImage}
-                onToggleRemoveImage={review.imageUrl ? (() => {
-                  setEditingReviewRemoveImage((current) => !current);
-                  setEditingReviewFile(null);
-                }) : undefined}
-              />
-              {reviewEditError ? <p className="form-error-copy">{reviewEditError}</p> : null}
-              <div className="review-card__actions review-card__actions--my-feed review-card__actions--my-feed-links">
-                <button
-                  type="button"
-                  className="secondary-button"
-                  onClick={cancelEditingReview}
-                  disabled={reviewUpdatingId === review.id}
-                >
-                  취소
-                </button>
-                <button
-                  type="button"
-                  className="primary-button"
-                  disabled={reviewUpdatingId === review.id || editingReviewBody.trim().length < 4}
-                  onClick={() => void handleSaveReview(review.id)}
-                >
-                  {reviewUpdatingId === review.id ? '저장 중' : '수정 저장'}
-                </button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <p className="review-card__body">{review.body}</p>
-              <div className="review-card__actions review-card__actions--my-feed">
-                <button type="button" className="review-card__place-link" onClick={() => onOpenReview(review.id)}>내 피드 보기</button>
-                <button type="button" className="review-card__place-link" onClick={() => startEditingReview(review)}>수정</button>
-                <button type="button" className="review-card__place-link review-card__place-link--danger" onClick={() => void onDeleteReview(review.id)}>삭제</button>
-              </div>
-            </>
-          )}
-        </article>
+        <MyFeedReviewCard
+          key={review.id}
+          review={review}
+          onOpenPlace={onOpenPlace}
+          onOpenReview={onOpenReview}
+          onUpdateReview={onUpdateReview}
+          onDeleteReview={onDeleteReview}
+          {...reviewEditor}
+        />
       ))}
-      {reviews.length === 0 && <p className="empty-copy">아직 작성한 피드가 없어요.</p>}
+      {reviews.length === 0 && <p className="empty-copy">아직 작성한 리뷰가 없어요.</p>}
     </div>
   );
 }

--- a/src/components/my-page/myFeedTabTypes.ts
+++ b/src/components/my-page/myFeedTabTypes.ts
@@ -1,0 +1,12 @@
+import type { MyPageResponse, ReviewMood } from '../../types';
+
+export const reviewMoodOptions: ReviewMood[] = ['혼자서', '친구랑', '데이트', '야경 맛집'];
+
+export type MyReview = NonNullable<MyPageResponse>['reviews'][number];
+
+export interface ReviewUpdatePayload {
+  body: string;
+  mood: ReviewMood;
+  file?: File | null;
+  removeImage?: boolean;
+}

--- a/src/components/my-page/useMyFeedReviewEditor.ts
+++ b/src/components/my-page/useMyFeedReviewEditor.ts
@@ -1,0 +1,66 @@
+import { useState } from 'react';
+import type { ReviewMood } from '../../types';
+import type { MyReview, ReviewUpdatePayload } from './myFeedTabTypes';
+
+export function useMyFeedReviewEditor(onUpdateReview: (reviewId: string, payload: ReviewUpdatePayload) => Promise<void>) {
+  const [editingReviewId, setEditingReviewId] = useState<string | null>(null);
+  const [editingReviewBody, setEditingReviewBody] = useState('');
+  const [editingReviewMood, setEditingReviewMood] = useState<ReviewMood>('혼자서');
+  const [editingReviewFile, setEditingReviewFile] = useState<File | null>(null);
+  const [editingReviewRemoveImage, setEditingReviewRemoveImage] = useState(false);
+  const [reviewUpdatingId, setReviewUpdatingId] = useState<string | null>(null);
+  const [reviewEditError, setReviewEditError] = useState<string | null>(null);
+
+  function startEditingReview(review: MyReview) {
+    setEditingReviewId(review.id);
+    setEditingReviewBody(review.body);
+    setEditingReviewMood(review.mood);
+    setEditingReviewFile(null);
+    setEditingReviewRemoveImage(false);
+    setReviewEditError(null);
+  }
+
+  function cancelEditingReview() {
+    setEditingReviewId(null);
+    setEditingReviewBody('');
+    setEditingReviewMood('혼자서');
+    setEditingReviewFile(null);
+    setEditingReviewRemoveImage(false);
+    setReviewEditError(null);
+  }
+
+  async function handleSaveReview(reviewId: string) {
+    try {
+      setReviewUpdatingId(reviewId);
+      setReviewEditError(null);
+      await onUpdateReview(reviewId, {
+        body: editingReviewBody.trim(),
+        mood: editingReviewMood,
+        file: editingReviewFile,
+        removeImage: editingReviewRemoveImage,
+      });
+      cancelEditingReview();
+    } catch (error) {
+      setReviewEditError(error instanceof Error ? error.message : '리뷰를 수정하지 못했어요.');
+    } finally {
+      setReviewUpdatingId(null);
+    }
+  }
+
+  return {
+    editingReviewId,
+    editingReviewBody,
+    editingReviewMood,
+    editingReviewFile,
+    editingReviewRemoveImage,
+    reviewUpdatingId,
+    reviewEditError,
+    setEditingReviewBody,
+    setEditingReviewMood,
+    setEditingReviewFile,
+    setEditingReviewRemoveImage,
+    startEditingReview,
+    cancelEditingReview,
+    handleSaveReview,
+  };
+}


### PR DESCRIPTION
## Summary
- split MyFeedTabSection into review editor state and review card components
- keep the section focused on list orchestration
- fix broken review mood/type strings that were leaking into the edit flow

## Validation
- npm run typecheck
- npm run lint -- src/components/my-page/MyFeedTabSection.tsx src/components/my-page/MyFeedReviewCard.tsx src/components/my-page/useMyFeedReviewEditor.ts src/components/my-page/myFeedTabTypes.ts src/components/my-page/myRoutesTabTypes.ts src/components/ReviewComposer.tsx src/types/core.ts
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py