### PR TITLE
fix: move alerts under settings and stabilize build

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "build": "tsx scripts/build-frontend.ts",
+    "prebuild": "node scripts/build-frontend.mjs prepare",
+    "build": "esbuild src/main.tsx --bundle --outdir=infra/nginx/site/assets --public-path=/assets --entry-names=main-[hash] --chunk-names=chunk-[hash] --asset-names=asset-[hash] --format=esm --splitting --target=es2020,chrome110,safari16 --jsx=automatic --loader:.css=css --loader:.png=file --loader:.otf=file --loader:.ttf=file --loader:.woff=file --loader:.woff2=file --minify --log-level=info && node scripts/build-frontend.mjs finalize",
     "lint": "eslint src scripts deploy/api-worker-shell test",
     "test": "node --max-old-space-size=8192 ./node_modules/vitest/vitest.mjs run",
     "test:unit": "tsx scripts/run-unit-tests.ts",

--- a/scripts/build-frontend.mjs
+++ b/scripts/build-frontend.mjs
@@ -1,36 +1,37 @@
-﻿import { build } from "esbuild";
-import { mkdir, readFile, readdir, rm, writeFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+/* global console, process */
+
+import { mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
-const rootDir = path.resolve(__dirname, "..");
-const siteDir = path.join(rootDir, "infra", "nginx", "site");
-const assetsDir = path.join(siteDir, "assets");
-const iconsDir = path.join(siteDir, "icons");
+const rootDir = path.resolve(__dirname, '..');
+const siteDir = path.join(rootDir, 'infra', 'nginx', 'site');
+const assetsDir = path.join(siteDir, 'assets');
+const iconsDir = path.join(siteDir, 'icons');
 
-const APP_NAME = "대전잼있슈";
-const APP_SHORT_NAME = "잼있슈";
-const APP_DESCRIPTION = "대전을 한 입에 고르는 모바일 여행 앱";
-const MAP_KEY_WARNING = "PUBLIC_NAVER_MAP_CLIENT_ID 값이 비어 있어 지도 영역은 안내 상태로 표시됩니다.";
+const APP_NAME = '대전잼있슈';
+const APP_SHORT_NAME = '잼있슈';
+const APP_DESCRIPTION = '대전을 한 입에 고르는 모바일 여행 앱';
+const MAP_KEY_WARNING = 'PUBLIC_NAVER_MAP_CLIENT_ID 값이 비어 있어 지도 영역은 안내 상태로 표시됩니다.';
 
 async function readPublicEnv() {
-  const envFiles = [path.join(rootDir, ".env.example"), path.join(rootDir, ".env")];
+  const envFiles = [path.join(rootDir, '.env.example'), path.join(rootDir, '.env')];
   const values = {
     ...process.env,
   };
 
   for (const envFile of envFiles) {
     try {
-      const content = await readFile(envFile, "utf8");
+      const content = await readFile(envFile, 'utf8');
       for (const line of content.split(/\r?\n/)) {
         const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith("#")) {
+        if (!trimmed || trimmed.startsWith('#')) {
           continue;
         }
 
-        const separatorIndex = trimmed.indexOf("=");
+        const separatorIndex = trimmed.indexOf('=');
         if (separatorIndex <= 0) {
           continue;
         }
@@ -48,17 +49,17 @@ async function readPublicEnv() {
 
   const mapKey =
     (values.PUBLIC_NAVER_MAP_CLIENT_ID &&
-    values.PUBLIC_NAVER_MAP_CLIENT_ID !== "YOUR_NAVER_MAP_CLIENT_ID"
+    values.PUBLIC_NAVER_MAP_CLIENT_ID !== 'YOUR_NAVER_MAP_CLIENT_ID'
       ? values.PUBLIC_NAVER_MAP_CLIENT_ID
-      : "") ||
+      : '') ||
     values.NAVER_MAP_CLIENT_ID ||
-    "";
+    '';
 
   return {
-    apiBaseUrl: values.PUBLIC_APP_BASE_URL || values.APP_BASE_URL || "http://localhost:8000",
+    apiBaseUrl: values.PUBLIC_APP_BASE_URL || values.APP_BASE_URL || 'http://localhost:8000',
     naverMapClientId: mapKey,
-    supabaseUrl: values.PUBLIC_SUPABASE_URL || values.APP_SUPABASE_URL || "",
-    supabaseAnonKey: values.PUBLIC_SUPABASE_ANON_KEY || values.APP_SUPABASE_ANON_KEY || "",
+    supabaseUrl: values.PUBLIC_SUPABASE_URL || values.APP_SUPABASE_URL || '',
+    supabaseAnonKey: values.PUBLIC_SUPABASE_ANON_KEY || values.APP_SUPABASE_ANON_KEY || '',
   };
 }
 
@@ -68,17 +69,17 @@ function createManifest() {
       name: APP_NAME,
       short_name: APP_SHORT_NAME,
       description: APP_DESCRIPTION,
-      start_url: "/",
-      display: "standalone",
-      background_color: "#fff8fb",
-      theme_color: "#ff7fa8",
-      lang: "ko",
+      start_url: '/',
+      display: 'standalone',
+      background_color: '#fff8fb',
+      theme_color: '#ff7fa8',
+      lang: 'ko',
       icons: [
         {
-          src: "/icons/jamissue-icon.svg",
-          sizes: "any",
-          type: "image/svg+xml",
-          purpose: "any maskable",
+          src: '/icons/jamissue-icon.svg',
+          sizes: 'any',
+          type: 'image/svg+xml',
+          purpose: 'any maskable',
         },
       ],
     },
@@ -158,64 +159,53 @@ async function resolveBuiltAssets() {
   const cssFile = files.find((file) => /^main-[A-Z0-9]+\.css$/i.test(file));
 
   if (!jsFile || !cssFile) {
-    throw new Error(`Expected hashed main assets, found: ${files.join(", ")}`);
+    throw new Error(`Expected hashed main assets, found: ${files.join(', ')}`);
   }
 
   return { jsFile, cssFile };
 }
 
-async function writeStaticFiles(publicConfig, builtAssets) {
-  await mkdir(siteDir, { recursive: true });
-  await mkdir(iconsDir, { recursive: true });
-  await writeFile(path.join(siteDir, "index.html"), createIndexHtml(builtAssets), "utf8");
-  await writeFile(path.join(siteDir, "_headers"), createPagesHeaders(), "utf8");
-  await writeFile(path.join(siteDir, "manifest.webmanifest"), createManifest(), "utf8");
-  await writeFile(path.join(iconsDir, "jamissue-icon.svg"), createIconSvg(), "utf8");
-  await writeFile(
-    path.join(siteDir, "app-config.js"),
-    `window.__JAMISSUE_CONFIG__ = ${JSON.stringify(publicConfig, null, 2)};\n`,
-    "utf8",
-  );
+async function prepareBuild() {
+  await rm(siteDir, { recursive: true, force: true });
+  await mkdir(assetsDir, { recursive: true });
 }
 
-async function main() {
+async function finalizeBuild() {
   const publicConfig = await readPublicEnv();
 
   if (!publicConfig.naverMapClientId) {
     console.warn(MAP_KEY_WARNING);
   }
 
-  await rm(siteDir, { recursive: true, force: true });
-  await mkdir(assetsDir, { recursive: true });
-
-  await build({
-    entryPoints: [path.join(rootDir, "src", "main.tsx")],
-    bundle: true,
-    outdir: assetsDir,
-    publicPath: "/assets",
-    entryNames: "main-[hash]",
-    chunkNames: "chunk-[hash]",
-    assetNames: "asset-[hash]",
-    format: "esm",
-    splitting: true,
-    target: ["es2020", "chrome110", "safari16"],
-    jsx: "automatic",
-    loader: {
-      ".css": "css",
-      ".png": "file",
-      ".otf": "file",
-      ".ttf": "file",
-      ".woff": "file",
-      ".woff2": "file",
-    },
-    minify: true,
-    sourcemap: false,
-    logLevel: "info",
-  });
-
   const builtAssets = await resolveBuiltAssets();
-  await writeStaticFiles(publicConfig, builtAssets);
+  await mkdir(siteDir, { recursive: true });
+  await mkdir(iconsDir, { recursive: true });
+  await writeFile(path.join(siteDir, 'index.html'), createIndexHtml(builtAssets), 'utf8');
+  await writeFile(path.join(siteDir, '_headers'), createPagesHeaders(), 'utf8');
+  await writeFile(path.join(siteDir, 'manifest.webmanifest'), createManifest(), 'utf8');
+  await writeFile(path.join(iconsDir, 'jamissue-icon.svg'), createIconSvg(), 'utf8');
+  await writeFile(
+    path.join(siteDir, 'app-config.js'),
+    `window.__JAMISSUE_CONFIG__ = ${JSON.stringify(publicConfig, null, 2)};\n`,
+    'utf8',
+  );
   console.log(`Built mobile web bundle to ${siteDir}`);
+}
+
+async function main() {
+  const mode = process.argv[2];
+
+  if (mode === 'prepare') {
+    await prepareBuild();
+    return;
+  }
+
+  if (mode === 'finalize') {
+    await finalizeBuild();
+    return;
+  }
+
+  throw new Error(`Unknown build mode: ${mode ?? '(missing)'}`);
 }
 
 main().catch((error) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,9 +2,7 @@ import { useState } from 'react';
 import { AppMapStageView } from './components/AppMapStageView';
 import { AppPageStage } from './components/AppPageStage';
 import { BottomNav } from './components/BottomNav';
-import { GlobalFeedbackButton } from './components/GlobalFeedbackButton';
 import { FloatingBackButton } from './components/FloatingBackButton';
-import { GlobalNotificationCenter } from './components/GlobalNotificationCenter';
 import { GlobalStatusBanner } from './components/GlobalStatusBanner';
 import {
   useAppRouteState,
@@ -51,38 +49,26 @@ export default function App() {
     handleNavigateBack,
     handleBottomNavChange,
     globalStatus,
-    hydratedMyPage,
-    sessionUser,
-    handleOpenGlobalNotification,
-    handleMarkAllNotificationsRead,
-    handleDeleteNotification,
     mapStageProps,
     pageStageProps,
   } = useAppStageProps(coordinator);
   return (
     <div className="map-app-shell">
-      <div className={[
-        'phone-shell',
-        activeTab === 'map' ? 'phone-shell--map' : '',
-      ].filter(Boolean).join(' ')}>
+      <div
+        className={[
+          'phone-shell',
+          activeTab === 'map' ? 'phone-shell--map' : '',
+        ].filter(Boolean).join(' ')}
+      >
         {globalStatus && (
           <div className="phone-shell__status-slot">
-            <GlobalStatusBanner tone={globalStatus.tone} message={globalStatus.message} layout={activeTab === 'map' ? 'map' : 'page'} />
+            <GlobalStatusBanner
+              tone={globalStatus.tone}
+              message={globalStatus.message}
+              layout={activeTab === 'map' ? 'map' : 'page'}
+            />
           </div>
         )}
-        <div className="phone-shell__utility-slot">
-          <GlobalFeedbackButton />
-          {sessionUser && hydratedMyPage && (
-            <GlobalNotificationCenter
-              sessionUserName={sessionUser.nickname}
-              notifications={hydratedMyPage.notifications}
-              unreadCount={hydratedMyPage.unreadNotificationCount}
-              onOpenNotification={handleOpenGlobalNotification}
-              onMarkAllNotificationsRead={handleMarkAllNotificationsRead}
-              onDeleteNotification={handleDeleteNotification}
-            />
-          )}
-        </div>
         <div className="phone-shell__body">
           {activeTab === 'map' ? (
             <AppMapStageView {...mapStageProps} />

--- a/src/components/GlobalFeedbackButton.tsx
+++ b/src/components/GlobalFeedbackButton.tsx
@@ -1,4 +1,4 @@
-const FEEDBACK_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSfKNC80Y2_kDm2NFzOAa6IBOfcgjdZYv48EavTkjdbEI4bMQw/viewform?usp=publish-editor';
+export const FEEDBACK_FORM_URL = 'https://docs.google.com/forms/d/e/1FAIpQLSfKNC80Y2_kDm2NFzOAa6IBOfcgjdZYv48EavTkjdbEI4bMQw/viewform?usp=publish-editor';
 
 function FeedbackIcon() {
   return (

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -28,6 +28,7 @@ export function MyPagePanel({
     routeError,
     commentsHasMore,
     commentsLoadingMore,
+    unreadNotificationCount,
   } = panelState;
   const {
     onOpenPlace,
@@ -47,7 +48,14 @@ export function MyPagePanel({
     onPublishRoute,
   } = panelActions;
   const { adminSummary, adminBusyPlaceId, adminLoading } = adminData;
-  const { onRefreshAdmin, onToggleAdminPlace, onToggleAdminManualOverride } = adminActions;
+  const {
+    onRefreshAdmin,
+    onToggleAdminPlace,
+    onToggleAdminManualOverride,
+    onOpenNotification,
+    onMarkAllNotificationsRead,
+    onDeleteNotification,
+  } = adminActions;
   const [nickname, setNickname] = useState(sessionUser?.nickname ?? '');
   const [showVisitedDetail, setShowVisitedDetail] = useState(false);
   const [showSettings, setShowSettings] = useState(false);
@@ -104,10 +112,16 @@ export function MyPagePanel({
       <MyPageSettingsSection
         nickname={nickname}
         showSettings={showSettings}
+        sessionUserName={sessionUser.nickname}
+        notifications={myPage?.notifications ?? []}
+        unreadNotificationCount={unreadNotificationCount}
         profileCompletedAt={sessionUser.profileCompletedAt}
         profileSaving={profileSaving}
         profileError={profileError}
         onNicknameChange={setNickname}
+        onOpenNotification={onOpenNotification}
+        onMarkAllNotificationsRead={onMarkAllNotificationsRead}
+        onDeleteNotification={onDeleteNotification}
         onClose={() => setShowSettings(false)}
         onSubmit={handleNicknameSubmit}
       />

--- a/src/components/my-page/MyPageAccountSection.tsx
+++ b/src/components/my-page/MyPageAccountSection.tsx
@@ -32,9 +32,8 @@ export function MyPageAccountSection({
         </button>
       </div>
       {!sessionUser.profileCompletedAt && (
-        <p className="section-copy">닉네임을 먼저 정하면 기록을 계정 기준으로 계속 이어갈 수 있어요.</p>
+        <p className="section-copy">프로필을 먼저 완성하면 기록과 계정 정보가 같은 기준으로 이어져요.</p>
       )}
     </section>
   );
 }
-

--- a/src/components/my-page/MyPageSettingsSection.tsx
+++ b/src/components/my-page/MyPageSettingsSection.tsx
@@ -1,12 +1,22 @@
-import type { FormEvent } from 'react';
+import { useState, type FormEvent } from 'react';
+import { FEEDBACK_FORM_URL } from '../GlobalFeedbackButton';
+import { NotificationPanel } from '../notifications/NotificationPanel';
+import type { NotificationItem } from '../notifications/notificationTypes';
+import { useNotificationPanelActions } from '../notifications/useNotificationPanelActions';
 
 type MyPageSettingsSectionProps = {
   nickname: string;
   showSettings: boolean;
+  sessionUserName: string;
+  notifications: NotificationItem[];
+  unreadNotificationCount: number;
   profileCompletedAt: string | null | undefined;
   profileSaving: boolean;
   profileError: string | null;
   onNicknameChange: (value: string) => void;
+  onOpenNotification: (notification: NotificationItem) => Promise<void>;
+  onMarkAllNotificationsRead: () => Promise<void>;
+  onDeleteNotification: (notificationId: string) => Promise<void>;
   onClose: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 };
@@ -14,13 +24,27 @@ type MyPageSettingsSectionProps = {
 export function MyPageSettingsSection({
   nickname,
   showSettings,
+  sessionUserName,
+  notifications,
+  unreadNotificationCount,
   profileCompletedAt,
   profileSaving,
   profileError,
   onNicknameChange,
+  onOpenNotification,
+  onMarkAllNotificationsRead,
+  onDeleteNotification,
   onClose,
   onSubmit,
 }: MyPageSettingsSectionProps) {
+  const [showNotifications, setShowNotifications] = useState(false);
+  const notificationActions = useNotificationPanelActions({
+    onOpenNotification,
+    onMarkAllNotificationsRead,
+    onDeleteNotification,
+    onClose: () => setShowNotifications(false),
+  });
+
   if (!showSettings && profileCompletedAt) {
     return null;
   }
@@ -30,8 +54,8 @@ export function MyPageSettingsSection({
       <div className="settings-card__header">
         <div>
           <p className="eyebrow">SETTINGS</p>
-          <h3>{profileCompletedAt ? '닉네임 수정' : '닉네임을 먼저 정해 주세요'}</h3>
-          <p className="section-copy">닉네임은 서비스 전체에서 하나만 사용할 수 있어요.</p>
+          <h3>{profileCompletedAt ? '프로필 설정' : '프로필을 먼저 정해 주세요'}</h3>
+          <p className="section-copy">프로필은 서비스 전체에서 하나만 사용돼요.</p>
         </div>
         {profileCompletedAt && (
           <button type="button" className="settings-card__close" onClick={onClose} aria-label="설정 닫기">
@@ -41,14 +65,36 @@ export function MyPageSettingsSection({
       </div>
       <form className="route-builder-form" onSubmit={(event) => void onSubmit(event)}>
         <label className="route-builder-field">
-          <span>닉네임</span>
+          <span>프로필명</span>
           <input value={nickname} onChange={(event) => onNicknameChange(event.target.value)} placeholder="예: 대전산책러" maxLength={40} />
         </label>
         {profileError && <p className="form-error-copy">{profileError}</p>}
         <button type="submit" className="primary-button route-submit-button" disabled={profileSaving || nickname.trim().length < 2}>
-          {profileSaving ? '저장 중' : '닉네임 저장'}
+          {profileSaving ? '저장 중' : '프로필 저장'}
         </button>
       </form>
+      <div className="settings-card__links">
+        <button
+          type="button"
+          className={showNotifications ? 'secondary-button is-complete settings-card__link-button' : 'secondary-button settings-card__link-button'}
+          onClick={() => setShowNotifications((current) => !current)}
+        >
+          <span>알람</span>
+          {unreadNotificationCount > 0 && <strong>{unreadNotificationCount}</strong>}
+        </button>
+        <a className="secondary-button settings-card__link-button" href={FEEDBACK_FORM_URL} target="_blank" rel="noreferrer">
+          <span>피드백</span>
+        </a>
+      </div>
+      {showNotifications && (
+        <NotificationPanel
+          sessionUserName={sessionUserName}
+          notifications={notifications}
+          unreadCount={unreadNotificationCount}
+          actions={notificationActions}
+          embedded
+        />
+      )}
     </section>
   );
 }

--- a/src/components/my-page/myPagePanelTypes.ts
+++ b/src/components/my-page/myPagePanelTypes.ts
@@ -5,6 +5,7 @@ import type {
   MyPageTabKey,
   ReviewMood,
   SessionUser,
+  UserNotification,
 } from '../../types';
 
 export interface MyPagePanelProps {
@@ -23,6 +24,7 @@ export interface MyPagePanelProps {
     routeError: string | null;
     commentsHasMore: boolean;
     commentsLoadingMore: boolean;
+    unreadNotificationCount: number;
   };
   reviewActions: {
     onOpenPlace: (placeId: string) => void;
@@ -50,5 +52,8 @@ export interface MyPagePanelProps {
     onRefreshAdmin: () => Promise<void>;
     onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
     onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
+    onOpenNotification: (notification: UserNotification) => Promise<void>;
+    onMarkAllNotificationsRead: () => Promise<void>;
+    onDeleteNotification: (notificationId: string) => Promise<void>;
   };
 }

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -7,6 +7,7 @@ interface NotificationPanelProps {
   notifications: NotificationItem[];
   unreadCount: number;
   actions: NotificationPanelActions;
+  embedded?: boolean;
 }
 
 export function NotificationPanel({
@@ -14,6 +15,7 @@ export function NotificationPanel({
   notifications,
   unreadCount,
   actions,
+  embedded = false,
 }: NotificationPanelProps) {
   const {
     busyAll,
@@ -25,12 +27,12 @@ export function NotificationPanel({
   } = actions;
 
   return (
-    <section className="global-notification-panel">
+    <section className={embedded ? 'global-notification-panel global-notification-panel--embedded' : 'global-notification-panel'}>
       <div className="notification-panel__header">
         <div>
           <p className="eyebrow">ALERT</p>
           <h3>{sessionUserName ? `${sessionUserName}님의 새 알림` : '새 알림'}</h3>
-          <p className="section-copy">어느 탭에 있든 여기서 바로 확인하고 이동할 수 있어요.</p>
+          <p className="section-copy">탭에 있던 내용을 잃지 않고 바로 확인하고 이동할 수 있어요.</p>
         </div>
         <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAll()} disabled={busyAll || unreadCount === 0}>
           {busyAll ? '처리 중' : '모두 읽음'}

--- a/src/components/page-stage/PageStageMyView.tsx
+++ b/src/components/page-stage/PageStageMyView.tsx
@@ -26,6 +26,7 @@ export function PageStageMyView({
         routeError: myPageData.routeError,
         commentsHasMore: myPageData.commentsHasMore,
         commentsLoadingMore: myPageData.commentsLoadingMore,
+        unreadNotificationCount: myPageData.unreadNotificationCount,
       }}
       reviewActions={{
         onOpenPlace: sharedActions.onOpenPlace,
@@ -53,6 +54,9 @@ export function PageStageMyView({
         onRefreshAdmin: myPageActions.onRefreshAdmin,
         onToggleAdminPlace: myPageActions.onToggleAdminPlace,
         onToggleAdminManualOverride: myPageActions.onToggleAdminManualOverride,
+        onOpenNotification: myPageActions.onOpenNotification,
+        onMarkAllNotificationsRead: myPageActions.onMarkAllNotificationsRead,
+        onDeleteNotification: myPageActions.onDeleteNotification,
       }}
     />
   );

--- a/src/components/page-stage/appPageStageTypes.ts
+++ b/src/components/page-stage/appPageStageTypes.ts
@@ -13,6 +13,7 @@ import type {
   RoutePreview,
   SessionUser,
   Tab,
+  UserNotification,
   UserRoute,
 } from '../../types';
 
@@ -60,6 +61,7 @@ export interface AppPageStageProps {
     adminLoading: boolean;
     commentsHasMore: boolean;
     commentsLoadingMore: boolean;
+    unreadNotificationCount: number;
   };
   sharedActions: {
     onRequestLogin: () => void;
@@ -97,5 +99,8 @@ export interface AppPageStageProps {
     onRefreshAdmin: () => Promise<void>;
     onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
     onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
+    onOpenNotification: (notification: UserNotification) => Promise<void>;
+    onMarkAllNotificationsRead: () => Promise<void>;
+    onDeleteNotification: (notificationId: string) => Promise<void>;
   };
 }

--- a/src/hooks/useAppShellStageProps.ts
+++ b/src/hooks/useAppShellStageProps.ts
@@ -5,10 +5,6 @@ type AppShellCoordinatorState = ReturnType<typeof useAppShellCoordinator>;
 export function useAppShellStageProps(state: AppShellCoordinatorState) {
   const {
     activeTab,
-    handleDeleteNotification,
-    handleMarkAllNotificationsRead,
-    handleOpenGlobalNotification,
-    sessionUser,
     shellNavigation: {
       canNavigateBack,
       handleNavigateBack,
@@ -23,10 +19,5 @@ export function useAppShellStageProps(state: AppShellCoordinatorState) {
     handleNavigateBack,
     handleBottomNavChange,
     globalStatus: viewModels.globalStatus,
-    hydratedMyPage: viewModels.hydratedMyPage,
-    sessionUser,
-    handleOpenGlobalNotification,
-    handleMarkAllNotificationsRead,
-    handleDeleteNotification,
   };
 }

--- a/src/hooks/usePageStageProps.ts
+++ b/src/hooks/usePageStageProps.ts
@@ -95,6 +95,7 @@ export function usePageStageProps(state: AppShellCoordinatorState) {
       adminLoading,
       commentsHasMore: myCommentsHasMore,
       commentsLoadingMore: myCommentsLoadingMore,
+      unreadNotificationCount: viewModels.hydratedMyPage?.unreadNotificationCount ?? 0,
     },
     sharedActions: {
       onRequestLogin: mapStageActions.handleRequestLogin,
@@ -132,6 +133,9 @@ export function usePageStageProps(state: AppShellCoordinatorState) {
       onRefreshAdmin: adminActions.handleRefreshAdminImport,
       onToggleAdminPlace: adminActions.handleToggleAdminPlace,
       onToggleAdminManualOverride: adminActions.handleToggleAdminManualOverride,
+      onOpenNotification: state.handleOpenGlobalNotification,
+      onMarkAllNotificationsRead: state.handleMarkAllNotificationsRead,
+      onDeleteNotification: state.handleDeleteNotification,
     },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -174,6 +174,15 @@ textarea {
   backdrop-filter: blur(18px);
 }
 
+.global-notification-panel--embedded {
+  position: relative;
+  top: auto;
+  right: auto;
+  width: 100%;
+  max-height: none;
+  margin-top: 6px;
+}
+
 .global-notification-panel::-webkit-scrollbar {
   width: 10px;
 }
@@ -193,6 +202,107 @@ textarea {
 
 .global-notification-panel::-webkit-scrollbar-thumb:hover {
   background: linear-gradient(180deg, rgba(255, 126, 170, 0.96), rgba(255, 96, 150, 0.88));
+}
+
+.notification-panel__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.notification-panel__mark-all {
+  flex-shrink: 0;
+}
+
+.notification-list {
+  display: grid;
+  gap: 12px;
+}
+
+.notification-item {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+  padding: 14px;
+  border-radius: 22px;
+  border: 1px solid rgba(255, 197, 217, 0.42);
+  background: rgba(255, 255, 255, 0.86);
+}
+
+.notification-item.is-unread {
+  background: rgba(255, 248, 251, 0.96);
+  box-shadow: 0 10px 20px rgba(255, 143, 183, 0.08);
+}
+
+.notification-item__content {
+  display: grid;
+  gap: 8px;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  text-align: left;
+  color: inherit;
+}
+
+.notification-item__top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+
+.notification-item__time {
+  color: var(--muted);
+  font-size: 12px;
+}
+
+.notification-item__delete {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.notification-item__delete:hover {
+  color: var(--ink);
+  background: rgba(66, 40, 60, 0.07);
+}
+
+.settings-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.settings-card__close {
+  width: 28px;
+  height: 28px;
+  border: 0;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--muted);
+  font-size: 20px;
+  line-height: 1;
+}
+
+.settings-card__links {
+  display: grid;
+  gap: 10px;
+}
+
+.settings-card__link-button {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  text-decoration: none;
 }
 
 .map-stage {


### PR DESCRIPTION
## Summary
- move alerts and feedback under the settings section and remove the top-right global entry points
- embed the notification panel in my page settings so the map overlay path no longer competes with Naver controls
- switch the frontend build pipeline to esbuild CLI plus finalize script to avoid local spawn EPERM failures

## Validation
- npm run typecheck
- npm run lint
- npm run build
- python .tmp/check_utf8_integrity.py