### PR TITLE
Refactor my page panel states

### DIFF
--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -1,8 +1,10 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useAutoLoadMore } from '../hooks/useAutoLoadMore';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
-import { ProviderButtons } from './ProviderButtons';
 import { MyPageAccountSection } from './my-page/MyPageAccountSection';
+import { MyPageGuestState } from './my-page/MyPageGuestState';
+import { MyPageHeader } from './my-page/MyPageHeader';
+import { MyPageLoadError } from './my-page/MyPageLoadError';
 import { MyPageOverviewSection } from './my-page/MyPageOverviewSection';
 import { MyPageSettingsSection } from './my-page/MyPageSettingsSection';
 import { MyPageTabContent } from './my-page/MyPageTabContent';
@@ -80,44 +82,16 @@ export function MyPagePanel({
   if (!sessionUser) {
     return (
       <section ref={scrollRef} className="page-panel page-panel--scrollable">
-        <header className="panel-header">
-          <p className="eyebrow">MY PAGE</p>
-          <h2>로그인하고 기록 이어보기</h2>
-          <p>스탬프, 피드, 코스를 계정 기준으로 이어보려면 먼저 로그인해 주세요.</p>
-        </header>
-        <section className="sheet-card stack-gap">
-          <ProviderButtons providers={providers} onLogin={onLogin} />
-        </section>
+        <MyPageGuestState providers={providers} onLogin={onLogin} />
       </section>
     );
   }
 
   return (
     <section ref={scrollRef} className="page-panel page-panel--scrollable">
-      <header className="panel-header panel-header--with-action">
-        <div>
-          <p className="eyebrow">MY PAGE</p>
-          <h2>{sessionUser.nickname}님의 기록</h2>
-          <p>
-            스탬프와 피드, 댓글을 확인할 수 있고,
-            <br />
-            하나의 여행 세션을 코스로 발행할 수 있어요.
-          </p>
-        </div>
-      </header>
+      <MyPageHeader sessionUser={sessionUser} />
 
-      {!myPage && myPageError && (
-        <section className="sheet-card stack-gap">
-          <div>
-            <p className="eyebrow">MY PAGE</p>
-            <h3>기록을 아직 불러오지 못했어요</h3>
-            <p className="section-copy">{myPageError}</p>
-          </div>
-          <button type="button" className="primary-button route-submit-button" onClick={() => void onRetry()}>
-            다시 불러오기
-          </button>
-        </section>
-      )}
+      {!myPage && myPageError && <MyPageLoadError myPageError={myPageError} onRetry={onRetry} />}
 
       <MyPageAccountSection
         sessionUser={sessionUser}

--- a/src/components/my-page/MyPageGuestState.tsx
+++ b/src/components/my-page/MyPageGuestState.tsx
@@ -1,0 +1,22 @@
+import type { AuthProvider, ProviderKey } from '../../types';
+import { ProviderButtons } from '../ProviderButtons';
+
+interface MyPageGuestStateProps {
+  providers: AuthProvider[];
+  onLogin: (provider: ProviderKey) => void;
+}
+
+export function MyPageGuestState({ providers, onLogin }: MyPageGuestStateProps) {
+  return (
+    <>
+      <header className="panel-header">
+        <p className="eyebrow">MY PAGE</p>
+        <h2>로그인하고 기록 이어보기</h2>
+        <p>스탬프와 리뷰, 코스를 계정 기준으로 이어보려면 먼저 로그인해 주세요.</p>
+      </header>
+      <section className="sheet-card stack-gap">
+        <ProviderButtons providers={providers} onLogin={onLogin} />
+      </section>
+    </>
+  );
+}

--- a/src/components/my-page/MyPageHeader.tsx
+++ b/src/components/my-page/MyPageHeader.tsx
@@ -1,0 +1,21 @@
+import type { SessionUser } from '../../types';
+
+interface MyPageHeaderProps {
+  sessionUser: SessionUser;
+}
+
+export function MyPageHeader({ sessionUser }: MyPageHeaderProps) {
+  return (
+    <header className="panel-header panel-header--with-action">
+      <div>
+        <p className="eyebrow">MY PAGE</p>
+        <h2>{sessionUser.nickname}님의 기록</h2>
+        <p>
+          스탬프와 리뷰, 여정을 확인하면서,
+          <br />
+          하나의 여행 동선을 코스로 발행할 수 있어요.
+        </p>
+      </div>
+    </header>
+  );
+}

--- a/src/components/my-page/MyPageLoadError.tsx
+++ b/src/components/my-page/MyPageLoadError.tsx
@@ -1,0 +1,19 @@
+interface MyPageLoadErrorProps {
+  myPageError: string;
+  onRetry: () => Promise<void>;
+}
+
+export function MyPageLoadError({ myPageError, onRetry }: MyPageLoadErrorProps) {
+  return (
+    <section className="sheet-card stack-gap">
+      <div>
+        <p className="eyebrow">MY PAGE</p>
+        <h3>기록을 아직 불러오지 못했어요</h3>
+        <p className="section-copy">{myPageError}</p>
+      </div>
+      <button type="button" className="primary-button route-submit-button" onClick={() => void onRetry()}>
+        다시 불러오기
+      </button>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary
- split MyPagePanel guest state, header, and load-error rendering into dedicated components
- keep MyPagePanel focused on state wiring and tab composition
- restore broken my-page intro copy while preserving behavior

## Validation
- npm run typecheck
- npm run lint -- src/components/MyPagePanel.tsx src/components/my-page/MyPageGuestState.tsx src/components/my-page/MyPageHeader.tsx src/components/my-page/MyPageLoadError.tsx
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py