### PR TITLE
Refactor app route state orchestration

### DIFF
--- a/src/hooks/app-route/routeStateActions.ts
+++ b/src/hooks/app-route/routeStateActions.ts
@@ -1,0 +1,53 @@
+import type { RoutePreview, Tab } from '../../types';
+import type { RouteState, RouteStateCommitOptions } from './routeHistoryState';
+import { buildHistoryState, buildRouteUrl } from './routeHistoryState';
+
+interface RouteStateSetterSet {
+  setActiveTab: (tab: Tab) => void;
+  setSelectedPlaceId: (placeId: string | null) => void;
+  setSelectedFestivalId: (festivalId: string | null) => void;
+  setDrawerState: (state: 'closed' | 'partial' | 'full') => void;
+  setSelectedRoutePreview: (preview: RoutePreview | null) => void;
+}
+
+export function applyRouteState(
+  routeState: RouteState,
+  routePreview: RoutePreview | null,
+  setters: RouteStateSetterSet,
+) {
+  setters.setActiveTab(routeState.tab);
+  setters.setSelectedPlaceId(routeState.tab === 'map' ? routeState.placeId : null);
+  setters.setSelectedFestivalId(routeState.tab === 'map' ? routeState.festivalId : null);
+  setters.setDrawerState(routeState.tab === 'map' ? routeState.drawerState : 'closed');
+  setters.setSelectedRoutePreview(routeState.tab === 'map' ? routePreview : null);
+}
+
+interface BuildCommitRouteStateParams extends RouteStateSetterSet {
+  getSelectedRoutePreview: () => RoutePreview | null;
+}
+
+export function buildCommitRouteState({
+  getSelectedRoutePreview,
+  ...setters
+}: BuildCommitRouteStateParams) {
+  return (routeState: RouteState, mode: 'push' | 'replace' = 'push', options?: RouteStateCommitOptions) => {
+    const requestedRoutePreview = options && Object.prototype.hasOwnProperty.call(options, 'routePreview')
+      ? options.routePreview ?? null
+      : getSelectedRoutePreview();
+    const nextRoutePreview = routeState.tab === 'map' ? requestedRoutePreview : null;
+    applyRouteState(routeState, nextRoutePreview, setters);
+
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const nextUrl = buildRouteUrl(routeState);
+    const nextHistoryState = buildHistoryState(routeState, nextRoutePreview);
+    if (mode === 'replace') {
+      window.history.replaceState(nextHistoryState, '', nextUrl);
+      return;
+    }
+
+    window.history.pushState(nextHistoryState, '', nextUrl);
+  };
+}

--- a/src/hooks/app-route/routeStoreInitialization.ts
+++ b/src/hooks/app-route/routeStoreInitialization.ts
@@ -1,0 +1,22 @@
+import { useAppMapStore } from '../../store/app-map-store';
+import { useAppRouteStore } from '../../store/app-route-store';
+import { getInitialRouteState } from './authQueryState';
+import { getRoutePreviewFromHistoryState } from './routeHistoryState';
+
+let routeStoreInitialized = false;
+
+export function initializeRouteStore() {
+  if (routeStoreInitialized || typeof window === 'undefined') {
+    return;
+  }
+
+  const routeState = getInitialRouteState();
+  useAppRouteStore.setState({
+    activeTab: routeState.tab,
+    selectedPlaceId: routeState.tab === 'map' ? routeState.placeId : null,
+    selectedFestivalId: routeState.tab === 'map' ? routeState.festivalId : null,
+    drawerState: routeState.tab === 'map' ? routeState.drawerState : 'closed',
+  });
+  useAppMapStore.setState({ selectedRoutePreview: getRoutePreviewFromHistoryState(window.history.state) });
+  routeStoreInitialized = true;
+}

--- a/src/hooks/useAppRouteState.ts
+++ b/src/hooks/useAppRouteState.ts
@@ -1,11 +1,11 @@
 import { useCallback, useEffect } from 'react';
 import { useAppMapStore } from '../store/app-map-store';
 import { useAppRouteStore } from '../store/app-route-store';
