### PR TITLE
refactor: split bootstrap effect responsibilities

### DIFF
--- a/src/hooks/app-bootstrap/bootstrapAuthNotice.ts
+++ b/src/hooks/app-bootstrap/bootstrapAuthNotice.ts
@@ -1,7 +1,7 @@
 import type { SessionUser } from '../../types';
 
 const PROFILE_COMPLETION_NOTICE =
-  '닉네임을 먼저 정하면 같은 계정으로 스탬프와 리뷰를 이어서 남길 수 있어요.';
+  '프로필을 먼저 완성하면 같은 계정으로 스탬프와 리뷰를 이어서 남길 수 있어요.';
 
 interface HandleBootstrapAuthNoticeParams {
   authState: string | null;

--- a/src/hooks/app-bootstrap/bootstrapFestivalLoader.ts
+++ b/src/hooks/app-bootstrap/bootstrapFestivalLoader.ts
@@ -1,0 +1,28 @@
+import type * as React from 'react';
+
+import { getFestivals } from '../../api/bootstrapClient';
+import type { FestivalItem } from '../../types';
+import { resetFestivalSelection } from './bootstrapRuntimeReset';
+
+interface BootstrapFestivalLoaderParams {
+  setFestivals: React.Dispatch<React.SetStateAction<FestivalItem[]>>;
+  setSelectedFestivalId: (updater: (current: string | null) => string | null) => void;
+  isActive: () => boolean;
+}
+
+export async function bootstrapFestivalLoader({
+  setFestivals,
+  setSelectedFestivalId,
+  isActive,
+}: BootstrapFestivalLoaderParams) {
+  const festivalResult = await getFestivals();
+  if (!isActive()) {
+    return;
+  }
+
+  setFestivals(festivalResult);
+  resetFestivalSelection(
+    festivalResult.map((festival) => festival.id),
+    setSelectedFestivalId
+  );
+}

--- a/src/hooks/app-bootstrap/bootstrapMapSession.ts
+++ b/src/hooks/app-bootstrap/bootstrapMapSession.ts
@@ -1,0 +1,102 @@
+import type * as React from 'react';
+
+import { getMapBootstrap } from '../../api/bootstrapClient';
+import type { MyPageResponse, Place, SessionUser, StampState } from '../../types';
+import { handleBootstrapAuthNotice } from './bootstrapAuthNotice';
+import { applyBootstrapSelections, resetBootstrapRuntime } from './bootstrapRuntimeReset';
+
+type SetProviders = (providers: Array<{ key: 'naver' | 'kakao'; label: string; isEnabled: boolean; loginUrl: string | null }>) => void;
+
+interface BootstrapSharedRefs {
+  refreshMyPageForUserRef: { current: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null> };
+  resetReviewCachesRef: { current: () => void };
+  goToTabRef: { current: (tab: 'my', historyMode?: 'push' | 'replace') => void };
+}
+
+interface BootstrapMapSessionParams extends BootstrapSharedRefs {
+  authState: string | null;
+  setPlaces: React.Dispatch<React.SetStateAction<Place[]>>;
+  setStampState: React.Dispatch<React.SetStateAction<StampState>>;
+  setHasRealData: React.Dispatch<React.SetStateAction<boolean>>;
+  setSessionUser: (user: SessionUser | null) => void;
+  setFeedNextCursor: (cursor: string | null) => void;
+  setFeedHasMore: (value: boolean) => void;
+  setFeedLoadingMore: (value: boolean) => void;
+  setMyCommentsNextCursor: (cursor: string | null) => void;
+  setMyCommentsHasMore: (value: boolean) => void;
+  setMyCommentsLoadingMore: (value: boolean) => void;
+  setMyCommentsLoadedOnce: (value: boolean) => void;
+  setProviders: SetProviders;
+  setSelectedPlaceId: (updater: (current: string | null) => string | null) => void;
+  setSelectedFestivalId: (updater: (current: string | null) => string | null) => void;
+  setMyPage: React.Dispatch<React.SetStateAction<MyPageResponse | null>>;
+  setNotice: (message: string | null) => void;
+  isActive: () => boolean;
+}
+
+export async function bootstrapMapSession({
+  authState,
+  refreshMyPageForUserRef,
+  resetReviewCachesRef,
+  goToTabRef,
+  setPlaces,
+  setStampState,
+  setHasRealData,
+  setSessionUser,
+  setFeedNextCursor,
+  setFeedHasMore,
+  setFeedLoadingMore,
+  setMyCommentsNextCursor,
+  setMyCommentsHasMore,
+  setMyCommentsLoadingMore,
+  setMyCommentsLoadedOnce,
+  setProviders,
+  setSelectedPlaceId,
+  setSelectedFestivalId,
+  setMyPage,
+  setNotice,
+  isActive,
+}: BootstrapMapSessionParams) {
+  const bootstrap = await getMapBootstrap();
+  if (!isActive()) {
+    return;
+  }
+
+  setPlaces(bootstrap.places);
+  setStampState(bootstrap.stamps);
+  setHasRealData(bootstrap.hasRealData);
+  setSessionUser(bootstrap.auth.user);
+  resetReviewCachesRef.current();
+  resetBootstrapRuntime({
+    setFeedNextCursor,
+    setFeedHasMore,
+    setFeedLoadingMore,
+    setMyCommentsNextCursor,
+    setMyCommentsHasMore,
+    setMyCommentsLoadingMore,
+    setMyCommentsLoadedOnce,
+    setProviders,
+  });
+  setProviders(bootstrap.auth.providers);
+  applyBootstrapSelections({
+    placeIds: bootstrap.places.map((place) => place.id),
+    setSelectedPlaceId,
+    setSelectedFestivalId,
+  });
+
+  if (bootstrap.auth.user) {
+    await refreshMyPageForUserRef.current(bootstrap.auth.user, true);
+    if (!isActive()) {
+      return;
+    }
+  } else {
+    setMyPage(null);
+  }
+
+  handleBootstrapAuthNotice({
+    authState,
+    user: bootstrap.auth.user,
+    goToTab: goToTabRef.current,
+    setNotice,
+  });
+}

--- a/src/hooks/useAppBootstrapEffects.ts
+++ b/src/hooks/useAppBootstrapEffects.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
-import { getFestivals, getMapBootstrap } from '../api/bootstrapClient';
+
 import type {
   FestivalItem,
   MyPageResponse,
@@ -8,12 +8,8 @@ import type {
   SessionUser,
   StampState,
 } from '../types';
-import { handleBootstrapAuthNotice } from './app-bootstrap/bootstrapAuthNotice';
-import {
-  applyBootstrapSelections,
-  resetBootstrapRuntime,
-  resetFestivalSelection,
-} from './app-bootstrap/bootstrapRuntimeReset';
+import { bootstrapFestivalLoader } from './app-bootstrap/bootstrapFestivalLoader';
+import { bootstrapMapSession } from './app-bootstrap/bootstrapMapSession';
 import { clearAuthQueryParams } from './useAppRouteState';
 import type { AppBootstrapSharedRefs } from './useAppBootstrapSharedRefs';
 
@@ -75,17 +71,15 @@ export function useMapBootstrapEffect({
       setBootstrapError(null);
 
       try {
-        const bootstrap = await getMapBootstrap();
-        if (!active) {
-          return;
-        }
-
-        setPlaces(bootstrap.places);
-        setStampState(bootstrap.stamps);
-        setHasRealData(bootstrap.hasRealData);
-        setSessionUser(bootstrap.auth.user);
-        resetReviewCachesRef.current();
-        resetBootstrapRuntime({
+        await bootstrapMapSession({
+          authState,
+          refreshMyPageForUserRef,
+          resetReviewCachesRef,
+          goToTabRef,
+          setPlaces,
+          setStampState,
+          setHasRealData,
+          setSessionUser,
           setFeedNextCursor,
           setFeedHasMore,
           setFeedLoadingMore,
@@ -94,30 +88,17 @@ export function useMapBootstrapEffect({
           setMyCommentsLoadingMore,
           setMyCommentsLoadedOnce,
           setProviders,
-        });
-        setProviders(bootstrap.auth.providers);
-        applyBootstrapSelections({
-          placeIds: bootstrap.places.map((place) => place.id),
           setSelectedPlaceId,
           setSelectedFestivalId,
+          setMyPage,
+          setNotice,
+          isActive: () => active,
         });
-
-        if (bootstrap.auth.user) {
-          await refreshMyPageForUserRef.current(bootstrap.auth.user, true);
-          if (!active) {
-            return;
-          }
-        } else {
-          setMyPage(null);
+        if (!active) {
+          return;
         }
 
         setBootstrapStatus('ready');
-        handleBootstrapAuthNotice({
-          authState,
-          user: bootstrap.auth.user,
-          goToTab: goToTabRef.current,
-          setNotice,
-        });
       } catch (error) {
         setBootstrapError(formatErrorMessageRef.current(error));
         setBootstrapStatus('error');
@@ -166,18 +147,11 @@ export function useFestivalBootstrapEffect({
   useEffect(() => {
     let active = true;
 
-    void getFestivals()
-      .then((festivalResult) => {
-        if (!active) {
-          return;
-        }
-        setFestivals(festivalResult);
-        resetFestivalSelection(
-          festivalResult.map((festival) => festival.id),
-          setSelectedFestivalId
-        );
-      })
-      .catch((error) => reportBackgroundErrorRef.current(error));
+    void bootstrapFestivalLoader({
+      setFestivals,
+      setSelectedFestivalId,
+      isActive: () => active,
+    }).catch((error) => reportBackgroundErrorRef.current(error));
 
     return () => {
       active = false;


### PR DESCRIPTION
## Summary
- split map bootstrap session loading into a dedicated helper
- split festival bootstrap loading into a dedicated helper
- keep useAppBootstrapEffects focused on orchestration

## Validation
- npm run lint -- src/hooks/useAppBootstrapEffects.ts src/hooks/app-bootstrap
- npm run typecheck
- npm run build
- npm run test:all
- python .tmp/check_utf8_integrity.py