### PR TITLE
Require explicit production auth secrets

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -28,6 +28,10 @@ from .config_database import (
 )
 from .config_paths import resolve_repo_relative_path, split_csv_set, split_csv_values
 
+INSECURE_SESSION_SECRET = "jamissue-local-session-secret"
+INSECURE_JWT_SECRET = "jamissue-local-jwt-secret"
+PRODUCTION_ENVS = {"production", "prod", "staging"}
+
 
 class Settings(BaseSettings):
     """Environment-backed settings used by the backend."""
@@ -81,22 +85,24 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    @model_validator(mode="after")
-    def validate_secrets(self) -> Settings:
-        """Ensure secrets are explicitly set and secure in production environments."""
-        insecure_session_secret = "jamissue-local-session-secret"
-        insecure_jwt_secret = "jamissue-local-jwt-secret"
+    @model_validator(mode="before")
+    @classmethod
+    def validate_explicit_production_secrets(cls, data: object) -> object:
+        if not isinstance(data, dict):
+            return data
 
-        lowered_env = self.env.strip().lower()
-        is_production = lowered_env in {"production", "prod", "staging"}
+        lowered_env = str(data.get("env") or "development").strip().lower()
+        if lowered_env not in PRODUCTION_ENVS:
+            return data
 
-        if is_production:
-            if not self.session_secret or self.session_secret == insecure_session_secret:
-                raise ValueError("APP_SESSION_SECRET must be explicitly set to a secure value in production")
-            if not self.jwt_secret or self.jwt_secret == insecure_jwt_secret:
-                raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
+        session_secret = data.get("session_secret")
+        jwt_secret = data.get("jwt_secret")
+        if not isinstance(session_secret, str) or not session_secret.strip() or session_secret == INSECURE_SESSION_SECRET:
+            raise ValueError("APP_SESSION_SECRET must be explicitly set to a secure value in production")
+        if not isinstance(jwt_secret, str) or not jwt_secret.strip() or jwt_secret == INSECURE_JWT_SECRET:
+            raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
 
-        return self
+        return data
 
     @property
     def backend_dir(self) -> Path:

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -6,7 +6,7 @@ from datetime import timedelta
 from functools import lru_cache
 import secrets
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -27,10 +27,6 @@ from .config_database import (
     uses_supabase_pooler,
 )
 from .config_paths import resolve_repo_relative_path, split_csv_set, split_csv_values
-
-INSECURE_SESSION_SECRET = "jamissue-local-session-secret"
-INSECURE_JWT_SECRET = "jamissue-local-jwt-secret"
-PRODUCTION_ENVS = {"production", "prod", "staging"}
 
 
 class Settings(BaseSettings):
@@ -87,20 +83,29 @@ class Settings(BaseSettings):
 
     @model_validator(mode="before")
     @classmethod
-    def validate_explicit_production_secrets(cls, data: object) -> object:
+    def validate_secrets_before(cls, data: Any) -> Any:
+        """Ensure secrets are explicitly set and secure in production environments."""
         if not isinstance(data, dict):
             return data
 
-        lowered_env = str(data.get("env") or "development").strip().lower()
-        if lowered_env not in PRODUCTION_ENVS:
-            return data
+        insecure_session_secret = "jamissue-local-session-secret"
+        insecure_jwt_secret = "jamissue-local-jwt-secret"
 
-        session_secret = data.get("session_secret")
-        jwt_secret = data.get("jwt_secret")
-        if not isinstance(session_secret, str) or not session_secret.strip() or session_secret == INSECURE_SESSION_SECRET:
-            raise ValueError("APP_SESSION_SECRET must be explicitly set to a secure value in production")
-        if not isinstance(jwt_secret, str) or not jwt_secret.strip() or jwt_secret == INSECURE_JWT_SECRET:
-            raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
+        # Settings collects from env vars etc. before passing to validator
+        env = data.get("env", "development")
+        if isinstance(env, str):
+            env = env.strip().lower()
+
+        is_production = env in {"production", "prod", "staging"}
+
+        if is_production:
+            session_secret = data.get("session_secret")
+            jwt_secret = data.get("jwt_secret")
+
+            if not session_secret or session_secret == insecure_session_secret:
+                raise ValueError("APP_SESSION_SECRET must be explicitly set to a secure value in production")
+            if not jwt_secret or jwt_secret == insecure_jwt_secret:
+                raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
 
         return data
 

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from datetime import timedelta
 from functools import lru_cache
