### PR TITLE
fix: nudge top-right settings button inward

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -120,8 +120,8 @@ textarea {
 
 .phone-shell__utility-slot {
   position: absolute;
-  top: 10px;
-  right: 16px;
+  top: 14px;
+  right: 20px;
   z-index: 1200;
   display: inline-flex;
   align-items: flex-start;


### PR DESCRIPTION
## Summary
- move the top-right settings button slightly inward from the page edge
- keep the restored global gear entry and menu behavior unchanged

## Validation
- npm run typecheck
- npm run lint
- npm run build
- python .tmp/check_utf8_integrity.py