### PR TITLE
refactor: split api models by domain

### DIFF
--- a/backend/app/model_contracts/__init__.py
+++ b/backend/app/model_contracts/__init__.py
@@ -1,47 +1,27 @@
-"""FastAPI request and response models for JamIssue."""
+"""Domain-organized request and response models for JamIssue."""
 
-from __future__ import annotations
-
-from .model_contracts import (
+from .admin import (
     AdminPlaceOut,
     AdminSummaryResponse,
-    ApiModel,
-    AuthProviderOut,
-    AuthSessionResponse,
-    BootstrapResponse,
-    CategoryFilter,
-    CategoryType,
-    CommentCreate,
-    CommentOut,
-    CourseMood,
-    CourseOut,
-    HealthResponse,
+    PlaceVisibilityUpdate,
+    PublicImportResponse,
+    UploadResponse,
+)
+from .auth import AuthProviderOut, AuthSessionResponse, ProfileUpdateRequest, SessionUser
+from .content import BootstrapResponse, CourseOut, PlaceOut
+from .core import ApiModel, CategoryFilter, CategoryType, CourseMood, ProviderKey, ReviewMood, RouteSort
+from .my_page import (
     MyCommentOut,
     MyPageResponse,
     MyStatsOut,
     NotificationDeleteResponse,
     NotificationReadResponse,
-    PlaceOut,
-    PlaceVisibilityUpdate,
-    ProfileUpdateRequest,
-    ProviderKey,
-    PublicImportResponse,
-    ReviewCreate,
-    ReviewLikeResponse,
-    ReviewMood,
-    ReviewOut,
-    RouteSort,
-    SessionUser,
-    StampLogOut,
-    StampState,
-    StampToggleRequest,
-    TravelSessionOut,
-    UploadResponse,
     UserNotificationOut,
-    UserRouteCreate,
-    UserRouteLikeResponse,
-    UserRouteOut,
 )
+from .review import CommentCreate, CommentOut, ReviewCreate, ReviewLikeResponse, ReviewOut
+from .routes import UserRouteCreate, UserRouteLikeResponse, UserRouteOut
+from .stamp import StampLogOut, StampState, StampToggleRequest, TravelSessionOut
+from .system import HealthResponse
 
 __all__ = [
     'AdminPlaceOut',
@@ -83,5 +63,3 @@ __all__ = [
     'UserRouteLikeResponse',
     'UserRouteOut',
 ]
-
-CommentOut.model_rebuild()

--- a/backend/app/model_contracts/admin.py
+++ b/backend/app/model_contracts/admin.py
@@ -1,0 +1,45 @@
+"""Admin and import-related API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel, CategoryType
+
+
+class PlaceVisibilityUpdate(ApiModel):
+    is_active: bool | None = Field(default=None, alias='isActive')
+    is_manual_override: bool | None = Field(default=None, alias='isManualOverride')
+
+
+class AdminPlaceOut(ApiModel):
+    id: str
+    name: str
+    district: str
+    category: CategoryType
+    is_active: bool = Field(alias='isActive')
+    is_manual_override: bool = Field(alias='isManualOverride')
+    review_count: int = Field(alias='reviewCount')
+    updated_at: str = Field(alias='updatedAt')
+
+
+class AdminSummaryResponse(ApiModel):
+    user_count: int = Field(alias='userCount')
+    place_count: int = Field(alias='placeCount')
+    review_count: int = Field(alias='reviewCount')
+    comment_count: int = Field(alias='commentCount')
+    stamp_count: int = Field(alias='stampCount')
+    source_ready: bool = Field(alias='sourceReady')
+    places: list[AdminPlaceOut]
+
+
+class UploadResponse(ApiModel):
+    url: str
+    file_name: str = Field(alias='fileName')
+    content_type: str = Field(alias='contentType')
+    thumbnail_url: str | None = Field(default=None, alias='thumbnailUrl')
+
+
+class PublicImportResponse(ApiModel):
+    imported_places: int = Field(alias='importedPlaces')
+    imported_courses: int = Field(alias='importedCourses')

--- a/backend/app/model_contracts/auth.py
+++ b/backend/app/model_contracts/auth.py
@@ -1,0 +1,34 @@
+"""Authentication and profile API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel, ProviderKey
+
+
+class SessionUser(ApiModel):
+    id: str
+    nickname: str
+    email: str | None = None
+    provider: str
+    profile_image: str | None = Field(default=None, alias='profileImage')
+    is_admin: bool = Field(default=False, alias='isAdmin')
+    profile_completed_at: str | None = Field(default=None, alias='profileCompletedAt')
+
+
+class AuthProviderOut(ApiModel):
+    key: ProviderKey
+    label: str
+    is_enabled: bool = Field(alias='isEnabled')
+    login_url: str | None = Field(default=None, alias='loginUrl')
+
+
+class AuthSessionResponse(ApiModel):
+    is_authenticated: bool = Field(alias='isAuthenticated')
+    user: SessionUser | None = None
+    providers: list[AuthProviderOut] = Field(default_factory=list)
+
+
+class ProfileUpdateRequest(ApiModel):
+    nickname: str

--- a/backend/app/model_contracts/content.py
+++ b/backend/app/model_contracts/content.py
@@ -1,0 +1,49 @@
+"""Place, course, and bootstrap API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel, CategoryType, CourseMood
+from .review import ReviewOut
+from .stamp import StampState
+
+
+class PlaceOut(ApiModel):
+    id: str
+    position_id: str | None = Field(default=None, alias='positionId')
+    name: str
+    district: str
+    category: CategoryType
+    jam_color: str = Field(alias='jamColor')
+    accent_color: str = Field(alias='accentColor')
+    image_url: str | None = Field(default=None, alias='imageUrl')
+    image_storage_path: str | None = Field(default=None, alias='imageStoragePath')
+    latitude: float
+    longitude: float
+    summary: str
+    description: str
+    vibe_tags: list[str] = Field(alias='vibeTags')
+    visit_time: str = Field(alias='visitTime')
+    route_hint: str = Field(alias='routeHint')
+    stamp_reward: str = Field(alias='stampReward')
+    hero_label: str = Field(alias='heroLabel')
+    total_visit_count: int = Field(default=0, alias='totalVisitCount')
+
+
+class CourseOut(ApiModel):
+    id: str
+    title: str
+    mood: CourseMood | str
+    duration: str
+    note: str
+    color: str
+    place_ids: list[str] = Field(alias='placeIds')
+
+
+class BootstrapResponse(ApiModel):
+    places: list[PlaceOut]
+    reviews: list[ReviewOut]
+    courses: list[CourseOut]
+    stamps: StampState
+    has_real_data: bool = Field(alias='hasRealData')

--- a/backend/app/model_contracts/core.py
+++ b/backend/app/model_contracts/core.py
@@ -1,0 +1,18 @@
+"""Shared API model primitives and common type aliases."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+CategoryType = Literal['landmark', 'food', 'cafe', 'night']
+CategoryFilter = Literal['all', 'landmark', 'food', 'cafe', 'night']
+CourseMood = Literal['전체', '데이트', '사진', '힐링', '비 오는 날']
+ReviewMood = Literal['설렘', '친구랑', '혼자서', '야경 맛집']
+ProviderKey = Literal['naver', 'kakao']
+RouteSort = Literal['popular', 'latest']
+
+
+class ApiModel(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, from_attributes=True)

--- a/backend/app/model_contracts/my_page.py
+++ b/backend/app/model_contracts/my_page.py
@@ -1,0 +1,70 @@
+"""My page, comments, and notification API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .auth import SessionUser
+from .content import PlaceOut
+from .core import ApiModel
+from .review import ReviewOut
+from .routes import UserRouteOut
+from .stamp import StampLogOut, TravelSessionOut
+
+
+class MyCommentOut(ApiModel):
+    id: str
+    review_id: str = Field(alias='reviewId')
+    place_id: str = Field(alias='placeId')
+    place_name: str = Field(alias='placeName')
+    body: str
+    is_deleted: bool = Field(alias='isDeleted')
+    parent_id: str | None = Field(default=None, alias='parentId')
+    created_at: str = Field(alias='createdAt')
+    review_body: str = Field(alias='reviewBody')
+
+
+class UserNotificationOut(ApiModel):
+    id: str
+    type: str
+    title: str
+    body: str
+    created_at: str = Field(alias='createdAt')
+    is_read: bool = Field(alias='isRead')
+    review_id: str | None = Field(default=None, alias='reviewId')
+    comment_id: str | None = Field(default=None, alias='commentId')
+    route_id: str | None = Field(default=None, alias='routeId')
+    actor_name: str | None = Field(default=None, alias='actorName')
+
+
+class NotificationReadResponse(ApiModel):
+    notification_id: str = Field(alias='notificationId')
+    read: bool
+
+
+class NotificationDeleteResponse(ApiModel):
+    notification_id: str = Field(alias='notificationId')
+    deleted: bool
+
+
+class MyStatsOut(ApiModel):
+    review_count: int = Field(alias='reviewCount')
+    stamp_count: int = Field(alias='stampCount')
+    unique_place_count: int = Field(alias='uniquePlaceCount')
+    total_place_count: int = Field(alias='totalPlaceCount')
+    route_count: int = Field(default=0, alias='routeCount')
+
+
+class MyPageResponse(ApiModel):
+    user: SessionUser
+    stats: MyStatsOut
+    reviews: list[ReviewOut]
+    comments: list[MyCommentOut] = Field(default_factory=list)
+    notifications: list[UserNotificationOut] = Field(default_factory=list)
+    unread_notification_count: int = Field(default=0, alias='unreadNotificationCount')
+    stamp_logs: list[StampLogOut] = Field(default_factory=list, alias='stampLogs')
+    travel_sessions: list[TravelSessionOut] = Field(default_factory=list, alias='travelSessions')
+    visited_places: list[PlaceOut] = Field(default_factory=list, alias='visitedPlaces')
+    unvisited_places: list[PlaceOut] = Field(default_factory=list, alias='unvisitedPlaces')
+    collected_places: list[PlaceOut] = Field(default_factory=list, alias='collectedPlaces')
+    routes: list[UserRouteOut] = Field(default_factory=list)

--- a/backend/app/model_contracts/review.py
+++ b/backend/app/model_contracts/review.py
@@ -1,0 +1,60 @@
+"""Review and comment API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel, ReviewMood
+
+
+class CommentOut(ApiModel):
+    id: str
+    user_id: str = Field(alias='userId')
+    author: str
+    body: str
+    parent_id: str | None = Field(default=None, alias='parentId')
+    is_deleted: bool = Field(alias='isDeleted')
+    created_at: str = Field(alias='createdAt')
+    replies: list['CommentOut'] = Field(default_factory=list)
+
+
+class ReviewOut(ApiModel):
+    id: str
+    user_id: str = Field(alias='userId')
+    place_id: str = Field(alias='placeId')
+    place_name: str = Field(alias='placeName')
+    author: str
+    body: str
+    mood: ReviewMood | str
+    badge: str
+    visited_at: str = Field(alias='visitedAt')
+    image_url: str | None = Field(default=None, alias='imageUrl')
+    thumbnail_url: str | None = Field(default=None, alias='thumbnailUrl')
+    comment_count: int = Field(alias='commentCount')
+    like_count: int = Field(default=0, alias='likeCount')
+    liked_by_me: bool = Field(default=False, alias='likedByMe')
+    stamp_id: str | None = Field(default=None, alias='stampId')
+    visit_number: int = Field(default=1, alias='visitNumber')
+    visit_label: str = Field(alias='visitLabel')
+    travel_session_id: str | None = Field(default=None, alias='travelSessionId')
+    has_published_route: bool = Field(default=False, alias='hasPublishedRoute')
+    comments: list[CommentOut] = Field(default_factory=list)
+
+
+class ReviewLikeResponse(ApiModel):
+    review_id: str = Field(alias='reviewId')
+    like_count: int = Field(alias='likeCount')
+    liked_by_me: bool = Field(alias='likedByMe')
+
+
+class ReviewCreate(ApiModel):
+    place_id: str = Field(alias='placeId')
+    stamp_id: str = Field(alias='stampId')
+    body: str
+    mood: ReviewMood | str
+    image_url: str | None = Field(default=None, alias='imageUrl')
+
+
+class CommentCreate(ApiModel):
+    body: str
+    parent_id: str | None = Field(default=None, alias='parentId')

--- a/backend/app/model_contracts/routes.py
+++ b/backend/app/model_contracts/routes.py
@@ -1,0 +1,37 @@
+"""User route and course publishing API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel
+
+
+class UserRouteOut(ApiModel):
+    id: str
+    author_id: str = Field(alias='authorId')
+    author: str
+    title: str
+    description: str
+    mood: str
+    like_count: int = Field(alias='likeCount')
+    liked_by_me: bool = Field(alias='likedByMe')
+    created_at: str = Field(alias='createdAt')
+    place_ids: list[str] = Field(alias='placeIds')
+    place_names: list[str] = Field(alias='placeNames')
+    is_user_generated: bool = Field(alias='isUserGenerated')
+    travel_session_id: str | None = Field(default=None, alias='travelSessionId')
+
+
+class UserRouteLikeResponse(ApiModel):
+    route_id: str = Field(alias='routeId')
+    like_count: int = Field(alias='likeCount')
+    liked_by_me: bool = Field(alias='likedByMe')
+
+
+class UserRouteCreate(ApiModel):
+    title: str
+    description: str
+    mood: str
+    travel_session_id: str = Field(alias='travelSessionId')
+    is_public: bool = Field(default=True, alias='isPublic')

--- a/backend/app/model_contracts/stamp.py
+++ b/backend/app/model_contracts/stamp.py
@@ -1,0 +1,44 @@
+"""Stamping and travel-session API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel
+
+
+class StampLogOut(ApiModel):
+    id: str
+    place_id: str = Field(alias='placeId')
+    place_name: str = Field(alias='placeName')
+    stamped_at: str = Field(alias='stampedAt')
+    stamped_date: str = Field(alias='stampedDate')
+    visit_number: int = Field(alias='visitNumber')
+    visit_label: str = Field(alias='visitLabel')
+    travel_session_id: str | None = Field(default=None, alias='travelSessionId')
+    is_today: bool = Field(alias='isToday')
+
+
+class TravelSessionOut(ApiModel):
+    id: str
+    started_at: str = Field(alias='startedAt')
+    ended_at: str = Field(alias='endedAt')
+    duration_label: str = Field(alias='durationLabel')
+    stamp_count: int = Field(alias='stampCount')
+    place_ids: list[str] = Field(alias='placeIds')
+    place_names: list[str] = Field(alias='placeNames')
+    can_publish: bool = Field(alias='canPublish')
+    published_route_id: str | None = Field(default=None, alias='publishedRouteId')
+    cover_place_id: str | None = Field(default=None, alias='coverPlaceId')
+
+
+class StampState(ApiModel):
+    collected_place_ids: list[str] = Field(alias='collectedPlaceIds')
+    logs: list[StampLogOut] = Field(default_factory=list)
+    travel_sessions: list[TravelSessionOut] = Field(default_factory=list, alias='travelSessions')
+
+
+class StampToggleRequest(ApiModel):
+    place_id: str = Field(alias='placeId')
+    latitude: float
+    longitude: float

--- a/backend/app/model_contracts/system.py
+++ b/backend/app/model_contracts/system.py
@@ -1,0 +1,17 @@
+"""System and health API models."""
+
+from __future__ import annotations
+
+from pydantic import Field
+
+from .core import ApiModel
+
+
+class HealthResponse(ApiModel):
+    status: str
+    env: str
+    database_url: str = Field(alias='databaseUrl')
+    database_provider: str = Field(alias='databaseProvider')
+    storage_backend: str = Field(alias='storageBackend')
+    storage_path: str = Field(alias='storagePath')
+    supabase_configured: bool = Field(alias='supabaseConfigured')


### PR DESCRIPTION
## Summary
- split backend API contracts into domain modules
- keep backend/app/models.py as a compatibility facade
- preserve existing import surface while reducing mixed responsibilities

## Validation
- python -m compileall backend/app
- py -3.14 -m pytest tests/test_auth_service.py tests/test_repository.py tests/test_review_service.py tests/test_user_routes.py
- npm run typecheck
- npm run build
- python .tmp/check_utf8_integrity.py