### PR TITLE
fix: move settings menu back to top-right

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { AppMapStageView } from './components/AppMapStageView';
 import { AppPageStage } from './components/AppPageStage';
 import { BottomNav } from './components/BottomNav';
 import { FloatingBackButton } from './components/FloatingBackButton';
+import { GlobalSettingsMenu } from './components/GlobalSettingsMenu';
 import { GlobalStatusBanner } from './components/GlobalStatusBanner';
 import {
   useAppRouteState,
@@ -49,6 +50,7 @@ export default function App() {
     handleNavigateBack,
     handleBottomNavChange,
     globalStatus,
+    globalUtility,
     mapStageProps,
     pageStageProps,
   } = useAppStageProps(coordinator);
@@ -69,6 +71,9 @@ export default function App() {
             />
           </div>
         )}
+        <div className="phone-shell__utility-slot">
+          <GlobalSettingsMenu {...globalUtility} />
+        </div>
         <div className="phone-shell__body">
           {activeTab === 'map' ? (
             <AppMapStageView {...mapStageProps} />

--- a/src/components/GlobalSettingsMenu.tsx
+++ b/src/components/GlobalSettingsMenu.tsx
@@ -1,0 +1,96 @@
+import { useState } from 'react';
+import { FEEDBACK_FORM_URL } from './GlobalFeedbackButton';
+import { NotificationPanel } from './notifications/NotificationPanel';
+import { useNotificationPanelActions } from './notifications/useNotificationPanelActions';
+import type { NotificationItem } from './notifications/notificationTypes';
+
+type GlobalSettingsMenuProps = {
+  sessionUserName: string | null;
+  notifications: NotificationItem[];
+  unreadCount: number;
+  onOpenNotification: (notification: NotificationItem) => Promise<void>;
+  onMarkAllNotificationsRead: () => Promise<void>;
+  onDeleteNotification: (notificationId: string) => Promise<void>;
+};
+
+function GearIcon() {
+  return (
+    <svg viewBox="0 0 24 24" className="review-action-button__svg" aria-hidden="true">
+      <path
+        d="M10.23 4.23a1 1 0 0 1 1-.73h1.54a1 1 0 0 1 1 .73l.24.85a6.9 6.9 0 0 1 1.43.59l.78-.43a1 1 0 0 1 1.2.18l1.08 1.08a1 1 0 0 1 .18 1.2l-.43.78c.24.45.44.92.59 1.43l.85.24a1 1 0 0 1 .73 1v1.54a1 1 0 0 1-.73 1l-.85.24a6.9 6.9 0 0 1-.59 1.43l.43.78a1 1 0 0 1-.18 1.2l-1.08 1.08a1 1 0 0 1-1.2.18l-.78-.43a6.9 6.9 0 0 1-1.43.59l-.24.85a1 1 0 0 1-1 .73h-1.54a1 1 0 0 1-1-.73l-.24-.85a6.9 6.9 0 0 1-1.43-.59l-.78.43a1 1 0 0 1-1.2-.18l-1.08-1.08a1 1 0 0 1-.18-1.2l.43-.78a6.9 6.9 0 0 1-.59-1.43l-.85-.24a1 1 0 0 1-.73-1v-1.54a1 1 0 0 1 .73-1l.85-.24a6.9 6.9 0 0 1 .59-1.43l-.43-.78a1 1 0 0 1 .18-1.2l1.08-1.08a1 1 0 0 1 1.2-.18l.78.43c.45-.24.92-.44 1.43-.59z"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="1.6"
+        strokeLinejoin="round"
+      />
+      <circle cx="12" cy="12" r="2.75" fill="none" stroke="currentColor" strokeWidth="1.6" />
+    </svg>
+  );
+}
+
+export function GlobalSettingsMenu({
+  sessionUserName,
+  notifications,
+  unreadCount,
+  onOpenNotification,
+  onMarkAllNotificationsRead,
+  onDeleteNotification,
+}: GlobalSettingsMenuProps) {
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [showNotifications, setShowNotifications] = useState(false);
+
+  const notificationActions = useNotificationPanelActions({
+    onOpenNotification,
+    onMarkAllNotificationsRead,
+    onDeleteNotification,
+    onClose: () => {
+      setShowNotifications(false);
+      setIsMenuOpen(false);
+    },
+  });
+
+  return (
+    <div className="global-settings-menu">
+      <button
+        type="button"
+        className={isMenuOpen ? 'secondary-button icon-button global-settings-menu__trigger is-complete' : 'secondary-button icon-button global-settings-menu__trigger'}
+        onClick={() => {
+          setIsMenuOpen((current) => !current);
+          if (isMenuOpen) {
+            setShowNotifications(false);
+          }
+        }}
+        aria-label="설정 열기"
+        title="설정 열기"
+      >
+        <GearIcon />
+        {unreadCount > 0 && <span className="notification-bell__dot" aria-hidden="true" />}
+      </button>
+
+      {isMenuOpen && (
+        <div className="global-settings-menu__menu">
+          <button
+            type="button"
+            className={showNotifications ? 'secondary-button is-complete global-settings-menu__item' : 'secondary-button global-settings-menu__item'}
+            onClick={() => setShowNotifications((current) => !current)}
+          >
+            <span>알람</span>
+            {unreadCount > 0 && <strong>{unreadCount}</strong>}
+          </button>
+          <a className="secondary-button global-settings-menu__item" href={FEEDBACK_FORM_URL} target="_blank" rel="noreferrer">
+            <span>피드백</span>
+          </a>
+        </div>
+      )}
+
+      {isMenuOpen && showNotifications && (
+        <NotificationPanel
+          sessionUserName={sessionUserName}
+          notifications={notifications}
+          unreadCount={unreadCount}
+          actions={notificationActions}
+        />
+      )}
+    </div>
+  );
+}

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -28,7 +28,6 @@ export function MyPagePanel({
     routeError,
     commentsHasMore,
     commentsLoadingMore,
-    unreadNotificationCount,
   } = panelState;
   const {
     onOpenPlace,
@@ -52,9 +51,6 @@ export function MyPagePanel({
     onRefreshAdmin,
     onToggleAdminPlace,
     onToggleAdminManualOverride,
-    onOpenNotification,
-    onMarkAllNotificationsRead,
-    onDeleteNotification,
   } = adminActions;
   const [nickname, setNickname] = useState(sessionUser?.nickname ?? '');
   const [showVisitedDetail, setShowVisitedDetail] = useState(false);
@@ -112,16 +108,10 @@ export function MyPagePanel({
       <MyPageSettingsSection
         nickname={nickname}
         showSettings={showSettings}
-        sessionUserName={sessionUser.nickname}
-        notifications={myPage?.notifications ?? []}
-        unreadNotificationCount={unreadNotificationCount}
         profileCompletedAt={sessionUser.profileCompletedAt}
         profileSaving={profileSaving}
         profileError={profileError}
         onNicknameChange={setNickname}
-        onOpenNotification={onOpenNotification}
-        onMarkAllNotificationsRead={onMarkAllNotificationsRead}
-        onDeleteNotification={onDeleteNotification}
         onClose={() => setShowSettings(false)}
         onSubmit={handleNicknameSubmit}
       />

--- a/src/components/my-page/MyPageAccountSection.tsx
+++ b/src/components/my-page/MyPageAccountSection.tsx
@@ -25,6 +25,7 @@ export function MyPageAccountSection({
       </div>
       <div className="account-action-row">
         <button type="button" className={showSettings ? 'secondary-button is-complete' : 'secondary-button'} onClick={onToggleSettings}>
+          <span aria-hidden="true">⚙</span>{' '}
           {showSettings ? '설정 닫기' : '설정 열기'}
         </button>
         <button type="button" className="secondary-button" onClick={onLogout} disabled={isLoggingOut}>

--- a/src/components/my-page/MyPageSettingsSection.tsx
+++ b/src/components/my-page/MyPageSettingsSection.tsx
@@ -1,22 +1,12 @@
-import { useState, type FormEvent } from 'react';
-import { FEEDBACK_FORM_URL } from '../GlobalFeedbackButton';
-import { NotificationPanel } from '../notifications/NotificationPanel';
-import type { NotificationItem } from '../notifications/notificationTypes';
-import { useNotificationPanelActions } from '../notifications/useNotificationPanelActions';
+import type { FormEvent } from 'react';
 
 type MyPageSettingsSectionProps = {
   nickname: string;
   showSettings: boolean;
-  sessionUserName: string;
-  notifications: NotificationItem[];
-  unreadNotificationCount: number;
   profileCompletedAt: string | null | undefined;
   profileSaving: boolean;
   profileError: string | null;
   onNicknameChange: (value: string) => void;
-  onOpenNotification: (notification: NotificationItem) => Promise<void>;
-  onMarkAllNotificationsRead: () => Promise<void>;
-  onDeleteNotification: (notificationId: string) => Promise<void>;
   onClose: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 };
@@ -24,27 +14,13 @@ type MyPageSettingsSectionProps = {
 export function MyPageSettingsSection({
   nickname,
   showSettings,
-  sessionUserName,
-  notifications,
-  unreadNotificationCount,
   profileCompletedAt,
   profileSaving,
   profileError,
   onNicknameChange,
-  onOpenNotification,
-  onMarkAllNotificationsRead,
-  onDeleteNotification,
   onClose,
   onSubmit,
 }: MyPageSettingsSectionProps) {
-  const [showNotifications, setShowNotifications] = useState(false);
-  const notificationActions = useNotificationPanelActions({
-    onOpenNotification,
-    onMarkAllNotificationsRead,
-    onDeleteNotification,
-    onClose: () => setShowNotifications(false),
-  });
-
   if (!showSettings && profileCompletedAt) {
     return null;
   }
@@ -73,28 +49,6 @@ export function MyPageSettingsSection({
           {profileSaving ? '저장 중' : '프로필 저장'}
         </button>
       </form>
-      <div className="settings-card__links">
-        <button
-          type="button"
-          className={showNotifications ? 'secondary-button is-complete settings-card__link-button' : 'secondary-button settings-card__link-button'}
-          onClick={() => setShowNotifications((current) => !current)}
-        >
-          <span>알람</span>
-          {unreadNotificationCount > 0 && <strong>{unreadNotificationCount}</strong>}
-        </button>
-        <a className="secondary-button settings-card__link-button" href={FEEDBACK_FORM_URL} target="_blank" rel="noreferrer">
-          <span>피드백</span>
-        </a>
-      </div>
-      {showNotifications && (
-        <NotificationPanel
-          sessionUserName={sessionUserName}
-          notifications={notifications}
-          unreadCount={unreadNotificationCount}
-          actions={notificationActions}
-          embedded
-        />
-      )}
     </section>
   );
 }

--- a/src/components/my-page/myPagePanelTypes.ts
+++ b/src/components/my-page/myPagePanelTypes.ts
@@ -5,7 +5,6 @@ import type {
   MyPageTabKey,
   ReviewMood,
   SessionUser,
-  UserNotification,
 } from '../../types';
 
 export interface MyPagePanelProps {
@@ -24,7 +23,6 @@ export interface MyPagePanelProps {
     routeError: string | null;
     commentsHasMore: boolean;
     commentsLoadingMore: boolean;
-    unreadNotificationCount: number;
   };
   reviewActions: {
     onOpenPlace: (placeId: string) => void;
@@ -52,8 +50,5 @@ export interface MyPagePanelProps {
     onRefreshAdmin: () => Promise<void>;
     onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
     onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
-    onOpenNotification: (notification: UserNotification) => Promise<void>;
-    onMarkAllNotificationsRead: () => Promise<void>;
-    onDeleteNotification: (notificationId: string) => Promise<void>;
   };
 }

--- a/src/components/notifications/NotificationPanel.tsx
+++ b/src/components/notifications/NotificationPanel.tsx
@@ -1,6 +1,5 @@
 import { NotificationListItem } from './NotificationListItem';
-import type { NotificationItem } from './notificationTypes';
-import type { NotificationPanelActions } from './notificationTypes';
+import type { NotificationItem, NotificationPanelActions } from './notificationTypes';
 
 interface NotificationPanelProps {
   sessionUserName: string | null;
@@ -19,11 +18,11 @@ export function NotificationPanel({
 }: NotificationPanelProps) {
   const {
     busyAll,
-    busyId,
     error,
     handleDelete,
     handleMarkAll,
     handleOpenNotification,
+    busyId,
   } = actions;
 
   return (
@@ -32,7 +31,7 @@ export function NotificationPanel({
         <div>
           <p className="eyebrow">ALERT</p>
           <h3>{sessionUserName ? `${sessionUserName}님의 새 알림` : '새 알림'}</h3>
-          <p className="section-copy">탭에 있던 내용을 잃지 않고 바로 확인하고 이동할 수 있어요.</p>
+          <p className="section-copy">탭에 있던 내용을 닫지 않고 바로 확인하고 이동할 수 있어요.</p>
         </div>
         <button type="button" className="secondary-button notification-panel__mark-all" onClick={() => void handleMarkAll()} disabled={busyAll || unreadCount === 0}>
           {busyAll ? '처리 중' : '모두 읽음'}

--- a/src/components/page-stage/PageStageMyView.tsx
+++ b/src/components/page-stage/PageStageMyView.tsx
@@ -26,7 +26,6 @@ export function PageStageMyView({
         routeError: myPageData.routeError,
         commentsHasMore: myPageData.commentsHasMore,
         commentsLoadingMore: myPageData.commentsLoadingMore,
-        unreadNotificationCount: myPageData.unreadNotificationCount,
       }}
       reviewActions={{
         onOpenPlace: sharedActions.onOpenPlace,
@@ -54,9 +53,6 @@ export function PageStageMyView({
         onRefreshAdmin: myPageActions.onRefreshAdmin,
         onToggleAdminPlace: myPageActions.onToggleAdminPlace,
         onToggleAdminManualOverride: myPageActions.onToggleAdminManualOverride,
-        onOpenNotification: myPageActions.onOpenNotification,
-        onMarkAllNotificationsRead: myPageActions.onMarkAllNotificationsRead,
-        onDeleteNotification: myPageActions.onDeleteNotification,
       }}
     />
   );

--- a/src/components/page-stage/appPageStageTypes.ts
+++ b/src/components/page-stage/appPageStageTypes.ts
@@ -13,7 +13,6 @@ import type {
   RoutePreview,
   SessionUser,
   Tab,
-  UserNotification,
   UserRoute,
 } from '../../types';
 
@@ -61,7 +60,6 @@ export interface AppPageStageProps {
     adminLoading: boolean;
     commentsHasMore: boolean;
     commentsLoadingMore: boolean;
-    unreadNotificationCount: number;
   };
   sharedActions: {
     onRequestLogin: () => void;
@@ -99,8 +97,5 @@ export interface AppPageStageProps {
     onRefreshAdmin: () => Promise<void>;
     onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
     onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
-    onOpenNotification: (notification: UserNotification) => Promise<void>;
-    onMarkAllNotificationsRead: () => Promise<void>;
-    onDeleteNotification: (notificationId: string) => Promise<void>;
   };
 }

--- a/src/hooks/useAppShellStageProps.ts
+++ b/src/hooks/useAppShellStageProps.ts
@@ -19,5 +19,13 @@ export function useAppShellStageProps(state: AppShellCoordinatorState) {
     handleNavigateBack,
     handleBottomNavChange,
     globalStatus: viewModels.globalStatus,
+    globalUtility: {
+      sessionUserName: state.sessionUser?.nickname ?? null,
+      notifications: viewModels.hydratedMyPage?.notifications ?? [],
+      unreadCount: viewModels.hydratedMyPage?.unreadNotificationCount ?? 0,
+      onOpenNotification: state.handleOpenGlobalNotification,
+      onMarkAllNotificationsRead: state.handleMarkAllNotificationsRead,
+      onDeleteNotification: state.handleDeleteNotification,
+    },
   };
 }

--- a/src/hooks/usePageStageProps.ts
+++ b/src/hooks/usePageStageProps.ts
@@ -95,7 +95,6 @@ export function usePageStageProps(state: AppShellCoordinatorState) {
       adminLoading,
       commentsHasMore: myCommentsHasMore,
       commentsLoadingMore: myCommentsLoadingMore,
-      unreadNotificationCount: viewModels.hydratedMyPage?.unreadNotificationCount ?? 0,
     },
     sharedActions: {
       onRequestLogin: mapStageActions.handleRequestLogin,
@@ -133,9 +132,6 @@ export function usePageStageProps(state: AppShellCoordinatorState) {
       onRefreshAdmin: adminActions.handleRefreshAdminImport,
       onToggleAdminPlace: adminActions.handleToggleAdminPlace,
       onToggleAdminManualOverride: adminActions.handleToggleAdminManualOverride,
-      onOpenNotification: state.handleOpenGlobalNotification,
-      onMarkAllNotificationsRead: state.handleMarkAllNotificationsRead,
-      onDeleteNotification: state.handleDeleteNotification,
     },
   };
 }

--- a/src/index.css
+++ b/src/index.css
@@ -122,10 +122,11 @@ textarea {
   position: absolute;
   top: 10px;
   right: 16px;
-  z-index: 42;
+  z-index: 1200;
   display: inline-flex;
   align-items: flex-start;
   gap: 10px;
+  pointer-events: auto;
 }
 
 .phone-shell__body {
@@ -148,6 +149,41 @@ textarea {
   position: relative;
 }
 
+.global-settings-menu {
+  position: relative;
+}
+
+.global-settings-menu__trigger {
+  min-width: 48px;
+  width: 48px;
+  height: 48px;
+  border-radius: 18px;
+}
+
+.global-settings-menu__menu {
+  position: absolute;
+  top: 56px;
+  right: 0;
+  z-index: 1201;
+  display: grid;
+  gap: 10px;
+  width: min(220px, calc(100vw - 40px));
+  padding: 14px;
+  border-radius: 24px;
+  border: 1px solid rgba(255, 197, 217, 0.42);
+  background: rgba(255, 252, 249, 0.98);
+  box-shadow: 0 20px 42px rgba(66, 40, 60, 0.18);
+  backdrop-filter: blur(18px);
+}
+
+.global-settings-menu__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+  text-decoration: none;
+}
+
 .feedback-button {
   min-width: 48px;
   width: 48px;
@@ -158,8 +194,9 @@ textarea {
 
 .global-notification-panel {
   position: absolute;
-  top: 56px;
+  top: 156px;
   right: 0;
+  z-index: 1201;
   width: min(332px, calc(100vw - 40px));
   max-height: min(62vh, 520px);
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- restore the top-right gear entry and move alert/feedback under it
- keep alert ahead of feedback inside the settings menu
- raise the utility layer above map and NAVER controls

## Validation
- npm run typecheck
- npm run lint
- npm run build
- python .tmp/check_utf8_integrity.py