### PR TITLE
Refactor navigation and loader coupling

### DIFF
--- a/src/hooks/app-navigation/shellBackNavigation.ts
+++ b/src/hooks/app-navigation/shellBackNavigation.ts
@@ -1,0 +1,119 @@
+import type { DrawerState, MyPageTabKey, RoutePreview, SessionUser, Tab } from '../../types';
+import type { ReturnViewState } from '../../store/app-ui-store';
+import type { RouteStateCommitOptions } from '../useAppRouteState';
+
+interface CreateNavigateBackHandlerParams {
+  sessionUser: SessionUser | null;
+  returnView: ReturnViewState | null;
+  activeCommentReviewId: string | null;
+  activeTab: Tab;
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  drawerState: DrawerState;
+  selectedRoutePreview: RoutePreview | null;
+  setMyPageTab: (value: MyPageTabKey) => void;
+  setActiveCommentReviewId: (value: string | null) => void;
+  setHighlightedCommentId: (value: string | null) => void;
+  setHighlightedReviewId: (value: string | null) => void;
+  setFeedPlaceFilterId: (value: string | null) => void;
+  setSelectedRoutePreview: (value: RoutePreview | null) => void;
+  setReturnView: (value: ReturnViewState | null) => void;
+  handleCloseReviewComments: () => void;
+  goToTab: (tab: Tab, historyMode?: 'push' | 'replace') => void;
+  commitRouteState: (
+    nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
+    historyMode?: 'push' | 'replace',
+    options?: RouteStateCommitOptions,
+  ) => void;
+}
+
+export function createNavigateBackHandler({
+  sessionUser,
+  returnView,
+  activeCommentReviewId,
+  activeTab,
+  selectedPlaceId,
+  selectedFestivalId,
+  drawerState,
+  selectedRoutePreview,
+  setMyPageTab,
+  setActiveCommentReviewId,
+  setHighlightedCommentId,
+  setHighlightedReviewId,
+  setFeedPlaceFilterId,
+  setSelectedRoutePreview,
+  setReturnView,
+  handleCloseReviewComments,
+  goToTab,
+  commitRouteState,
+}: CreateNavigateBackHandlerParams) {
+  return function handleNavigateBack() {
+    const hasBrowserBackStepOnMap =
+      activeTab === 'map'
+      && (selectedPlaceId !== null || selectedFestivalId !== null || drawerState !== 'closed' || selectedRoutePreview !== null)
+      && typeof window !== 'undefined'
+      && window.history.length > 1;
+    const shouldClampAuthenticatedMyPageBack =
+      sessionUser !== null
+      && activeTab === 'my'
+      && returnView === null
+      && activeCommentReviewId === null
+      && selectedPlaceId === null
+      && selectedFestivalId === null
+      && drawerState === 'closed'
+      && selectedRoutePreview === null;
+
+    if (hasBrowserBackStepOnMap) {
+      window.history.back();
+      return;
+    }
+
+    if (returnView) {
+      setMyPageTab(returnView.myPageTab);
+      setActiveCommentReviewId(returnView.activeCommentReviewId);
+      setHighlightedCommentId(returnView.highlightedCommentId);
+      setHighlightedReviewId(returnView.highlightedReviewId);
+      setFeedPlaceFilterId(returnView.feedPlaceFilterId);
+      setSelectedRoutePreview(null);
+      const nextTab = returnView.tab;
+      setReturnView(null);
+      commitRouteState(
+        {
+          tab: nextTab,
+          placeId: nextTab === 'map' ? returnView.placeId : null,
+          festivalId: nextTab === 'map' ? returnView.festivalId : null,
+          drawerState: nextTab === 'map' ? returnView.drawerState : 'closed',
+        },
+        'replace',
+      );
+      return;
+    }
+
+    if (activeCommentReviewId !== null) {
+      handleCloseReviewComments();
+      return;
+    }
+
+    if (selectedRoutePreview) {
+      setSelectedRoutePreview(null);
+      return;
+    }
+
+    if (shouldClampAuthenticatedMyPageBack) {
+      setHighlightedCommentId(null);
+      setHighlightedReviewId(null);
+      setFeedPlaceFilterId(null);
+      setReturnView(null);
+      goToTab('map', 'replace');
+      return;
+    }
+
+    if (typeof window !== 'undefined' && window.history.length > 1) {
+      window.history.back();
+      return;
+    }
+
+    handleCloseReviewComments();
+    goToTab('map', 'replace');
+  };
+}