-import type { RoutePreview, Tab } from '../types';
+import type { Tab } from '../types';
 import {
   clearAuthQueryParams,
-  getInitialNotice,
   getInitialRouteState,
+  getInitialNotice,
   getLoginReturnUrl,
 } from './app-route/authQueryState';
 import {
@@ -21,35 +21,21 @@ import {
   type RouteState,
   type RouteStateCommitOptions,
 } from './app-route/routeHistoryState';
+import { buildCommitRouteState } from './app-route/routeStateActions';
+import { initializeRouteStore } from './app-route/routeStoreInitialization';
 
 export {
+  buildHistoryState,
+  buildRouteUrl,
   clearAuthQueryParams,
   getInitialMapViewport,
-  getInitialNotice,
   getInitialRouteState,
+  getInitialNotice,
   getLoginReturnUrl,
   updateMapViewportInUrl,
 };
 export type { AppHistoryState, MapViewport, RouteState, RouteStateCommitOptions };
-export { buildHistoryState, buildRouteUrl, getRoutePreviewFromHistoryState };
-
-let routeStoreInitialized = false;
-
-function initializeRouteStore() {
-  if (routeStoreInitialized || typeof window === 'undefined') {
-    return;
-  }
-
-  const routeState = getInitialRouteState();
-  useAppRouteStore.setState({
-    activeTab: routeState.tab,
-    selectedPlaceId: routeState.tab === 'map' ? routeState.placeId : null,
-    selectedFestivalId: routeState.tab === 'map' ? routeState.festivalId : null,
-    drawerState: routeState.tab === 'map' ? routeState.drawerState : 'closed',
-  });
-  useAppMapStore.setState({ selectedRoutePreview: getRoutePreviewFromHistoryState(window.history.state) });
-  routeStoreInitialized = true;
-}
+export { getRoutePreviewFromHistoryState, initializeRouteStore };
 
 export function useAppRouteState() {
   initializeRouteStore();
@@ -65,35 +51,16 @@ export function useAppRouteState() {
   const selectedRoutePreview = useAppMapStore((state) => state.selectedRoutePreview);
   const setSelectedRoutePreview = useAppMapStore((state) => state.setSelectedRoutePreview);
 
-  const applyRouteState = useCallback((routeState: RouteState, routePreview: RoutePreview | null = null) => {
-    setActiveTab(routeState.tab);
-    setSelectedPlaceId(routeState.tab === 'map' ? routeState.placeId : null);
-    setSelectedFestivalId(routeState.tab === 'map' ? routeState.festivalId : null);
-    setDrawerState(routeState.tab === 'map' ? routeState.drawerState : 'closed');
-    setSelectedRoutePreview(routeState.tab === 'map' ? routePreview : null);
-  }, [setActiveTab, setDrawerState, setSelectedFestivalId, setSelectedPlaceId, setSelectedRoutePreview]);
-
   const commitRouteState = useCallback(
-    (routeState: RouteState, mode: 'push' | 'replace' = 'push', options?: RouteStateCommitOptions) => {
-      const requestedRoutePreview = options && Object.prototype.hasOwnProperty.call(options, 'routePreview')
-        ? options.routePreview ?? null
-        : selectedRoutePreview;
-      const nextRoutePreview = routeState.tab === 'map' ? requestedRoutePreview : null;
-      applyRouteState(routeState, nextRoutePreview);
-      if (typeof window === 'undefined') {
-        return;
-      }
-
-      const nextUrl = buildRouteUrl(routeState);
-      const nextHistoryState = buildHistoryState(routeState, nextRoutePreview);
-      if (mode === 'replace') {
-        window.history.replaceState(nextHistoryState, '', nextUrl);
-        return;
-      }
-
-      window.history.pushState(nextHistoryState, '', nextUrl);
-    },
-    [applyRouteState, selectedRoutePreview],
+    buildCommitRouteState({
+      setActiveTab,
+      setDrawerState,
+      setSelectedPlaceId,
+      setSelectedFestivalId,
+      setSelectedRoutePreview,
+      getSelectedRoutePreview: () => selectedRoutePreview,
+    }),
+    [selectedRoutePreview, setActiveTab, setDrawerState, setSelectedFestivalId, setSelectedPlaceId, setSelectedRoutePreview],
   );
 
   const goToTab = useCallback(
@@ -151,12 +118,16 @@ export function useAppRouteState() {
     }
 
     const handlePopState = (event: PopStateEvent) => {
-      applyRouteState(getInitialRouteState(), getRoutePreviewFromHistoryState(event.state));
+      commitRouteState(
+        getInitialRouteState(),
+        'replace',
+        { routePreview: getRoutePreviewFromHistoryState(event.state) },
+      );
     };
 
     window.addEventListener('popstate', handlePopState);
     return () => window.removeEventListener('popstate', handlePopState);
-  }, [applyRouteState]);
+  }, [commitRouteState]);
 
   return {
     activeTab,


### PR DESCRIPTION
## Summary
- split route store initialization and route state commit logic out of useAppRouteState
- keep useAppRouteState focused on state subscription and public actions
- preserve helper re-exports and popstate behavior

## Validation
- npm run typecheck
- npm run lint -- src/hooks/useAppRouteState.ts src/hooks/app-route/routeStateActions.ts src/hooks/app-route/routeStoreInitialization.ts
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py