### PR TITLE
fix: restore settings gear entry

### DIFF
--- a/src/components/my-page/MyPageAccountSection.tsx
+++ b/src/components/my-page/MyPageAccountSection.tsx
@@ -25,6 +25,7 @@ export function MyPageAccountSection({
       </div>
       <div className="account-action-row">
         <button type="button" className={showSettings ? 'secondary-button is-complete' : 'secondary-button'} onClick={onToggleSettings}>
+          <span aria-hidden="true">⚙</span>{' '}
           {showSettings ? '설정 닫기' : '설정 열기'}
         </button>
         <button type="button" className="secondary-button" onClick={onLogout} disabled={isLoggingOut}>


### PR DESCRIPTION
## Summary
- restore the visible settings gear entry in my page account actions

## Validation
- npm run typecheck
- npm run lint
- python .tmp/check_utf8_integrity.py