### PR TITLE
Refactor render prop stability

### DIFF
--- a/src/components/CourseTab.tsx
+++ b/src/components/CourseTab.tsx
@@ -1,10 +1,11 @@
+import { memo } from 'react';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { CommunityRouteCard } from './course/CommunityRouteCard';
 import { CourseTabHeader } from './course/CourseTabHeader';
 import type { CourseTabProps } from './course/courseTabTypes';
 import { useHighlightedCourseRoute } from './course/useHighlightedCourseRoute';
 
-export function CourseTab({
+export const CourseTab = memo(function CourseTab({
   courses,
   communityRoutes,
   sort,
@@ -63,4 +64,4 @@ export function CourseTab({
       </section>
     </section>
   );
-}
+});

--- a/src/components/FeedTab.tsx
+++ b/src/components/FeedTab.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { memo, useMemo } from 'react';
 import { useAutoLoadMore } from '../hooks/useAutoLoadMore';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import { FeedLoadMoreRow } from './feed/FeedLoadMoreRow';
@@ -46,7 +46,7 @@ interface FeedTabProps {
   };
 }
 
-export function FeedTab({
+export const FeedTab = memo(function FeedTab({
   feedData,
   commentSheetData,
   sharedData,
@@ -115,7 +115,6 @@ export function FeedTab({
           onSubmitComment={onCreateComment}
           onUpdateComment={onUpdateComment}
           onDeleteComment={onDeleteComment}
-          onDeleteReview={onDeleteReview}
           onRequestLogin={onRequestLogin}
           onOpenPlace={onOpenPlace}
           onOpenComments={onOpenComments}
@@ -144,4 +143,4 @@ export function FeedTab({
       />
     </>
   );
-}
+});

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -1,4 +1,4 @@
-import { useRef } from 'react';
+import { memo, useRef } from 'react';
 import type { Review } from '../types';
 import { ReviewListEmptyState } from './review/ReviewListEmptyState';
 import { ReviewListItem } from './review/ReviewListItem';
@@ -16,7 +16,6 @@ interface ReviewListProps {
   onSubmitComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
   onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
   onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
-  onDeleteReview?: (reviewId: string) => Promise<void>;
   onRequestLogin: () => void;
   onOpenPlace?: (placeId: string) => void;
   onOpenComments?: (reviewId: string) => void;
@@ -24,7 +23,7 @@ interface ReviewListProps {
   emptyBody: string;
 }
 
-export function ReviewList({
+export const ReviewList = memo(function ReviewList({
   reviews,
   canWriteComment,
   canToggleLike,
@@ -36,7 +35,6 @@ export function ReviewList({
   onSubmitComment,
   onUpdateComment,
   onDeleteComment,
-  onDeleteReview: _onDeleteReview,
   onRequestLogin,
   onOpenPlace,
   onOpenComments,
@@ -73,4 +71,4 @@ export function ReviewList({
       ))}
     </div>
   );
-}
+});

--- a/src/components/course/CommunityRouteCard.tsx
+++ b/src/components/course/CommunityRouteCard.tsx
@@ -1,4 +1,4 @@
-import type { MutableRefObject } from 'react';
+import { memo, type MutableRefObject } from 'react';
 import type { SessionUser, UserRoute } from '../../types';
 import { HeartIcon } from '../review/ReviewActionIcons';
 import type { RoutePreviewPayload } from './courseTabTypes';
@@ -16,7 +16,7 @@ interface CommunityRouteCardProps {
   onRequestLogin: () => void;
 }
 
-export function CommunityRouteCard({
+export const CommunityRouteCard = memo(function CommunityRouteCard({
   route,
   highlightedRouteId,
   routeLikeUpdatingId,
@@ -80,4 +80,4 @@ export function CommunityRouteCard({
       </div>
     </article>
   );
-}
+});

--- a/src/components/page-stage/PageStageFeedView.tsx
+++ b/src/components/page-stage/PageStageFeedView.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { FeedTab } from '../FeedTab';
 import type { AppPageStageProps } from './appPageStageTypes';
 
@@ -9,44 +10,82 @@ export function PageStageFeedView({
   sharedActions,
   feedActions,
 }: PageStageFeedViewProps) {
+  const placeFilterName = feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null;
+
+  const feedTabData = useMemo(() => ({
+    reviews: feedData.reviews,
+    placeFilterId: feedData.feedPlaceFilterId,
+    placeFilterName,
+    highlightedReviewId: feedData.highlightedReviewId,
+    reviewLikeUpdatingId: feedData.reviewLikeUpdatingId,
+    hasMore: feedData.feedHasMore && !feedData.feedPlaceFilterId,
+    loadingMore: feedData.feedLoadingMore,
+  }), [
+    feedData.feedHasMore,
+    feedData.feedLoadingMore,
+    feedData.feedPlaceFilterId,
+    feedData.highlightedReviewId,
+    feedData.reviewLikeUpdatingId,
+    feedData.reviews,
+    placeFilterName,
+  ]);
+
+  const commentSheetData = useMemo(() => ({
+    activeCommentReviewId: feedData.activeCommentReviewId,
+    activeCommentReviewComments: feedData.activeCommentReviewComments,
+    activeCommentReviewStatus: feedData.activeCommentReviewStatus,
+    highlightedCommentId: feedData.highlightedCommentId,
+    commentSubmittingReviewId: feedData.commentSubmittingReviewId,
+    commentMutatingId: feedData.commentMutatingId,
+    deletingReviewId: feedData.deletingReviewId,
+  }), [
+    feedData.activeCommentReviewComments,
+    feedData.activeCommentReviewId,
+    feedData.activeCommentReviewStatus,
+    feedData.commentMutatingId,
+    feedData.commentSubmittingReviewId,
+    feedData.deletingReviewId,
+    feedData.highlightedCommentId,
+  ]);
+
+  const sharedFeedData = useMemo(() => ({
+    sessionUser: sharedData.sessionUser,
+  }), [sharedData.sessionUser]);
+
+  const feedTabActions = useMemo(() => ({
+    onLoadMore: feedActions.onLoadMoreFeed,
+    onToggleReviewLike: feedActions.onToggleReviewLike,
+    onCreateComment: feedActions.onCreateComment,
+    onUpdateComment: feedActions.onUpdateComment,
+    onDeleteComment: feedActions.onDeleteComment,
+    onDeleteReview: feedActions.onDeleteReview,
+    onClearPlaceFilter: feedActions.onClearPlaceFilter,
+    onOpenComments: feedActions.onOpenComments,
+    onCloseComments: feedActions.onCloseComments,
+  }), [
+    feedActions.onClearPlaceFilter,
+    feedActions.onCloseComments,
+    feedActions.onCreateComment,
+    feedActions.onDeleteComment,
+    feedActions.onDeleteReview,
+    feedActions.onLoadMoreFeed,
+    feedActions.onOpenComments,
+    feedActions.onToggleReviewLike,
+    feedActions.onUpdateComment,
+  ]);
+
+  const sharedFeedActions = useMemo(() => ({
+    onRequestLogin: sharedActions.onRequestLogin,
+    onOpenPlace: sharedActions.onOpenPlace,
+  }), [sharedActions.onOpenPlace, sharedActions.onRequestLogin]);
+
   return (
     <FeedTab
-      feedData={{
-        reviews: feedData.reviews,
-        placeFilterId: feedData.feedPlaceFilterId,
-        placeFilterName: feedData.feedPlaceFilterId ? sharedData.placeNameById[feedData.feedPlaceFilterId] ?? null : null,
-        highlightedReviewId: feedData.highlightedReviewId,
-        reviewLikeUpdatingId: feedData.reviewLikeUpdatingId,
-        hasMore: feedData.feedHasMore && !feedData.feedPlaceFilterId,
-        loadingMore: feedData.feedLoadingMore,
-      }}
-      commentSheetData={{
-        activeCommentReviewId: feedData.activeCommentReviewId,
-        activeCommentReviewComments: feedData.activeCommentReviewComments,
-        activeCommentReviewStatus: feedData.activeCommentReviewStatus,
-        highlightedCommentId: feedData.highlightedCommentId,
-        commentSubmittingReviewId: feedData.commentSubmittingReviewId,
-        commentMutatingId: feedData.commentMutatingId,
-        deletingReviewId: feedData.deletingReviewId,
-      }}
-      sharedData={{
-        sessionUser: sharedData.sessionUser,
-      }}
-      feedActions={{
-        onLoadMore: feedActions.onLoadMoreFeed,
-        onToggleReviewLike: feedActions.onToggleReviewLike,
-        onCreateComment: feedActions.onCreateComment,
-        onUpdateComment: feedActions.onUpdateComment,
-        onDeleteComment: feedActions.onDeleteComment,
-        onDeleteReview: feedActions.onDeleteReview,
-        onClearPlaceFilter: feedActions.onClearPlaceFilter,
-        onOpenComments: feedActions.onOpenComments,
-        onCloseComments: feedActions.onCloseComments,
-      }}
-      sharedActions={{
-        onRequestLogin: sharedActions.onRequestLogin,
-        onOpenPlace: sharedActions.onOpenPlace,
-      }}
+      feedData={feedTabData}
+      commentSheetData={commentSheetData}
+      sharedData={sharedFeedData}
+      feedActions={feedTabActions}
+      sharedActions={sharedFeedActions}
     />
   );
 }

--- a/src/hooks/useAppRouteActions.ts
+++ b/src/hooks/useAppRouteActions.ts
@@ -3,6 +3,7 @@ import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../types';
 import { createPublishRouteHandler } from './app-route-actions/publishRouteAction';
 import { createToggleRouteLikeHandler } from './app-route-actions/routeLikeAction';
 import { useAppRouteActionStoreBindings } from './useAppRouteActionStoreBindings';
+import { useEventCallback } from './useEventCallback';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
@@ -27,7 +28,7 @@ export function useAppRouteActions({
 }: UseAppRouteActionsParams) {
   const bindings = useAppRouteActionStoreBindings();
 
-  const handleToggleRouteLike = createToggleRouteLikeHandler({
+  const handleToggleRouteLike = useEventCallback(createToggleRouteLikeHandler({
     sessionUser: bindings.sessionUser,
     setNotice: bindings.setNotice,
     setRouteLikeUpdatingId: bindings.setRouteLikeUpdatingId,
@@ -35,9 +36,9 @@ export function useAppRouteActions({
     patchCommunityRoutes,
     formatErrorMessage,
     goToTab,
-  });
+  }));
 
-  const handlePublishRoute = createPublishRouteHandler({
+  const handlePublishRoute = useEventCallback(createPublishRouteHandler({
     sessionUser: bindings.sessionUser,
     setRouteSubmitting: bindings.setRouteSubmitting,
     setRouteError: bindings.setRouteError,
@@ -48,7 +49,7 @@ export function useAppRouteActions({
     refreshMyPageForUser,
     formatErrorMessage,
     goToTab,
-  });
+  }));
 
   return {
     handleToggleRouteLike,

--- a/test/unit/render-prop-stability.test.tsx
+++ b/test/unit/render-prop-stability.test.tsx
@@ -1,0 +1,132 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useRef, useState } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CommunityRouteCard } from '../../src/components/course/CommunityRouteCard';
+import type { UserRoute } from '../../src/types';
+import { createReviewFixture, placeFixture, routeFixture, sessionUserFixture } from '../fixtures/app-fixtures';
+
+const feedTabMock = vi.hoisted(() => ({
+  renderCount: 0,
+}));
+
+vi.mock('../../src/components/FeedTab', async () => {
+  const React = await import('react');
+
+  return {
+    FeedTab: React.memo(function MockFeedTab() {
+      feedTabMock.renderCount += 1;
+      return React.createElement('div', { 'data-testid': 'feed-tab' });
+    }),
+  };
+});
+
+describe('render prop stability', () => {
+  beforeEach(() => {
+    feedTabMock.renderCount = 0;
+  });
+
+  it('keeps FeedTab skipped when PageStageFeedView receives an unrelated parent render', async () => {
+    const { PageStageFeedView } = await import('../../src/components/page-stage/PageStageFeedView');
+    const review = createReviewFixture();
+    const props: Parameters<typeof PageStageFeedView>[0] = {
+      sharedData: {
+        sessionUser: sessionUserFixture,
+        placeNameById: { [placeFixture.id]: placeFixture.name },
+        festivals: [],
+      },
+      feedData: {
+        reviews: [review],
+        reviewLikeUpdatingId: null,
+        feedPlaceFilterId: null,
+        commentSubmittingReviewId: null,
+        commentMutatingId: null,
+        deletingReviewId: null,
+        activeCommentReviewId: null,
+        activeCommentReviewComments: [],
+        activeCommentReviewStatus: 'idle',
+        highlightedCommentId: null,
+        highlightedReviewId: null,
+        feedHasMore: false,
+        feedLoadingMore: false,
+      },
+      sharedActions: {
+        onRequestLogin: vi.fn(),
+        onOpenPlace: vi.fn(),
+      },
+      feedActions: {
+        onLoadMoreFeed: vi.fn().mockResolvedValue(undefined),
+        onToggleReviewLike: vi.fn().mockResolvedValue(undefined),
+        onCreateComment: vi.fn().mockResolvedValue(undefined),
+        onUpdateComment: vi.fn().mockResolvedValue(undefined),
+        onDeleteComment: vi.fn().mockResolvedValue(undefined),
+        onDeleteReview: vi.fn().mockResolvedValue(undefined),
+        onClearPlaceFilter: vi.fn(),
+        onOpenComments: vi.fn(),
+        onCloseComments: vi.fn(),
+      },
+    };
+
+    function Harness() {
+      const [tick, setTick] = useState(0);
+
+      return (
+        <>
+          <button type="button" onClick={() => setTick((value) => value + 1)}>
+            rerender parent {tick}
+          </button>
+          <PageStageFeedView {...props} />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(feedTabMock.renderCount).toBe(1);
+
+    fireEvent.click(screen.getByRole('button', { name: /rerender parent/ }));
+
+    expect(feedTabMock.renderCount).toBe(1);
+  });
+
+  it('keeps a stable community route card skipped during unrelated parent renders', () => {
+    let routeIdReadCount = 0;
+    const route: UserRoute = {
+      ...routeFixture,
+      get id() {
+        routeIdReadCount += 1;
+        return routeFixture.id;
+      },
+    };
+    const cardProps = {
+      highlightedRouteId: null,
+      routeLikeUpdatingId: null,
+      sessionUser: sessionUserFixture,
+      placeNameById: { [placeFixture.id]: placeFixture.name },
+      onToggleLike: vi.fn().mockResolvedValue(undefined),
+      onOpenPlace: vi.fn(),
+      onOpenRoutePreview: vi.fn(),
+      onRequestLogin: vi.fn(),
+    };
+
+    function Harness() {
+      const [tick, setTick] = useState(0);
+      const routeRefs = useRef<Record<string, HTMLElement | null>>({});
+
+      return (
+        <>
+          <button type="button" onClick={() => setTick((value) => value + 1)}>
+            rerender route parent {tick}
+          </button>
+          <CommunityRouteCard {...cardProps} route={route} routeRefs={routeRefs} />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    expect(routeIdReadCount).toBeGreaterThan(0);
+    const routeIdReadsAfterMount = routeIdReadCount;
+
+    fireEvent.click(screen.getByRole('button', { name: /rerender route parent/ }));
+
+    expect(routeIdReadCount).toBe(routeIdReadsAfterMount);
+  });
+});


### PR DESCRIPTION
## Summary
- Supersedes #211; the broad memo-only approach was closed because stable prop evidence was missing.
- Stabilizes PageStageFeedView -> FeedTab object props, then memoizes the verified FeedTab and ReviewList boundaries.
- Stabilizes route action callbacks with useEventCallback, then memoizes the verified CourseTab and CommunityRouteCard boundaries.
- Adds render-prop stability tests that prove unrelated parent renders are skipped.

## Render-skip evidence
- Feed: an unrelated PageStageFeedView parent state change does not re-render FeedTab when feed/comment/shared/action fields are unchanged.
- Course: a stable CommunityRouteCard does not re-read route props during an unrelated parent state change.
- .jules/bolt.md is not included.
- User-facing copy, API shape, and DB schema are unchanged.

## Tests
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run build