### PR TITLE
⚡ Bolt: [performance improvement] ReviewList Memoization

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-07 - Conditional Prop Passing for Flat List Memoization
+**Learning:** When using `React.memo` on items in a mapped flat list component (like `ReviewListItem` in `ReviewList`), passing global active IDs (e.g., `highlightedReviewId`, `likingReviewId`) directly to all items causes an O(N) re-render whenever the active ID changes, defeating the purpose of memoization.
+**Action:** Use a conditional prop pattern (`activeId === item.id ? activeId : null`) when mapping the list. This ensures that only the item becoming active and the item becoming inactive receive new props and re-render, reducing render complexity to O(1). Note: Apply this only to flat lists; it breaks nested structures because descendants get cut off from receiving the target ID.

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -55,11 +55,11 @@ export const ReviewList = memo(function ReviewList({
           key={review.id}
           review={review}
           currentUserId={currentUserId}
-          highlightedReviewId={highlightedReviewId}
+          highlightedReviewId={highlightedReviewId === review.id ? highlightedReviewId : null}
           canWriteComment={canWriteComment}
           canToggleLike={canToggleLike}
-          likingReviewId={likingReviewId}
-          submittingReviewId={submittingReviewId}
+          likingReviewId={likingReviewId === review.id ? likingReviewId : null}
+          submittingReviewId={submittingReviewId === review.id ? submittingReviewId : null}
           onToggleLike={onToggleLike}
           onSubmitComment={onSubmitComment}
           onUpdateComment={onUpdateComment}


### PR DESCRIPTION
💡 What: Added conditional prop passing (`activeId === item.id ? activeId : null`) for `highlightedReviewId`, `likingReviewId`, and `submittingReviewId` in the `ReviewList` map function. Also documented this pattern in `.jules/bolt.md`.
🎯 Why: In long feed lists, updating a global active state (like liking a review) previously caused every single `ReviewListItem` to receive new props, defeating `React.memo` and causing an O(N) re-render.
📊 Impact: Reduces render complexity from O(N) to O(1) during active state changes for flat lists.
🔬 Measurement: Verified via `npm run test:all` that existing behavior remains intact. Performance can be measured using React DevTools Profiler by toggling a like on a long feed list; only the specific item will now flash as re-rendered.

---
*PR created automatically by Jules for task [6058308005884588916](https://jules.google.com/task/6058308005884588916) started by @ClarusIubar*