--- a/src/hooks/app-navigation/shellBottomNav.ts
+++ b/src/hooks/app-navigation/shellBottomNav.ts
@@ -1,0 +1,62 @@
+import type { DrawerState, RoutePreview, Tab } from '../../types';
+import type { RouteStateCommitOptions } from '../useAppRouteState';
+
+interface CreateBottomNavChangeHandlerParams {
+  selectedPlaceId: string | null;
+  selectedFestivalId: string | null;
+  drawerState: DrawerState;
+  setSelectedRoutePreview: (value: RoutePreview | null) => void;
+  handleCloseReviewComments: () => void;
+  setFeedPlaceFilterId: (value: string | null) => void;
+  setHighlightedReviewId: (value: string | null) => void;
+  commitRouteState: (
+    nextState: { tab: Tab; placeId: string | null; festivalId: string | null; drawerState: DrawerState },
+    historyMode?: 'push' | 'replace',
+    options?: RouteStateCommitOptions,
+  ) => void;
+}
+
+export function createBottomNavChangeHandler({
+  selectedPlaceId,
+  selectedFestivalId,
+  drawerState,
+  setSelectedRoutePreview,
+  handleCloseReviewComments,
+  setFeedPlaceFilterId,
+  setHighlightedReviewId,
+  commitRouteState,
+}: CreateBottomNavChangeHandlerParams) {
+  return function handleBottomNavChange(nextTab: Tab) {
+    setSelectedRoutePreview(null);
+    handleCloseReviewComments();
+
+    if (nextTab !== 'feed') {
+      setFeedPlaceFilterId(null);
+      setHighlightedReviewId(null);
+    }
+
+    if (nextTab === 'map') {
+      commitRouteState(
+        {
+          tab: 'map',
+          placeId: selectedPlaceId,
+          festivalId: selectedFestivalId,
+          drawerState,
+        },
+        'replace',
+        { routePreview: null },
+      );
+      return;
+    }
+
+    commitRouteState(
+      {
+        tab: nextTab,
+        placeId: null,
+        festivalId: null,
+        drawerState: 'closed',
+      },
+      'push',
+    );
+  };
+}

--- a/src/hooks/app-route-actions/publishRouteAction.ts
+++ b/src/hooks/app-route-actions/publishRouteAction.ts
@@ -1,0 +1,86 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { createUserRoute } from '../../api/routesClient';
+import type { MyPageResponse, MyPageTabKey, SessionUser, Tab, UserRoute } from '../../types';
+
+type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
+type HistoryMode = 'push' | 'replace';
+
+interface CreatePublishRouteHandlerParams {
+  sessionUser: SessionUser | null;
+  setRouteSubmitting: (value: boolean) => void;
+  setRouteError: (value: string | null) => void;
+  setNotice: (message: string | null) => void;
+  setMyPageTab: (value: MyPageTabKey) => void;
+  setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
+  communityRoutesCacheRef: MutableRefObject<CommunityRoutesCache>;
+  refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
+  formatErrorMessage: (error: unknown) => string;
+  goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
+}
+
+export function createPublishRouteHandler({
+  sessionUser,
+  setRouteSubmitting,
+  setRouteError,
+  setNotice,
+  setMyPageTab,
+  setMyPage,
+  communityRoutesCacheRef,
+  refreshMyPageForUser,
+  formatErrorMessage,
+  goToTab,
+}: CreatePublishRouteHandlerParams) {
+  return async function handlePublishRoute(payload: {
+    travelSessionId: string;
+    title: string;
+    description: string;
+    mood: string;
+  }) {
+    if (!sessionUser) {
+      goToTab('my');
+      setRouteError('로그인하면 여행 세션을 코스로 발행할 수 있어요.');
+      return;
+    }
+
+    setRouteSubmitting(true);
+    setRouteError(null);
+    try {
+      const createdRoute = await createUserRoute({
+        travelSessionId: payload.travelSessionId,
+        title: payload.title,
+        description: payload.description,
+        mood: payload.mood,
+        isPublic: true,
+      });
+      communityRoutesCacheRef.current = {
+        ...communityRoutesCacheRef.current,
+        latest: [createdRoute, ...(communityRoutesCacheRef.current.latest ?? []).filter((route) => route.id !== createdRoute.id)],
+      };
+      delete communityRoutesCacheRef.current.popular;
+      setMyPage((current) => {
+        if (!current) {
+          return current;
+        }
+        const routeExists = current.routes.some((route) => route.id === createdRoute.id);
+        return {
+          ...current,
+          routes: [createdRoute, ...current.routes.filter((route) => route.id !== createdRoute.id)],
+          travelSessions: current.travelSessions.map((session) =>
+            session.id === payload.travelSessionId ? { ...session, publishedRouteId: createdRoute.id } : session,
+          ),
+          stats: {
+            ...current.stats,
+            routeCount: routeExists ? current.stats.routeCount : current.stats.routeCount + 1,
+          },
+        };
+      });
+      setNotice('코스를 발행했어요. 공개 경로 탭에서 바로 확인할 수 있어요.');
+      setMyPageTab('routes');
+      await refreshMyPageForUser(sessionUser, true);
+    } catch (error) {
+      setRouteError(formatErrorMessage(error));
+    } finally {
+      setRouteSubmitting(false);
+    }
+  };
+}

