### PR TITLE
Refactor map tab stage composition

### DIFF
--- a/src/components/MapTabStage.tsx
+++ b/src/components/MapTabStage.tsx
@@ -1,79 +1,8 @@
-import { FestivalDetailSheet } from './FestivalDetailSheet';
-import { NaverMap } from './NaverMap';
-import { PlaceDetailSheet } from './PlaceDetailSheet';
 import { MapStageBrandHeader } from './map-stage/MapStageBrandHeader';
 import { MapStageCategoryStrip } from './map-stage/MapStageCategoryStrip';
-import { MapStageDrawerTeaser } from './map-stage/MapStageDrawerTeaser';
-import { MapStageRoutePreviewCard } from './map-stage/MapStageRoutePreviewCard';
-import type {
-  ApiStatus,
-  BootstrapResponse,
-  Category,
-  DrawerState,
-  FestivalItem,
-  Place,
-  ReviewMood,
-  RoutePreview,
-  SessionUser,
-} from '../types';
-
-interface MapTabStageProps {
-  mapData: {
-    activeCategory: Category;
-    filteredPlaces: Place[];
-    festivals: FestivalItem[];
-    currentPosition: { latitude: number; longitude: number } | null;
-    mapLocationStatus: ApiStatus;
-    mapLocationFocusKey: number;
-    routePreviewPlaces: Place[];
-  };
-  routePreviewData: {
-    routePreview: RoutePreview | null;
-    onClearRoutePreview: () => void;
-    onOpenRoutePreviewPlace: (placeId: string) => void;
-  };
-  viewportData: {
-    initialMapCenter?: { lat: number; lng: number };
-    initialMapZoom?: number;
-    onLocateCurrentPosition: () => void;
-    onMapViewportChange: (lat: number, lng: number, zoom: number) => void;
-  };
-  placeSheet: {
-    selectedPlace: Place | null;
-    drawerState: DrawerState;
-    sessionUser: SessionUser | null;
-    selectedPlaceReviews: BootstrapResponse['reviews'];
-    visitCount: number;
-    latestStamp: BootstrapResponse['stamps']['logs'][number] | null;
-    todayStamp: BootstrapResponse['stamps']['logs'][number] | null;
-    stampActionStatus: ApiStatus;
-    stampActionMessage: string;
-    reviewProofMessage: string;
-    reviewError: string | null;
-    reviewSubmitting: boolean;
-    canCreateReview: boolean;
-    hasCreatedReviewToday: boolean;
-    onOpenPlace: (placeId: string) => void;
-    onOpenFeedReview: () => void;
-    onCloseDrawer: () => void;
-    onExpandPlaceDrawer: () => void;
-    onCollapsePlaceDrawer: () => void;
-    onRequestLogin: () => void;
-    onClaimStamp: (place: Place) => Promise<void>;
-    onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
-  };
-  festivalSheet: {
-    selectedFestival: FestivalItem | null;
-    drawerState: DrawerState;
-    onOpenFestival: (festivalId: string) => void;
-    onCloseDrawer: () => void;
-    onExpandFestivalDrawer: () => void;
-    onCollapseFestivalDrawer: () => void;
-  };
-  mapActions: {
-    setActiveCategory: (category: Category) => void;
-  };
-}
+import { MapStageMapSurface } from './map-stage/MapStageMapSurface';
+import { MapStageSheets } from './map-stage/MapStageSheets';
+import type { MapTabStageProps } from './map-stage/mapTabStageTypes';
 
 export function MapTabStage({
   mapData,
@@ -83,8 +12,6 @@ export function MapTabStage({
   festivalSheet,
   mapActions,
 }: MapTabStageProps) {
-  const showRoutePreview = !placeSheet.selectedPlace && !festivalSheet.selectedFestival;
-
   return (
     <div className="map-stage">
       <MapStageBrandHeader />
@@ -92,69 +19,14 @@ export function MapTabStage({
         activeCategory={mapData.activeCategory}
         onSelectCategory={mapActions.setActiveCategory}
       />
-
-      <NaverMap
-        places={mapData.filteredPlaces}
-        festivals={mapData.festivals}
-        selectedPlaceId={placeSheet.selectedPlace?.id ?? null}
-        selectedFestivalId={festivalSheet.selectedFestival?.id ?? null}
-        onSelectPlace={placeSheet.onOpenPlace}
-        onSelectFestival={festivalSheet.onOpenFestival}
-        currentPosition={mapData.currentPosition}
-        currentLocationStatus={mapData.mapLocationStatus}
-        currentLocationMessage={null}
-        focusCurrentLocationKey={mapData.mapLocationFocusKey}
-        onLocateCurrentPosition={viewportData.onLocateCurrentPosition}
-        initialCenter={viewportData.initialMapCenter}
-        initialZoom={viewportData.initialMapZoom}
-        onViewportChange={viewportData.onMapViewportChange}
-        routePreviewPlaces={mapData.routePreviewPlaces}
-        height="100%"
+      <MapStageMapSurface
+        mapData={mapData}
+        routePreviewData={routePreviewData}
+        viewportData={viewportData}
+        placeSheet={placeSheet}
+        festivalSheet={festivalSheet}
       />
-
-      {showRoutePreview && (
-        <MapStageRoutePreviewCard
-          routePreview={routePreviewData.routePreview}
-          onClearRoutePreview={routePreviewData.onClearRoutePreview}
-          onOpenRoutePreviewPlace={routePreviewData.onOpenRoutePreviewPlace}
-        />
-      )}
-
-      {showRoutePreview && <MapStageDrawerTeaser />}
-
-      <PlaceDetailSheet
-        place={placeSheet.selectedPlace}
-        reviews={placeSheet.selectedPlaceReviews}
-        isOpen={Boolean(placeSheet.selectedPlace) && placeSheet.drawerState !== 'closed'}
-        drawerState={placeSheet.drawerState}
-        loggedIn={Boolean(placeSheet.sessionUser)}
-        visitCount={placeSheet.visitCount}
-        latestStamp={placeSheet.latestStamp}
-        todayStamp={placeSheet.todayStamp}
-        hasCreatedReviewToday={placeSheet.hasCreatedReviewToday}
-        stampActionStatus={placeSheet.stampActionStatus}
-        stampActionMessage={placeSheet.stampActionMessage}
-        reviewProofMessage={placeSheet.reviewProofMessage}
-        reviewError={placeSheet.reviewError}
-        reviewSubmitting={placeSheet.reviewSubmitting}
-        canCreateReview={placeSheet.canCreateReview}
-        onOpenFeedReview={placeSheet.onOpenFeedReview}
-        onClose={placeSheet.onCloseDrawer}
-        onExpand={placeSheet.onExpandPlaceDrawer}
-        onCollapse={placeSheet.onCollapsePlaceDrawer}
-        onRequestLogin={placeSheet.onRequestLogin}
-        onClaimStamp={placeSheet.onClaimStamp}
-        onCreateReview={placeSheet.onCreateReview}
-      />
-
-      <FestivalDetailSheet
-        festival={festivalSheet.selectedFestival}
-        isOpen={Boolean(festivalSheet.selectedFestival) && festivalSheet.drawerState !== 'closed'}
-        drawerState={festivalSheet.drawerState}
-        onClose={festivalSheet.onCloseDrawer}
-        onExpand={festivalSheet.onExpandFestivalDrawer}
-        onCollapse={festivalSheet.onCollapseFestivalDrawer}
-      />
+      <MapStageSheets placeSheet={placeSheet} festivalSheet={festivalSheet} />
     </div>
   );
 }

--- a/src/components/map-stage/MapStageMapSurface.tsx
+++ b/src/components/map-stage/MapStageMapSurface.tsx
@@ -1,0 +1,55 @@
+import { NaverMap } from '../NaverMap';
+import { MapStageDrawerTeaser } from './MapStageDrawerTeaser';
+import { MapStageRoutePreviewCard } from './MapStageRoutePreviewCard';
+import type { MapTabStageProps } from './mapTabStageTypes';
+
+interface MapStageMapSurfaceProps {
+  mapData: MapTabStageProps['mapData'];
+  routePreviewData: MapTabStageProps['routePreviewData'];
+  viewportData: MapTabStageProps['viewportData'];
+  placeSheet: MapTabStageProps['placeSheet'];
+  festivalSheet: MapTabStageProps['festivalSheet'];
+}
+
+export function MapStageMapSurface({
+  mapData,
+  routePreviewData,
+  viewportData,
+  placeSheet,
+  festivalSheet,
+}: MapStageMapSurfaceProps) {
+  const showRoutePreview = !placeSheet.selectedPlace && !festivalSheet.selectedFestival;
+
+  return (
+    <>
+      <NaverMap
+        places={mapData.filteredPlaces}
+        festivals={mapData.festivals}
+        selectedPlaceId={placeSheet.selectedPlace?.id ?? null}
+        selectedFestivalId={festivalSheet.selectedFestival?.id ?? null}
+        onSelectPlace={placeSheet.onOpenPlace}
+        onSelectFestival={festivalSheet.onOpenFestival}
+        currentPosition={mapData.currentPosition}
+        currentLocationStatus={mapData.mapLocationStatus}
+        currentLocationMessage={null}
+        focusCurrentLocationKey={mapData.mapLocationFocusKey}
+        onLocateCurrentPosition={viewportData.onLocateCurrentPosition}
+        initialCenter={viewportData.initialMapCenter}
+        initialZoom={viewportData.initialMapZoom}
+        onViewportChange={viewportData.onMapViewportChange}
+        routePreviewPlaces={mapData.routePreviewPlaces}
+        height="100%"
+      />
+
+      {showRoutePreview && (
+        <MapStageRoutePreviewCard
+          routePreview={routePreviewData.routePreview}
+          onClearRoutePreview={routePreviewData.onClearRoutePreview}
+          onOpenRoutePreviewPlace={routePreviewData.onOpenRoutePreviewPlace}
+        />
+      )}
+
+      {showRoutePreview && <MapStageDrawerTeaser />}
+    </>
+  );
+}

--- a/src/components/map-stage/MapStageSheets.tsx
+++ b/src/components/map-stage/MapStageSheets.tsx
@@ -1,0 +1,48 @@
+import { FestivalDetailSheet } from '../FestivalDetailSheet';
+import { PlaceDetailSheet } from '../PlaceDetailSheet';
+import type { MapTabStageProps } from './mapTabStageTypes';
+
+interface MapStageSheetsProps {
+  placeSheet: MapTabStageProps['placeSheet'];
+  festivalSheet: MapTabStageProps['festivalSheet'];
+}
+
+export function MapStageSheets({ placeSheet, festivalSheet }: MapStageSheetsProps) {
+  return (
+    <>
+      <PlaceDetailSheet
+        place={placeSheet.selectedPlace}
+        reviews={placeSheet.selectedPlaceReviews}
+        isOpen={Boolean(placeSheet.selectedPlace) && placeSheet.drawerState !== 'closed'}
+        drawerState={placeSheet.drawerState}
+        loggedIn={Boolean(placeSheet.sessionUser)}
+        visitCount={placeSheet.visitCount}
+        latestStamp={placeSheet.latestStamp}
+        todayStamp={placeSheet.todayStamp}
+        hasCreatedReviewToday={placeSheet.hasCreatedReviewToday}
+        stampActionStatus={placeSheet.stampActionStatus}
+        stampActionMessage={placeSheet.stampActionMessage}
+        reviewProofMessage={placeSheet.reviewProofMessage}
+        reviewError={placeSheet.reviewError}
+        reviewSubmitting={placeSheet.reviewSubmitting}
+        canCreateReview={placeSheet.canCreateReview}
+        onOpenFeedReview={placeSheet.onOpenFeedReview}
+        onClose={placeSheet.onCloseDrawer}
+        onExpand={placeSheet.onExpandPlaceDrawer}
+        onCollapse={placeSheet.onCollapsePlaceDrawer}
+        onRequestLogin={placeSheet.onRequestLogin}
+        onClaimStamp={placeSheet.onClaimStamp}
+        onCreateReview={placeSheet.onCreateReview}
+      />
+
+      <FestivalDetailSheet
+        festival={festivalSheet.selectedFestival}
+        isOpen={Boolean(festivalSheet.selectedFestival) && festivalSheet.drawerState !== 'closed'}
+        drawerState={festivalSheet.drawerState}
+        onClose={festivalSheet.onCloseDrawer}
+        onExpand={festivalSheet.onExpandFestivalDrawer}
+        onCollapse={festivalSheet.onCollapseFestivalDrawer}
+      />
+    </>
+  );
+}

--- a/src/components/map-stage/mapTabStageTypes.ts
+++ b/src/components/map-stage/mapTabStageTypes.ts
@@ -1,0 +1,69 @@
+import type {
+  ApiStatus,
+  BootstrapResponse,
+  Category,
+  DrawerState,
+  FestivalItem,
+  Place,
+  ReviewMood,
+  RoutePreview,
+  SessionUser,
+} from '../../types';
+
+export interface MapTabStageProps {
+  mapData: {
+    activeCategory: Category;
+    filteredPlaces: Place[];
+    festivals: FestivalItem[];
+    currentPosition: { latitude: number; longitude: number } | null;
+    mapLocationStatus: ApiStatus;
+    mapLocationFocusKey: number;
+    routePreviewPlaces: Place[];
+  };
+  routePreviewData: {
+    routePreview: RoutePreview | null;
+    onClearRoutePreview: () => void;
+    onOpenRoutePreviewPlace: (placeId: string) => void;
+  };
+  viewportData: {
+    initialMapCenter?: { lat: number; lng: number };
+    initialMapZoom?: number;
+    onLocateCurrentPosition: () => void;
+    onMapViewportChange: (lat: number, lng: number, zoom: number) => void;
+  };
+  placeSheet: {
+    selectedPlace: Place | null;
+    drawerState: DrawerState;
+    sessionUser: SessionUser | null;
+    selectedPlaceReviews: BootstrapResponse['reviews'];
+    visitCount: number;
+    latestStamp: BootstrapResponse['stamps']['logs'][number] | null;
+    todayStamp: BootstrapResponse['stamps']['logs'][number] | null;
+    stampActionStatus: ApiStatus;
+    stampActionMessage: string;
+    reviewProofMessage: string;
+    reviewError: string | null;
+    reviewSubmitting: boolean;
+    canCreateReview: boolean;
+    hasCreatedReviewToday: boolean;
+    onOpenPlace: (placeId: string) => void;
+    onOpenFeedReview: () => void;
+    onCloseDrawer: () => void;
+    onExpandPlaceDrawer: () => void;
+    onCollapsePlaceDrawer: () => void;
+    onRequestLogin: () => void;
+    onClaimStamp: (place: Place) => Promise<void>;
+    onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
+  };
+  festivalSheet: {
+    selectedFestival: FestivalItem | null;
+    drawerState: DrawerState;
+    onOpenFestival: (festivalId: string) => void;
+    onCloseDrawer: () => void;
+    onExpandFestivalDrawer: () => void;
+    onCollapseFestivalDrawer: () => void;
+  };
+  mapActions: {
+    setActiveCategory: (category: Category) => void;
+  };
+}


### PR DESCRIPTION
## Summary
- split MapTabStage into map surface and sheet composition helpers
- keep the top-level stage focused on stage wiring
- preserve map, route preview, and drawer behavior

## Validation
- npm run typecheck
- npm run lint -- src/components/MapTabStage.tsx src/components/map-stage/MapStageMapSurface.tsx src/components/map-stage/MapStageSheets.tsx src/components/map-stage/mapTabStageTypes.ts
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py