### PR TITLE
fix: remove unused normalized repository imports

### DIFF
--- a/backend/app/repository_normalized.py
+++ b/backend/app/repository_normalized.py
@@ -2,9 +2,6 @@
 
 from __future__ import annotations
 
-from sqlalchemy.orm import Session
-
-from .models import CommentCreate, CommentOut, UserNotificationOut
 from .repositories.account_data_repository import delete_account as delete_account
 from .repositories.admin_data_repository import (
     get_admin_summary as get_admin_summary,


### PR DESCRIPTION
## Summary
- remove unused imports from repository_normalized to close the open CodeQL findings

## Validation
- py -3.14 -m pytest tests/test_repository.py
- npm run typecheck
- python .tmp/check_utf8_integrity.py