--- a/src/hooks/app-route-actions/routeLikeAction.ts
+++ b/src/hooks/app-route-actions/routeLikeAction.ts
@@ -1,0 +1,64 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { toggleCommunityRouteLike } from '../../api/routesClient';
+import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../../types';
+
+type HistoryMode = 'push' | 'replace';
+
+interface CreateToggleRouteLikeHandlerParams {
+  sessionUser: SessionUser | null;
+  setNotice: (message: string | null) => void;
+  setRouteLikeUpdatingId: (routeId: string | null) => void;
+  setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
+  patchCommunityRoutes: (routeId: string, updater: (route: UserRoute) => UserRoute) => void;
+  formatErrorMessage: (error: unknown) => string;
+  goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
+}
+
+export function createToggleRouteLikeHandler({
+  sessionUser,
+  setNotice,
+  setRouteLikeUpdatingId,
+  setMyPage,
+  patchCommunityRoutes,
+  formatErrorMessage,
+  goToTab,
+}: CreateToggleRouteLikeHandlerParams) {
+  return async function handleToggleRouteLike(routeId: string) {
+    if (!sessionUser) {
+      goToTab('my');
+      setNotice('좋아요를 누르려면 먼저 로그인해 주세요.');
+      return;
+    }
+
+    setRouteLikeUpdatingId(routeId);
+    try {
+      const result = await toggleCommunityRouteLike(routeId);
+      patchCommunityRoutes(routeId, (route) => ({
+        ...route,
+        likeCount: result.likeCount,
+        likedByMe: result.likedByMe,
+      }));
+      setMyPage((current) => {
+        if (!current) {
+          return current;
+        }
+        return {
+          ...current,
+          routes: current.routes.map((route) =>
+            route.id === routeId
+              ? {
+                  ...route,
+                  likeCount: result.likeCount,
+                  likedByMe: result.likedByMe,
+                }
+              : route,
+          ),
+        };
+      });
+    } catch (error) {
+      setNotice(formatErrorMessage(error));
+    } finally {
+      setRouteLikeUpdatingId(null);
+    }
+  };
+}

--- a/src/hooks/app-tab-loaders/communityRouteLoader.ts
+++ b/src/hooks/app-tab-loaders/communityRouteLoader.ts
@@ -1,0 +1,29 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { getCommunityRoutes } from '../../api/routesClient';
+import type { CommunityRouteSort, UserRoute } from '../../types';
+
+type CommunityRoutesCache = Partial<Record<CommunityRouteSort, UserRoute[]>>;
+
+interface CreateCommunityRouteLoaderParams {
+  communityRoutesCacheRef: MutableRefObject<CommunityRoutesCache>;
+  replaceCommunityRoutes: (nextRoutes: UserRoute[], sort?: CommunityRouteSort) => void;
+  setCommunityRoutes: Dispatch<SetStateAction<UserRoute[]>>;
+}
+
+export function createCommunityRouteLoader({
+  communityRoutesCacheRef,
+  replaceCommunityRoutes,
+  setCommunityRoutes,
+}: CreateCommunityRouteLoaderParams) {
+  return async function fetchCommunityRoutes(sort: CommunityRouteSort, force = false) {
+    const cached = communityRoutesCacheRef.current[sort];
+    if (!force && cached) {
+      setCommunityRoutes(cached);
+      return cached;
+    }
+
+    const nextRoutes = await getCommunityRoutes(sort);
+    replaceCommunityRoutes(nextRoutes, sort);
+    return nextRoutes;
+  };
+}

