### PR TITLE
refactor: remove residual coordinator and facade indirection

### DIFF
--- a/backend/app/repositories/review_write_repository.py
+++ b/backend/app/repositories/review_write_repository.py
@@ -173,6 +173,17 @@ def create_comment_with_notifications(
     return get_review_comments(db, review_id), notifications
 
 
+def create_comment(
+    db: Session,
+    review_id: str,
+    payload: CommentCreate,
+    user_id: str,
+    nickname: str,
+) -> list[CommentOut]:
+    comments, _ = create_comment_with_notifications(db, review_id, payload, user_id, nickname)
+    return comments
+
+
 def delete_comment(
     db: Session,
     review_id: str,

--- a/backend/app/repository_normalized.py
+++ b/backend/app/repository_normalized.py
@@ -45,7 +45,8 @@ from .repositories.review_query_repository import (
     to_review_out as to_review_out,
 )
 from .repositories.review_write_repository import (
-    create_comment_with_notifications as create_comment_with_notifications_entry,
+    create_comment as create_comment,
+    create_comment_with_notifications as create_comment_with_notifications,
     create_review as create_review,
     delete_comment as delete_comment,
     delete_review as delete_review,
@@ -103,25 +104,5 @@ __all__ = [
 
 def utcnow_naive():
     return utcnow_naive_entry()
-
-def create_comment_with_notifications(
-    db: Session,
-    review_id: str,
-    payload: CommentCreate,
-    user_id: str,
-    nickname: str,
-) -> tuple[list[CommentOut], list[tuple[str, UserNotificationOut]]]:
-    return create_comment_with_notifications_entry(db, review_id, payload, user_id, nickname)
-
-
-def create_comment(
-    db: Session,
-    review_id: str,
-    payload: CommentCreate,
-    user_id: str,
-    nickname: str,
-) -> list[CommentOut]:
-    comments, _ = create_comment_with_notifications(db, review_id, payload, user_id, nickname)
-    return comments
 
 

--- a/src/hooks/buildAppShellCoordinatorResult.ts
+++ b/src/hooks/buildAppShellCoordinatorResult.ts
@@ -1,0 +1,36 @@
+import type { CoordinatorArgs } from './useAppShellCoordinator.types';
+import type { useAppCoordinatorActions } from './useAppCoordinatorActions';
+import type { useAppCoordinatorServices } from './useAppCoordinatorServices';
+
+interface BuildCoordinatorResultParams extends CoordinatorArgs {
+  services: ReturnType<typeof useAppCoordinatorServices>;
+  actions: ReturnType<typeof useAppCoordinatorActions>;
+}
+
+export function buildAppShellCoordinatorResult({
+  routeState,
+  domainState,
+  shellRuntimeState,
+  pageRuntimeState,
+  dataState,
+  initialMapViewport,
+  services,
+  actions,
+}: BuildCoordinatorResultParams) {
+  return {
+    ...services,
+    ...actions,
+    initialMapViewport,
+    ...pageRuntimeState,
+    ...domainState.auth,
+    ...domainState.map,
+    ...domainState.myPage,
+    ...domainState.returnView,
+    ...domainState.review,
+    ...routeState,
+    ...shellRuntimeState,
+    ...dataState,
+    ...services.navigationHelpers,
+    ...services.paginationActions,
+  };
+}

--- a/src/hooks/useAppShellCoordinator.ts
+++ b/src/hooks/useAppShellCoordinator.ts
@@ -1,6 +1,7 @@
 import { useAppCoordinatorActions } from './useAppCoordinatorActions';
 import { useAppCoordinatorEffects } from './useAppCoordinatorEffects';
 import { useAppCoordinatorServices } from './useAppCoordinatorServices';
+import { buildAppShellCoordinatorResult } from './buildAppShellCoordinatorResult';
 import type { CoordinatorArgs } from './useAppShellCoordinator.types';
 
 export function useAppShellCoordinator({
@@ -36,20 +37,14 @@ export function useAppShellCoordinator({
     services,
   });
 
-  return {
-    ...services,
-    ...actions,
+  return buildAppShellCoordinatorResult({
+    routeState,
+    domainState,
+    shellRuntimeState,
+    pageRuntimeState,
+    dataState,
     initialMapViewport,
-    ...pageRuntimeState,
-    ...domainState.auth,
-    ...domainState.map,
-    ...domainState.myPage,
-    ...domainState.returnView,
-    ...domainState.review,
-    ...routeState,
-    ...shellRuntimeState,
-    ...dataState,
-    ...services.navigationHelpers,
-    ...services.paginationActions,
-  };
+    services,
+    actions,
+  });
 }


### PR DESCRIPTION
## Summary
- remove the last comment facade wrapper from repository_normalized
- move direct comment-only behavior into review_write_repository
- extract shell coordinator result assembly into a dedicated builder

## Validation
- py -3.14 -m pytest tests/test_repository.py tests/test_review_service.py
- npm run typecheck
- npm run build
- python .tmp/check_utf8_integrity.py