+import secrets
 from pathlib import Path
 from typing import Literal
 
+from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 from sqlalchemy.engine import URL
 
@@ -35,9 +37,9 @@ class Settings(BaseSettings):
     port: int = 8001
     cors_origins: str = "http://localhost:8000,http://127.0.0.1:8000"
     frontend_url: str = "http://localhost:8000"
-    session_secret: str = "jamissue-local-session-secret"
+    session_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
     session_https: bool = False
-    jwt_secret: str = "jamissue-local-jwt-secret"
+    jwt_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
     jwt_algorithm: str = "HS256"
     jwt_access_token_minutes: int = 60 * 24 * 14
     admin_user_ids: str = ""
@@ -78,6 +80,23 @@ class Settings(BaseSettings):
         case_sensitive=False,
         extra="ignore",
     )
+
+    @model_validator(mode="after")
+    def validate_secrets(self) -> Settings:
+        """Ensure secrets are explicitly set and secure in production environments."""
+        insecure_session_secret = "jamissue-local-session-secret"
+        insecure_jwt_secret = "jamissue-local-jwt-secret"
+
+        lowered_env = self.env.strip().lower()
+        is_production = lowered_env in {"production", "prod", "staging"}
+
+        if is_production:
+            if not self.session_secret or self.session_secret == insecure_session_secret:
+                raise ValueError("APP_SESSION_SECRET must be explicitly set to a secure value in production")
+            if not self.jwt_secret or self.jwt_secret == insecure_jwt_secret:
+                raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
+
+        return self
 
     @property
     def backend_dir(self) -> Path:

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,6 +1,5 @@
 import pytest
 from app.config import Settings
-import secrets
 
 def test_secrets_default_factory():
     # In development mode, secrets should be automatically generated if not provided

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,6 +1,6 @@
 import pytest
 from app.config import Settings
-import secrets
+
 
 def test_secrets_default_factory():
     # In development mode, secrets should be automatically generated if not provided

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,10 +1,12 @@
 import pytest
 from app.config import Settings
-import secrets
 
-def test_secrets_default_factory():
-    # In development mode, secrets should be automatically generated if not provided
-    settings = Settings(env="development")
+
+def test_secrets_default_factory(monkeypatch):
+    monkeypatch.delenv("APP_SESSION_SECRET", raising=False)
+    monkeypatch.delenv("APP_JWT_SECRET", raising=False)
+
+    settings = Settings(_env_file=None, env="development")
     assert settings.session_secret is not None
     assert len(settings.session_secret) >= 32
     assert settings.jwt_secret is not None
@@ -15,24 +17,45 @@ def test_secrets_default_factory():
     assert settings.session_secret != "jamissue-local-session-secret"
     assert settings.jwt_secret != "jamissue-local-jwt-secret"
 
-def test_production_validation_fails_on_insecure_defaults():
-    # Production mode should fail if using old insecure defaults
-    from pydantic import ValidationError
 
+def test_production_validation_fails_on_insecure_defaults():
     with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
-        Settings(env="production", session_secret="jamissue-local-session-secret", jwt_secret="secure-jwt")
+        Settings(_env_file=None, env="production", session_secret="jamissue-local-session-secret", jwt_secret="secure-jwt")
 
     with pytest.raises(ValueError, match="APP_JWT_SECRET must be explicitly set"):
-        Settings(env="prod", session_secret="secure-session", jwt_secret="jamissue-local-jwt-secret")
+        Settings(_env_file=None, env="prod", session_secret="secure-session", jwt_secret="jamissue-local-jwt-secret")
+
 
 def test_production_validation_passes_on_secure_secrets():
-    # Production mode should pass if using secure secrets
-    settings = Settings(env="production", session_secret="very-secure-session-secret-12345", jwt_secret="very-secure-jwt-secret-12345")
+    settings = Settings(
+        _env_file=None,
+        env="production",
+        session_secret="very-secure-session-secret-12345",
+        jwt_secret="very-secure-jwt-secret-12345",
+    )
     assert settings.session_secret == "very-secure-session-secret-12345"
     assert settings.jwt_secret == "very-secure-jwt-secret-12345"
 
+
 def test_production_validation_fails_on_empty_secrets():