--- a/src/hooks/app-tab-loaders/feedReviewLoader.ts
+++ b/src/hooks/app-tab-loaders/feedReviewLoader.ts
@@ -1,0 +1,30 @@
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
+import { getReviewFeedPage } from '../../api/reviewsClient';
+import { toReviewSummaryList } from '../../lib/reviews';
+import type { Review } from '../../types';
+
+interface CreateFeedReviewLoaderParams {
+  feedLoadedRef: MutableRefObject<boolean>;
+  setReviews: Dispatch<SetStateAction<Review[]>>;
+  setFeedNextCursor: (cursor: string | null) => void;
+  setFeedHasMore: (value: boolean) => void;
+}
+
+export function createFeedReviewLoader({
+  feedLoadedRef,
+  setReviews,
+  setFeedNextCursor,
+  setFeedHasMore,
+}: CreateFeedReviewLoaderParams) {
+  return async function ensureFeedReviews(force = false) {
+    if (!force && feedLoadedRef.current) {
+      return;
+    }
+
+    const page = await getReviewFeedPage({ limit: 10 });
+    setReviews(toReviewSummaryList(page.items));
+    setFeedNextCursor(page.nextCursor);
+    setFeedHasMore(Boolean(page.nextCursor));
+    feedLoadedRef.current = true;
+  };
+}

--- a/src/hooks/app-tab-loaders/summaryLoaders.ts
+++ b/src/hooks/app-tab-loaders/summaryLoaders.ts
@@ -1,0 +1,85 @@
+import type { Dispatch, SetStateAction } from 'react';
+import { getAdminSummary } from '../../api/adminClient';
+import { getMySummary } from '../../api/myClient';
+import { toReviewSummaryList } from '../../lib/reviews';
+import type { AdminSummaryResponse, MyPageResponse, SessionUser, Tab } from '../../types';
+
+interface CreateAdminSummaryLoaderParams {
+  activeTab: Tab;
+  adminSummary: AdminSummaryResponse | null;
+  sessionUser: SessionUser | null;
+  setAdminLoading: Dispatch<SetStateAction<boolean>>;
+  setAdminSummary: Dispatch<SetStateAction<AdminSummaryResponse | null>>;
+}
+
+export function createAdminSummaryLoader({
+  activeTab,
+  adminSummary,
+  sessionUser,
+  setAdminLoading,
+  setAdminSummary,
+}: CreateAdminSummaryLoaderParams) {
+  return async function refreshAdminSummary(force = false) {
+    if (!sessionUser?.isAdmin) {
+      setAdminSummary(null);
+      return null;
+    }
+
+    if (!force && activeTab !== 'my' && adminSummary !== null) {
+      return adminSummary;
+    }
+
+    setAdminLoading(true);
+    try {
+      const nextSummary = await getAdminSummary();
+      setAdminSummary(nextSummary);
+      return nextSummary;
+    } finally {
+      setAdminLoading(false);
+    }
+  };
+}
+
+interface CreateMyPageSummaryLoaderParams {
+  activeTab: Tab;
+  myPage: MyPageResponse | null;
+  setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
+  setMyPageError: (value: string | null) => void;
+}
+
+export function createMyPageSummaryLoader({
+  activeTab,
+  myPage,
+  setMyPage,
+  setMyPageError,
+}: CreateMyPageSummaryLoaderParams) {
+  return async function refreshMyPageForUser(user: SessionUser | null, force = false) {
+    if (!user) {
+      setMyPage(null);
+      setMyPageError(null);
+      return null;
+    }
+
+    if (!force && activeTab !== 'my' && myPage === null) {
+      return null;
+    }
+
+    try {
+      const nextMyPage = await getMySummary();
+      const nextMyPageSummary = {
+        ...nextMyPage,
+        reviews: toReviewSummaryList(nextMyPage.reviews),
+      };
+      setMyPage(nextMyPageSummary);
+      setMyPageError(null);
+      return nextMyPageSummary;
+    } catch (error) {
+      setMyPage(null);
+      setMyPageError(error instanceof Error ? error.message : '마이페이지 정보를 불러오지 못했어요.');
+      if (activeTab !== 'my') {
+        return null;
+      }
+      throw error;
+    }
+  };
+}

