### PR TITLE
Refactor place detail sheet responsibilities

### DIFF
--- a/src/components/PlaceDetailSheet.tsx
+++ b/src/components/PlaceDetailSheet.tsx
@@ -1,36 +1,10 @@
-﻿import { useRef } from 'react';
 import { categoryInfo } from '../lib/categories';
 import { PlaceBadgeRow } from './place/PlaceBadgeRow';
 import { PlaceDetailHeader } from './place/PlaceDetailHeader';
+import { PlaceDetailReviewSection } from './place/PlaceDetailReviewSection';
 import { PlaceProofCard } from './place/PlaceProofCard';
-import { PlaceReviewPreviewList } from './review/PlaceReviewPreviewList';
-import { ReviewComposer } from './ReviewComposer';
-import type { ApiStatus, DrawerState, Place, Review, ReviewMood, StampLog } from '../types';
-
-interface PlaceDetailSheetProps {
-  place: Place | null;
-  reviews: Review[];
-  isOpen: boolean;
-  drawerState: DrawerState;
-  loggedIn: boolean;
-  visitCount: number;
-  latestStamp: StampLog | null;
-  todayStamp: StampLog | null;
-  hasCreatedReviewToday: boolean;
-  stampActionStatus: ApiStatus;
-  stampActionMessage: string;
-  reviewProofMessage: string;
-  reviewError: string | null;
-  reviewSubmitting: boolean;
-  canCreateReview: boolean;
-  onOpenFeedReview: () => void;
-  onClose: () => void;
-  onExpand: () => void;
-  onCollapse: () => void;
-  onRequestLogin: () => void;
-  onClaimStamp: (place: Place) => Promise<void>;
-  onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
-}
+import type { PlaceDetailSheetProps } from './place/placeDetailSheetTypes';
+import { usePlaceDrawerHandle } from './place/usePlaceDrawerHandle';
 
 export function PlaceDetailSheet({
   place,
@@ -56,44 +30,21 @@ export function PlaceDetailSheet({
   onClaimStamp,
   onCreateReview,
 }: PlaceDetailSheetProps) {
-  const dragStartYRef = useRef<number | null>(null);
+  const { handlePointerDown, handlePointerUp, handleClick } = usePlaceDrawerHandle({
+    drawerState,
+    onClose,
+    onExpand,
+    onCollapse,
+  });
 
   if (!place || !isOpen) {
     return null;
-  }
-
-  function handlePointerDown(event: React.PointerEvent<HTMLButtonElement>) {
-    dragStartYRef.current = event.clientY;
-  }
-
-  function handlePointerUp(event: React.PointerEvent<HTMLButtonElement>) {
-    if (dragStartYRef.current === null) {
-      return;
-    }
-
-    const delta = event.clientY - dragStartYRef.current;
-    dragStartYRef.current = null;
-
-    if (delta > 72) {
-      if (drawerState === 'full') {
-        onCollapse();
-        return;
-      }
-      onClose();
-      return;
-    }
-
-    if (delta < -48) {
-      onExpand();
-    }
   }
 
   const sheetClassName = `place-drawer place-drawer--${drawerState}`;
   const visitLabel = latestStamp ? latestStamp.visitLabel : '첫 방문 대기';
   const canClaimStamp = loggedIn && !todayStamp;
   const categoryMeta = categoryInfo[place.category];
-  const reviewPreview = reviews.slice(0, 2);
-  const reviewComposerStatus = !loggedIn ? 'login' : hasCreatedReviewToday ? 'daily-limit' : todayStamp ? 'ready' : 'claim';
 
   return (
     <section className={sheetClassName} aria-label="장소 상세 시트">
@@ -103,7 +54,7 @@ export function PlaceDetailSheet({
         aria-label="시트 높이 조절"
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
-        onClick={drawerState === 'partial' ? onExpand : onCollapse}
+        onClick={handleClick}
       >
         <span />
       </button>
@@ -143,43 +94,21 @@ export function PlaceDetailSheet({
           <p>{place.routeHint}</p>
         </div>
 
-        <ReviewComposer
-          placeName={place.name}
+        <PlaceDetailReviewSection
+          place={place}
+          reviews={reviews}
           loggedIn={loggedIn}
-          canSubmit={canCreateReview}
-          status={reviewComposerStatus}
-          submitting={reviewSubmitting}
-          errorMessage={reviewError}
-          proofMessage={reviewProofMessage}
-          onSubmit={({ body, mood, file }) => {
-            if (!todayStamp) {
-              return Promise.resolve();
-            }
-            return onCreateReview({ stampId: todayStamp.id, body, mood, file });
-          }}
+          todayStamp={todayStamp}
+          hasCreatedReviewToday={hasCreatedReviewToday}
+          reviewSubmitting={reviewSubmitting}
+          reviewError={reviewError}
+          reviewProofMessage={reviewProofMessage}
+          canCreateReview={canCreateReview}
+          onOpenFeedReview={onOpenFeedReview}
           onRequestLogin={onRequestLogin}
-          onRequestProof={() => {
-            if (!loggedIn) {
-              onRequestLogin();
-              return;
-            }
-            if (!todayStamp) {
-              void onClaimStamp(place);
-            }
-          }}
+          onClaimStamp={onClaimStamp}
+          onCreateReview={onCreateReview}
         />
-
-        <div className="section-title-row section-title-row--tight">
-          <div>
-            <p className="eyebrow">PLACE FEED</p>
-            <h3>이 장소 피드</h3>
-          </div>
-          <button type="button" className="secondary-button place-drawer__feed-button" onClick={onOpenFeedReview}>
-            피드에서 보기
-          </button>
-        </div>
-
-        <PlaceReviewPreviewList reviews={reviewPreview} />
       </div>
     </section>
   );

--- a/src/components/place/PlaceDetailReviewSection.tsx
+++ b/src/components/place/PlaceDetailReviewSection.tsx
@@ -1,0 +1,80 @@
+import { PlaceReviewPreviewList } from '../review/PlaceReviewPreviewList';
+import { ReviewComposer } from '../ReviewComposer';
+import type { PlaceDetailSheetProps } from './placeDetailSheetTypes';
+
+interface PlaceDetailReviewSectionProps {
+  place: NonNullable<PlaceDetailSheetProps['place']>;
+  reviews: PlaceDetailSheetProps['reviews'];
+  loggedIn: boolean;
+  todayStamp: PlaceDetailSheetProps['todayStamp'];
+  hasCreatedReviewToday: boolean;
+  reviewSubmitting: boolean;
+  reviewError: string | null;
+  reviewProofMessage: string;
+  canCreateReview: boolean;
+  onOpenFeedReview: () => void;
+  onRequestLogin: () => void;
+  onClaimStamp: (place: NonNullable<PlaceDetailSheetProps['place']>) => Promise<void>;
+  onCreateReview: PlaceDetailSheetProps['onCreateReview'];
+}
+
+export function PlaceDetailReviewSection({
+  place,
+  reviews,
+  loggedIn,
+  todayStamp,
+  hasCreatedReviewToday,
+  reviewSubmitting,
+  reviewError,
+  reviewProofMessage,
+  canCreateReview,
+  onOpenFeedReview,
+  onRequestLogin,
+  onClaimStamp,
+  onCreateReview,
+}: PlaceDetailReviewSectionProps) {
+  const reviewPreview = reviews.slice(0, 2);
+  const reviewComposerStatus = !loggedIn ? 'login' : hasCreatedReviewToday ? 'daily-limit' : todayStamp ? 'ready' : 'claim';
+
+  return (
+    <>
+      <ReviewComposer
+        placeName={place.name}
+        loggedIn={loggedIn}
+        canSubmit={canCreateReview}
+        status={reviewComposerStatus}
+        submitting={reviewSubmitting}
+        errorMessage={reviewError}
+        proofMessage={reviewProofMessage}
+        onSubmit={({ body, mood, file }) => {
+          if (!todayStamp) {
+            return Promise.resolve();
+          }
+          return onCreateReview({ stampId: todayStamp.id, body, mood, file });
+        }}
+        onRequestLogin={onRequestLogin}
+        onRequestProof={() => {
+          if (!loggedIn) {
+            onRequestLogin();
+            return;
+          }
+          if (!todayStamp) {
+            void onClaimStamp(place);
+          }
+        }}
+      />
+
+      <div className="section-title-row section-title-row--tight">
+        <div>
+          <p className="eyebrow">PLACE FEED</p>
+          <h3>이 장소 피드</h3>
+        </div>
+        <button type="button" className="secondary-button place-drawer__feed-button" onClick={onOpenFeedReview}>
+          피드에서 보기
+        </button>
+      </div>
+
+      <PlaceReviewPreviewList reviews={reviewPreview} />
+    </>
+  );
+}

--- a/src/components/place/placeDetailSheetTypes.ts
+++ b/src/components/place/placeDetailSheetTypes.ts
@@ -1,0 +1,26 @@
+import type { ApiStatus, DrawerState, Place, Review, ReviewMood, StampLog } from '../../types';
+
+export interface PlaceDetailSheetProps {
+  place: Place | null;
+  reviews: Review[];
+  isOpen: boolean;
+  drawerState: DrawerState;
+  loggedIn: boolean;
+  visitCount: number;
+  latestStamp: StampLog | null;
+  todayStamp: StampLog | null;
+  hasCreatedReviewToday: boolean;
+  stampActionStatus: ApiStatus;
+  stampActionMessage: string;
+  reviewProofMessage: string;
+  reviewError: string | null;
+  reviewSubmitting: boolean;
+  canCreateReview: boolean;
+  onOpenFeedReview: () => void;
+  onClose: () => void;
+  onExpand: () => void;
+  onCollapse: () => void;
+  onRequestLogin: () => void;
+  onClaimStamp: (place: Place) => Promise<void>;
+  onCreateReview: (payload: { stampId: string; body: string; mood: ReviewMood; file: File | null }) => Promise<void>;
+}

--- a/src/components/place/usePlaceDrawerHandle.ts
+++ b/src/components/place/usePlaceDrawerHandle.ts
@@ -1,0 +1,50 @@
+import { useRef } from 'react';
+import type { DrawerState } from '../../types';
+
+interface UsePlaceDrawerHandleOptions {
+  drawerState: DrawerState;
+  onClose: () => void;
+  onExpand: () => void;
+  onCollapse: () => void;
+}
+
+export function usePlaceDrawerHandle({
+  drawerState,
+  onClose,
+  onExpand,
+  onCollapse,
+}: UsePlaceDrawerHandleOptions) {
+  const dragStartYRef = useRef<number | null>(null);
+
+  function handlePointerDown(event: React.PointerEvent<HTMLButtonElement>) {
+    dragStartYRef.current = event.clientY;
+  }
+
+  function handlePointerUp(event: React.PointerEvent<HTMLButtonElement>) {
+    if (dragStartYRef.current === null) {
+      return;
+    }
+
+    const delta = event.clientY - dragStartYRef.current;
+    dragStartYRef.current = null;
+
+    if (delta > 72) {
+      if (drawerState === 'full') {
+        onCollapse();
+        return;
+      }
+      onClose();
+      return;
+    }
+
+    if (delta < -48) {
+      onExpand();
+    }
+  }
+
+  return {
+    handlePointerDown,
+    handlePointerUp,
+    handleClick: drawerState === 'partial' ? onExpand : onCollapse,
+  };
+}


### PR DESCRIPTION
## Summary
- split PlaceDetailSheet drag handle logic into a dedicated hook
- move review composer and preview wiring into PlaceDetailReviewSection
- keep the top-level sheet focused on composition and place metadata

## Validation
- npm run typecheck
- npm run lint -- src/components/PlaceDetailSheet.tsx src/components/place/PlaceDetailReviewSection.tsx src/components/place/usePlaceDrawerHandle.ts src/components/place/placeDetailSheetTypes.ts
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py