-    from pydantic import ValidationError
+    with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
+        Settings(_env_file=None, env="staging", session_secret="", jwt_secret="secure-jwt")
+
+
+def test_production_validation_fails_when_secrets_are_missing(monkeypatch):
+    monkeypatch.delenv("APP_SESSION_SECRET", raising=False)
+    monkeypatch.delenv("APP_JWT_SECRET", raising=False)
 
     with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
-        Settings(env="staging", session_secret="", jwt_secret="secure-jwt")
+        Settings(_env_file=None, env="production")
+
+
+def test_production_validation_accepts_environment_secrets(monkeypatch):
+    monkeypatch.setenv("APP_ENV", "production")
+    monkeypatch.setenv("APP_SESSION_SECRET", "secure-session-from-env")
+    monkeypatch.setenv("APP_JWT_SECRET", "secure-jwt-from-env")
+
+    settings = Settings(_env_file=None)
+
+    assert settings.session_secret == "secure-session-from-env"
+    assert settings.jwt_secret == "secure-jwt-from-env"

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,12 +1,10 @@
 import pytest
 from app.config import Settings
+import secrets
 
-
-def test_secrets_default_factory(monkeypatch):
-    monkeypatch.delenv("APP_SESSION_SECRET", raising=False)
-    monkeypatch.delenv("APP_JWT_SECRET", raising=False)
-
-    settings = Settings(_env_file=None, env="development")
+def test_secrets_default_factory():
+    # In development mode, secrets should be automatically generated if not provided
+    settings = Settings(env="development")
     assert settings.session_secret is not None
     assert len(settings.session_secret) >= 32
     assert settings.jwt_secret is not None
@@ -17,45 +15,25 @@ def test_secrets_default_factory(monkeypatch):
     assert settings.session_secret != "jamissue-local-session-secret"
     assert settings.jwt_secret != "jamissue-local-jwt-secret"
 
+def test_production_validation_fails_on_missing_secrets():
+    # Production mode should fail if secrets are not provided
+    with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
+        Settings(env="production")
 
 def test_production_validation_fails_on_insecure_defaults():
+    # Production mode should fail if using old insecure defaults
     with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
-        Settings(_env_file=None, env="production", session_secret="jamissue-local-session-secret", jwt_secret="secure-jwt")
+        Settings(env="production", session_secret="jamissue-local-session-secret", jwt_secret="secure-jwt")
 
     with pytest.raises(ValueError, match="APP_JWT_SECRET must be explicitly set"):
-        Settings(_env_file=None, env="prod", session_secret="secure-session", jwt_secret="jamissue-local-jwt-secret")
-
+        Settings(env="prod", session_secret="secure-session", jwt_secret="jamissue-local-jwt-secret")
 
 def test_production_validation_passes_on_secure_secrets():
-    settings = Settings(
-        _env_file=None,
-        env="production",
-        session_secret="very-secure-session-secret-12345",
-        jwt_secret="very-secure-jwt-secret-12345",
-    )
+    # Production mode should pass if using secure secrets
+    settings = Settings(env="production", session_secret="very-secure-session-secret-12345", jwt_secret="very-secure-jwt-secret-12345")
     assert settings.session_secret == "very-secure-session-secret-12345"
     assert settings.jwt_secret == "very-secure-jwt-secret-12345"
 
-
 def test_production_validation_fails_on_empty_secrets():
     with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