--- a/src/hooks/useAppRouteActionStoreBindings.ts
+++ b/src/hooks/useAppRouteActionStoreBindings.ts
@@ -1,0 +1,22 @@
+import { useAuthStore } from '../store/auth-store';
+import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
+import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
+import { useMyPageStore } from '../store/my-page-store';
+
+export function useAppRouteActionStoreBindings() {
+  const sessionUser = useAuthStore((state) => state.sessionUser);
+  const setRouteLikeUpdatingId = useAppPageRuntimeStore((state) => state.setRouteLikeUpdatingId);
+  const setRouteSubmitting = useAppPageRuntimeStore((state) => state.setRouteSubmitting);
+  const setRouteError = useAppPageRuntimeStore((state) => state.setRouteError);
+  const setNotice = useAppShellRuntimeStore((state) => state.setNotice);
+  const setMyPageTab = useMyPageStore((state) => state.setMyPageTab);
+
+  return {
+    sessionUser,
+    setRouteLikeUpdatingId,
+    setRouteSubmitting,
+    setRouteError,
+    setNotice,
+    setMyPageTab,
+  };
+}

--- a/src/hooks/useAppRouteActions.ts
+++ b/src/hooks/useAppRouteActions.ts
@@ -1,10 +1,8 @@
-﻿import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import { createUserRoute, toggleCommunityRouteLike } from '../api/routesClient';
-import { useAuthStore } from '../store/auth-store';
-import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
-import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import { useMyPageStore } from '../store/my-page-store';
+import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../types';
+import { createPublishRouteHandler } from './app-route-actions/publishRouteAction';
+import { createToggleRouteLikeHandler } from './app-route-actions/routeLikeAction';
+import { useAppRouteActionStoreBindings } from './useAppRouteActionStoreBindings';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
@@ -27,101 +25,30 @@ export function useAppRouteActions({
   formatErrorMessage,
   goToTab,
 }: UseAppRouteActionsParams) {
-  const sessionUser = useAuthStore((state) => state.sessionUser);
-  const setRouteLikeUpdatingId = useAppPageRuntimeStore((state) => state.setRouteLikeUpdatingId);
-  const setRouteSubmitting = useAppPageRuntimeStore((state) => state.setRouteSubmitting);
-  const setRouteError = useAppPageRuntimeStore((state) => state.setRouteError);
-  const setNotice = useAppShellRuntimeStore((state) => state.setNotice);
-  const setMyPageTab = useMyPageStore((state) => state.setMyPageTab);
+  const bindings = useAppRouteActionStoreBindings();
 
-  async function handleToggleRouteLike(routeId: string) {
-    if (!sessionUser) {
-      goToTab('my');
-      setNotice('좋아요를 누르려면 먼저 로그인해 주세요.');
-      return;
-    }
+  const handleToggleRouteLike = createToggleRouteLikeHandler({
+    sessionUser: bindings.sessionUser,
+    setNotice: bindings.setNotice,
+    setRouteLikeUpdatingId: bindings.setRouteLikeUpdatingId,
+    setMyPage,
+    patchCommunityRoutes,
+    formatErrorMessage,
+    goToTab,
+  });
 
-    setRouteLikeUpdatingId(routeId);
-    try {
-      const result = await toggleCommunityRouteLike(routeId);
-      patchCommunityRoutes(routeId, (route) => ({
-        ...route,
-        likeCount: result.likeCount,
-        likedByMe: result.likedByMe,
-      }));
-      setMyPage((current) => {
-        if (!current) {
-          return current;
-        }
-        return {
-          ...current,
-          routes: current.routes.map((route) =>
-            route.id === routeId
-              ? {
-                  ...route,
-                  likeCount: result.likeCount,
-                  likedByMe: result.likedByMe,
-                }
-              : route,
-          ),
-        };
-      });
-    } catch (error) {
-      setNotice(formatErrorMessage(error));
-    } finally {
-      setRouteLikeUpdatingId(null);
-    }
-  }
-
-  async function handlePublishRoute(payload: { travelSessionId: string; title: string; description: string; mood: string }) {
-    if (!sessionUser) {
-      goToTab('my');
-      setRouteError('로그인하면 여행 세션을 코스로 발행할 수 있어요.');
-      return;
-    }
-
-    setRouteSubmitting(true);
-    setRouteError(null);
-    try {
-      const createdRoute = await createUserRoute({
-        travelSessionId: payload.travelSessionId,
-        title: payload.title,
-        description: payload.description,
-        mood: payload.mood,
-        isPublic: true,
-      });
-      // 발행 직후 공개 경로 목록이 최신 상태를 보도록 캐시를 갱신한다.
-      communityRoutesCacheRef.current = {
-        ...communityRoutesCacheRef.current,
-        latest: [createdRoute, ...(communityRoutesCacheRef.current.latest ?? []).filter((route) => route.id !== createdRoute.id)],
-      };
-      delete communityRoutesCacheRef.current.popular;
-      setMyPage((current) => {
-        if (!current) {
-          return current;
-        }
-        const routeExists = current.routes.some((route) => route.id === createdRoute.id);
-        return {
-          ...current,
-          routes: [createdRoute, ...current.routes.filter((route) => route.id !== createdRoute.id)],
-          travelSessions: current.travelSessions.map((session) =>
-            session.id === payload.travelSessionId ? { ...session, publishedRouteId: createdRoute.id } : session,
-          ),
-          stats: {
-            ...current.stats,
-            routeCount: routeExists ? current.stats.routeCount : current.stats.routeCount + 1,
-          },
-        };
-      });
-      setNotice('코스를 발행했어요. 공개 경로 탭에서 바로 확인할 수 있어요.');
-      setMyPageTab('routes');
-      await refreshMyPageForUser(sessionUser, true);
-    } catch (error) {
-      setRouteError(formatErrorMessage(error));
-    } finally {
-      setRouteSubmitting(false);
-    }
-  }
+  const handlePublishRoute = createPublishRouteHandler({
+    sessionUser: bindings.sessionUser,
+    setRouteSubmitting: bindings.setRouteSubmitting,
+    setRouteError: bindings.setRouteError,
+    setNotice: bindings.setNotice,
+    setMyPageTab: bindings.setMyPageTab,
+    setMyPage,
+    communityRoutesCacheRef,
+    refreshMyPageForUser,
+    formatErrorMessage,
+    goToTab,
+  });
 
   return {
     handleToggleRouteLike,

--- a/src/hooks/useAppShellNavigation.ts
+++ b/src/hooks/useAppShellNavigation.ts
@@ -1,6 +1,8 @@
 import type { DrawerState, MyPageTabKey, RoutePreview, SessionUser, Tab } from '../types';
 import type { ReturnViewState } from '../store/app-ui-store';
 import type { RouteStateCommitOptions } from './useAppRouteState';
+import { createNavigateBackHandler } from './app-navigation/shellBackNavigation';
+import { createBottomNavChangeHandler } from './app-navigation/shellBottomNav';
 
 interface UseAppShellNavigationParams {
   sessionUser: SessionUser | null;
@@ -57,108 +59,37 @@ export function useAppShellNavigation({
     selectedRoutePreview !== null ||
     (typeof window !== 'undefined' && window.history.length > 1);
 
-  function handleNavigateBack() {
-    const hasBrowserBackStepOnMap = activeTab === 'map'
-      && (selectedPlaceId !== null || selectedFestivalId !== null || drawerState !== 'closed' || selectedRoutePreview !== null)
-      && typeof window !== 'undefined'
-      && window.history.length > 1;
-    const shouldClampAuthenticatedMyPageBack =
-      sessionUser !== null
-      && activeTab === 'my'
-      && returnView === null
-      && activeCommentReviewId === null
-      && selectedPlaceId === null
-      && selectedFestivalId === null
-      && drawerState === 'closed'
-      && selectedRoutePreview === null;
+  const handleNavigateBack = createNavigateBackHandler({
+    sessionUser,
+    returnView,
+    activeCommentReviewId,
+    activeTab,
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    selectedRoutePreview,
+    setMyPageTab,
+    setActiveCommentReviewId,
+    setHighlightedCommentId,
+    setHighlightedReviewId,
+    setFeedPlaceFilterId,
+    setSelectedRoutePreview,
+    setReturnView,
+    handleCloseReviewComments,
+    goToTab,
+    commitRouteState,
+  });
 
-    if (hasBrowserBackStepOnMap) {
-      window.history.back();
-      return;
-    }
-
-    if (returnView) {
-      setMyPageTab(returnView.myPageTab);
-      setActiveCommentReviewId(returnView.activeCommentReviewId);
-      setHighlightedCommentId(returnView.highlightedCommentId);
-      setHighlightedReviewId(returnView.highlightedReviewId);
-      setFeedPlaceFilterId(returnView.feedPlaceFilterId);
-      setSelectedRoutePreview(null);
-      const nextTab = returnView.tab;
-      setReturnView(null);
-      commitRouteState(
-        {
-          tab: nextTab,
-          placeId: nextTab === 'map' ? returnView.placeId : null,
-          festivalId: nextTab === 'map' ? returnView.festivalId : null,
-          drawerState: nextTab === 'map' ? returnView.drawerState : 'closed',
-        },
-        'replace',
-      );
-      return;
-    }
-
-    if (activeCommentReviewId !== null) {
-      handleCloseReviewComments();
-      return;
-    }
-
-    if (selectedRoutePreview) {
-      setSelectedRoutePreview(null);
-      return;
-    }
-
-    if (shouldClampAuthenticatedMyPageBack) {
-      setHighlightedCommentId(null);
-      setHighlightedReviewId(null);
-      setFeedPlaceFilterId(null);
-      setReturnView(null);
-      goToTab('map', 'replace');
-      return;
-    }
-
-    if (typeof window !== 'undefined' && window.history.length > 1) {
-      window.history.back();
-      return;
-    }
-
-    handleCloseReviewComments();
-    goToTab('map', 'replace');
-  }
-
-  function handleBottomNavChange(nextTab: Tab) {
-    setSelectedRoutePreview(null);
-    handleCloseReviewComments();
-
-    if (nextTab !== 'feed') {
-      setFeedPlaceFilterId(null);
-      setHighlightedReviewId(null);
-    }
-
-    if (nextTab === 'map') {
-      commitRouteState(
-        {
-          tab: 'map',
-          placeId: selectedPlaceId,
-          festivalId: selectedFestivalId,
-          drawerState,
-        },
-        'replace',
-        { routePreview: null },
-      );
-      return;
-    }
-
-    commitRouteState(
-      {
-        tab: nextTab,
-        placeId: null,
-        festivalId: null,
-        drawerState: 'closed',
-      },
-      'push',
-    );
-  }
+  const handleBottomNavChange = createBottomNavChangeHandler({
+    selectedPlaceId,
+    selectedFestivalId,
+    drawerState,
+    setSelectedRoutePreview,
+    handleCloseReviewComments,
+    setFeedPlaceFilterId,
+    setHighlightedReviewId,
+    commitRouteState,
+  });
 
   return {
     canNavigateBack,

--- a/src/hooks/useAppTabDataLoaders.ts
+++ b/src/hooks/useAppTabDataLoaders.ts
@@ -1,11 +1,5 @@
-﻿import { useCallback } from 'react';
+import { useCallback } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import { getAdminSummary } from '../api/adminClient';
-import { getMySummary } from '../api/myClient';
-import { getCommunityRoutes } from '../api/routesClient';
-import { getReviewFeedPage } from '../api/reviewsClient';
-import { toReviewSummaryList } from '../lib/reviews';
-import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import type {
   AdminSummaryResponse,
   CommunityRouteSort,
@@ -16,6 +10,10 @@ import type {
   Tab,
   UserRoute,
 } from '../types';
+import { createCommunityRouteLoader } from './app-tab-loaders/communityRouteLoader';
+import { createFeedReviewLoader } from './app-tab-loaders/feedReviewLoader';
+import { createAdminSummaryLoader, createMyPageSummaryLoader } from './app-tab-loaders/summaryLoaders';
+import { useAppTabLoaderBindings } from './useAppTabLoaderBindings';
 
 type CommunityRoutesCache = Partial<Record<CommunityRouteSort, UserRoute[]>>;
 
@@ -52,33 +50,26 @@ export function useAppTabDataLoaders({
   setAdminSummary,
   setMyPage,
 }: UseAppTabDataLoadersParams) {
-  const setFeedHasMore = useAppPageRuntimeStore((state) => state.setFeedHasMore);
-  const setFeedNextCursor = useAppPageRuntimeStore((state) => state.setFeedNextCursor);
-  const setMyPageError = useAppPageRuntimeStore((state) => state.setMyPageError);
+  const bindings = useAppTabLoaderBindings();
 
-  const fetchCommunityRoutes = useCallback(async (sort: CommunityRouteSort, force = false) => {
-    const cached = communityRoutesCacheRef.current[sort];
-    if (!force && cached) {
-      setCommunityRoutes(cached);
-      return cached;
-    }
+  const fetchCommunityRoutes = useCallback(
+    createCommunityRouteLoader({
+      communityRoutesCacheRef,
+      replaceCommunityRoutes,
+      setCommunityRoutes,
+    }),
+    [communityRoutesCacheRef, replaceCommunityRoutes, setCommunityRoutes],
+  );
 
-    const nextRoutes = await getCommunityRoutes(sort);
-    replaceCommunityRoutes(nextRoutes, sort);
-    return nextRoutes;
-  }, [communityRoutesCacheRef, replaceCommunityRoutes, setCommunityRoutes]);
-
-  const ensureFeedReviews = useCallback(async (force = false) => {
-    if (!force && feedLoadedRef.current) {
-      return;
-    }
-
-    const page = await getReviewFeedPage({ limit: 10 });
-    setReviews(toReviewSummaryList(page.items));
-    setFeedNextCursor(page.nextCursor);
-    setFeedHasMore(Boolean(page.nextCursor));
-    feedLoadedRef.current = true;
-  }, [feedLoadedRef, setFeedHasMore, setFeedNextCursor, setReviews]);
+  const ensureFeedReviews = useCallback(
+    createFeedReviewLoader({
+      feedLoadedRef,
+      setReviews,
+      setFeedNextCursor: bindings.setFeedNextCursor,
+      setFeedHasMore: bindings.setFeedHasMore,
+    }),
+    [bindings.setFeedHasMore, bindings.setFeedNextCursor, feedLoadedRef, setReviews],
+  );
 
   const ensureCuratedCourses = useCallback(async (force = false) => {
     if (!force && coursesLoadedRef.current) {
@@ -89,55 +80,26 @@ export function useAppTabDataLoaders({
     coursesLoadedRef.current = true;
   }, [coursesLoadedRef, setCourses]);
 
-  const refreshAdminSummary = useCallback(async (force = false) => {
-    if (!sessionUser?.isAdmin) {
-      setAdminSummary(null);
-      return null;
-    }
+  const refreshAdminSummary = useCallback(
+    createAdminSummaryLoader({
+      activeTab,
+      adminSummary,
+      sessionUser,
+      setAdminLoading,
+      setAdminSummary,
+    }),
+    [activeTab, adminSummary, sessionUser, setAdminLoading, setAdminSummary],
+  );
 
-    if (!force && activeTab !== 'my' && adminSummary !== null) {
-      return adminSummary;
-    }
-
-    setAdminLoading(true);
-    try {
-      const nextSummary = await getAdminSummary();
-      setAdminSummary(nextSummary);
-      return nextSummary;
-    } finally {
-      setAdminLoading(false);
-    }
-  }, [activeTab, adminSummary, sessionUser, setAdminLoading, setAdminSummary]);
-
-  const refreshMyPageForUser = useCallback(async (user: SessionUser | null, force = false) => {
-    if (!user) {
-      setMyPage(null);
-      setMyPageError(null);
-      return null;
-    }
-
-    if (!force && activeTab !== 'my' && myPage === null) {
-      return null;
-    }
-
-    try {
-      const nextMyPage = await getMySummary();
-      const nextMyPageSummary = {
-        ...nextMyPage,
-        reviews: toReviewSummaryList(nextMyPage.reviews),
-      };
-      setMyPage(nextMyPageSummary);
-      setMyPageError(null);
-      return nextMyPageSummary;
-    } catch (error) {
-      setMyPage(null);
-      setMyPageError(error instanceof Error ? error.message : '마이페이지 정보를 불러오지 못했어요.');
-      if (activeTab !== 'my') {
-        return null;
-      }
-      throw error;
-    }
-  }, [activeTab, myPage, setMyPage, setMyPageError]);
+  const refreshMyPageForUser = useCallback(
+    createMyPageSummaryLoader({
+      activeTab,
+      myPage,
+      setMyPage,
+      setMyPageError: bindings.setMyPageError,
+    }),
+    [activeTab, bindings.setMyPageError, myPage, setMyPage],
+  );
 
   return {
     fetchCommunityRoutes,

--- a/src/hooks/useAppTabLoaderBindings.ts
+++ b/src/hooks/useAppTabLoaderBindings.ts
@@ -1,0 +1,13 @@
+import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
+
+export function useAppTabLoaderBindings() {
+  const setFeedHasMore = useAppPageRuntimeStore((state) => state.setFeedHasMore);
+  const setFeedNextCursor = useAppPageRuntimeStore((state) => state.setFeedNextCursor);
+  const setMyPageError = useAppPageRuntimeStore((state) => state.setMyPageError);
+
+  return {
+    setFeedHasMore,
+    setFeedNextCursor,
+    setMyPageError,
+  };
+}


### PR DESCRIPTION
## Summary
- separate route action store bindings from route action handlers
- separate tab loader factories from useAppTabDataLoaders
- separate shell back navigation and bottom nav decision logic

## Validation
- npm run lint
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py