### PR TITLE
⚡ Bolt: Prevent O(N) re-renders in ReviewList

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Conditional Props for List Memoization
+**Learning:** For flat mapped lists like `ReviewList`, passing globally active IDs (like `highlightedReviewId`) to all items breaks `React.memo` for the inactive $N-1$ items when the active item changes, causing O(N) re-renders.
+**Action:** Conditionally pass active IDs (e.g., `id === review.id ? id : null`) to the child component. This keeps props referentially stable for inactive items, reducing re-renders to O(1). Do not use this for nested recursive components.

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -55,11 +55,16 @@ export const ReviewList = memo(function ReviewList({
           key={review.id}
           review={review}
           currentUserId={currentUserId}
-          highlightedReviewId={highlightedReviewId}
+          // Performance Optimization: Prevent O(N) re-renders
+          // Conditionally pass active IDs (highlightedReviewId, likingReviewId, submittingReviewId)
+          // only to the specific list item that needs them, passing null to the rest.
+          // This keeps the props referentially stable for inactive items, allowing React.memo
+          // to skip re-rendering them when one active ID changes.
+          highlightedReviewId={highlightedReviewId === review.id ? highlightedReviewId : null}
           canWriteComment={canWriteComment}
           canToggleLike={canToggleLike}
-          likingReviewId={likingReviewId}
-          submittingReviewId={submittingReviewId}
+          likingReviewId={likingReviewId === review.id ? likingReviewId : null}
+          submittingReviewId={submittingReviewId === review.id ? submittingReviewId : null}
           onToggleLike={onToggleLike}
           onSubmitComment={onSubmitComment}
           onUpdateComment={onUpdateComment}


### PR DESCRIPTION
💡 **What:** Modified `ReviewList.tsx` to conditionally pass active IDs (`highlightedReviewId`, `likingReviewId`, `submittingReviewId`) only to the matching `ReviewListItem`.
🎯 **Why:** Previously, passing the active ID directly meant every item received a new prop value when the ID changed, breaking `React.memo` and causing all N items to re-render.
📊 **Impact:** Reduces an O(N) re-render bottleneck down to O(1). When an item is liked or highlighted, only the newly active and previously active items will re-render, keeping the list extremely fast even with many reviews.
🔬 **Measurement:** Verified that the test suite passes with `npm run test:all`. You can verify by opening the app, expanding a list of reviews, clicking the "Like" button, and observing through React DevTools Profiler that only the interacted list item re-renders.

---
*PR created automatically by Jules for task [9610535589677158486](https://jules.google.com/task/9610535589677158486) started by @ClarusIubar*