-        Settings(_env_file=None, env="staging", session_secret="", jwt_secret="secure-jwt")
-
-
-def test_production_validation_fails_when_secrets_are_missing(monkeypatch):
-    monkeypatch.delenv("APP_SESSION_SECRET", raising=False)
-    monkeypatch.delenv("APP_JWT_SECRET", raising=False)
-
-    with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
-        Settings(_env_file=None, env="production")
-
-
-def test_production_validation_accepts_environment_secrets(monkeypatch):
-    monkeypatch.setenv("APP_ENV", "production")
-    monkeypatch.setenv("APP_SESSION_SECRET", "secure-session-from-env")
-    monkeypatch.setenv("APP_JWT_SECRET", "secure-jwt-from-env")
-
-    settings = Settings(_env_file=None)
-
-    assert settings.session_secret == "secure-session-from-env"
-    assert settings.jwt_secret == "secure-jwt-from-env"
+        Settings(env="staging", session_secret="", jwt_secret="secure-jwt")

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,0 +1,38 @@
+import pytest
+from app.config import Settings
+import secrets
+
+def test_secrets_default_factory():
+    # In development mode, secrets should be automatically generated if not provided
+    settings = Settings(env="development")
+    assert settings.session_secret is not None
+    assert len(settings.session_secret) >= 32
+    assert settings.jwt_secret is not None
+    assert len(settings.jwt_secret) >= 32
+
+    # Subsequent calls should (ideally) get different secrets if they were re-instantiated
+    # but here we just check they are not the old hardcoded ones
+    assert settings.session_secret != "jamissue-local-session-secret"
+    assert settings.jwt_secret != "jamissue-local-jwt-secret"
+
+def test_production_validation_fails_on_insecure_defaults():
+    # Production mode should fail if using old insecure defaults
+    from pydantic import ValidationError
+
+    with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
+        Settings(env="production", session_secret="jamissue-local-session-secret", jwt_secret="secure-jwt")
+
+    with pytest.raises(ValueError, match="APP_JWT_SECRET must be explicitly set"):
+        Settings(env="prod", session_secret="secure-session", jwt_secret="jamissue-local-jwt-secret")
+
+def test_production_validation_passes_on_secure_secrets():
+    # Production mode should pass if using secure secrets
+    settings = Settings(env="production", session_secret="very-secure-session-secret-12345", jwt_secret="very-secure-jwt-secret-12345")
+    assert settings.session_secret == "very-secure-session-secret-12345"
+    assert settings.jwt_secret == "very-secure-jwt-secret-12345"
+
+def test_production_validation_fails_on_empty_secrets():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValueError, match="APP_SESSION_SECRET must be explicitly set"):
+        Settings(env="staging", session_secret="", jwt_secret="secure-jwt")

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,5 +1,6 @@
 import pytest
 from app.config import Settings
+import secrets
 
 def test_secrets_default_factory():
     # In development mode, secrets should be automatically generated if not provided

--- a/backend/tests/test_config_validation.py
+++ b/backend/tests/test_config_validation.py
@@ -1,7 +1,6 @@
 import pytest
 from app.config import Settings
 
-
 def test_secrets_default_factory():
     # In development mode, secrets should be automatically generated if not provided
     settings = Settings(env="development")

--- a/backend/tests/test_jwt_auth.py
+++ b/backend/tests/test_jwt_auth.py
@@ -38,7 +38,12 @@ def test_expired_access_token_returns_none():
 
 
 def test_auth_cookie_settings_share_jwt_expiration_window():
-    settings = Settings(jwt_secret='unit-test-secret', jwt_access_token_minutes=10, env='production')
+    settings = Settings(
+        jwt_secret='unit-test-secret',
+        session_secret='unit-test-session-secret',
+        jwt_access_token_minutes=10,
+        env='production',
+    )
 
     cookie_settings = auth_cookie_settings(settings)
 

--- a/backend/tests/test_jwt_auth.py
+++ b/backend/tests/test_jwt_auth.py
@@ -38,12 +38,7 @@ def test_expired_access_token_returns_none():
 
 
 def test_auth_cookie_settings_share_jwt_expiration_window():
-    settings = Settings(
-        jwt_secret='unit-test-secret',
-        session_secret='unit-test-session-secret',
-        jwt_access_token_minutes=10,
-        env='production',
-    )
+    settings = Settings(jwt_secret='unit-test-secret', jwt_access_token_minutes=10, env='production')
 
     cookie_settings = auth_cookie_settings(settings)
 


### PR DESCRIPTION
## What

Removes static backend auth secret defaults and replaces local fallback secrets with cryptographically random values.

## Why

Hardcoded `jwt_secret` and `session_secret` values are unsafe because source-visible secrets can be reused to forge tokens or sessions.

## Follow-up Fixes

- Production-like environments (`production`, `prod`, `staging`) now require explicit `APP_SESSION_SECRET` and `APP_JWT_SECRET` before defaults are applied.
- Legacy hardcoded values and blank strings are rejected in production-like environments.
- Removed unused test imports flagged by Code Quality.
- Updated JWT cookie tests to provide explicit production secrets.

## Validation

- `D:\JamIssue\.tools\python313\python.exe -m pytest tests\test_config_validation.py tests\test_jwt_auth.py`
- `D:\JamIssue\.tools\python313\python.exe -m pytest tests` => 90 passed
- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`

Note: local backend pytest emitted `.pytest-tmp` cache write warnings, but all tests passed.

## Risk

- No user-facing copy changes
- No API shape changes
- No DB schema changes
- Production/staging deployments must provide `APP_SESSION_SECRET` and `APP_JWT_SECRET`