### PR TITLE
ci: accelerate node builds with ghcr cache

### DIFF
--- a/.github/actions/prime-node-tooling/action.yml
+++ b/.github/actions/prime-node-tooling/action.yml
@@ -1,0 +1,56 @@
+name: Prime Node Tooling
+description: Prepare Node and hydrate npm cache from a GHCR image when available.
+
+inputs:
+  node-version:
+    description: Node.js version to install.
+    required: false
+    default: "22"
+  ghcr-image:
+    description: GHCR image containing a warmed npm cache.
+    required: true
+  registry-username:
+    description: Username for GHCR login.
+    required: true
+  registry-password:
+    description: Token for GHCR login.
+    required: true
+
+outputs:
+  cache-source:
+    description: Cache source used for this run.
+    value: ${{ steps.prime-cache.outputs.cache_source }}
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: npm
+
+    - uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ inputs.registry-username }}
+        password: ${{ inputs.registry-password }}
+
+    - id: prime-cache
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        cache_dir="${RUNNER_TEMP}/jamissue-npm-cache"
+        rm -rf "${cache_dir}"
+        mkdir -p "${cache_dir}"
+
+        if docker pull "${{ inputs.ghcr-image }}" >/tmp/jamissue-node-cache-pull.log 2>&1; then
+          cid="$(docker create "${{ inputs.ghcr-image }}")"
+          docker cp "${cid}:/opt/jamissue-npm-cache/." "${cache_dir}"
+          docker rm "${cid}" >/dev/null
+          echo "npm_config_cache=${cache_dir}" >> "${GITHUB_ENV}"
+          echo "cache_source=ghcr" >> "${GITHUB_OUTPUT}"
+        else
+          cat /tmp/jamissue-node-cache-pull.log
+          echo "cache_source=setup-node" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,16 +9,22 @@ on:
       - main
   workflow_dispatch:
 
+permissions:
+  contents: read
+  packages: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
-          node-version: 22
-          cache: npm
-      - run: npm ci
+          node-version: "22"
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm ci --prefer-offline --no-audit
       - run: npm run lint
       - run: npm run typecheck
       - run: npm run build

--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: cloudflare-pages-${{ github.event_name }}-${{ github.ref }}
@@ -26,12 +27,13 @@ jobs:
       CF_PAGES_BRANCH: ${{ github.event_name == 'pull_request' && github.head_ref || 'main' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
-          cache: npm
-      - run: npm install -g wrangler@4.74.0
-      - run: npm ci
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm ci --prefer-offline --no-audit
       - name: Ensure Pages project exists and production branch is main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -66,4 +68,4 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: wrangler pages deploy infra/nginx/site --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" --branch "${CF_PAGES_BRANCH}"
+        run: npx --yes wrangler@4.74.0 pages deploy infra/nginx/site --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" --branch "${CF_PAGES_BRANCH}"

--- a/.github/workflows/cloudflare-worker.yml
+++ b/.github/workflows/cloudflare-worker.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: cloudflare-worker-${{ github.event_name }}-${{ github.ref }}
@@ -22,12 +23,14 @@ jobs:
         working-directory: deploy/api-worker-shell
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
-      - run: npm install -g wrangler@4.74.0
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Validate worker bundle
-        run: wrangler deploy --dry-run
+        run: npx --yes wrangler@4.74.0 deploy --dry-run
 
   deploy-worker:
     if: github.event_name != 'pull_request'
@@ -37,12 +40,14 @@ jobs:
         working-directory: deploy/api-worker-shell
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
-      - run: npm install -g wrangler@4.74.0
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy production worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: wrangler deploy
+        run: npx --yes wrangler@4.74.0 deploy

--- a/.github/workflows/node-cache-image.yml
+++ b/.github/workflows/node-cache-image.yml
@@ -1,0 +1,46 @@
+name: node-cache-image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - package.json
+      - package-lock.json
+      - infra/docker/node-cache/Dockerfile
+      - .github/workflows/node-cache-image.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: node-cache-image-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  publish-node-cache-image:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: docker/setup-buildx-action@v3
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache
+          tags: |
+            type=raw,value=node22-latest
+            type=sha
+      - uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: infra/docker/node-cache/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/production-smoke.yml
+++ b/.github/workflows/production-smoke.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: read
+  packages: read
 
 concurrency:
   group: production-smoke-${{ github.ref }}
@@ -25,12 +26,13 @@ jobs:
       CF_PAGES_BRANCH: main
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
-          cache: npm
-      - run: npm install -g wrangler@4.74.0
-      - run: npm ci
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm ci --prefer-offline --no-audit
       - name: Ensure Pages project exists and production branch is main
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
@@ -65,7 +67,7 @@ jobs:
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: wrangler pages deploy infra/nginx/site --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" --branch "${CF_PAGES_BRANCH}"
+        run: npx --yes wrangler@4.74.0 pages deploy infra/nginx/site --project-name "${CLOUDFLARE_PAGES_PROJECT_NAME}" --branch "${CF_PAGES_BRANCH}"
 
   deploy-worker:
     runs-on: ubuntu-latest
@@ -74,15 +76,17 @@ jobs:
         working-directory: deploy/api-worker-shell
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
-      - run: npm install -g wrangler@4.74.0
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
       - name: Deploy production worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: wrangler deploy
+        run: npx --yes wrangler@4.74.0 deploy
 
   smoke:
     needs:
@@ -98,11 +102,15 @@ jobs:
       SMOKE_RETRY_DELAY_MS: 15000
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm ci --prefer-offline --no-audit
       - name: Run public production smoke checks
-        run: npx tsx scripts/run-public-smoke-checks.ts
+        run: npm run smoke:public
 
   protected-smoke:
     needs:
@@ -119,8 +127,12 @@ jobs:
       SMOKE_AUTH_BEARER_TOKEN: ${{ secrets.SMOKE_AUTH_BEARER_TOKEN || '' }}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: ./.github/actions/prime-node-tooling
         with:
           node-version: "22"
+          ghcr-image: ghcr.io/${{ github.repository_owner }}/jamissue-node-cache:node22-latest
+          registry-username: ${{ github.actor }}
+          registry-password: ${{ secrets.GITHUB_TOKEN }}
+      - run: npm ci --prefer-offline --no-audit
       - name: Run protected production smoke checks
-        run: npx tsx scripts/run-protected-smoke-checks.ts
+        run: npm run smoke:protected

--- a/infra/docker/node-cache/Dockerfile
+++ b/infra/docker/node-cache/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:22-bookworm-slim
+
+ENV NPM_CONFIG_CACHE=/opt/jamissue-npm-cache
+
+WORKDIR /opt/jamissue
+
+COPY package.json package-lock.json ./
+
+RUN npm cache add wrangler@4.74.0 \
+    && npm ci --ignore-scripts --include=dev \
+    && rm -rf node_modules \
+    && npm cache verify


### PR DESCRIPTION
## Summary
- add a GHCR-backed node cache image workflow for warmed npm artifacts
- add a shared composite action that hydrates npm cache from GHCR and falls back to setup-node cache
- switch CI, Pages deploy, Worker deploy, and production smoke jobs to prefer the warmed cache and use cached wrangler execution

## Validation
- yaml.safe_load on updated workflow and action files
- git diff --check