### PR TITLE
🧪 [Add unit tests for filterPlacesByCategory]

### DIFF
--- a/test/unit/filterPlaces.test.ts
+++ b/test/unit/filterPlaces.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { filterPlacesByCategory } from '../../src/lib/filterPlaces';
+import { filterPlacesByCategory } from '../../src/hooks/app-view-models/placeSelections';
 import type { Place } from '../../src/types';
 import { placeFixture } from '../fixtures/app-fixtures';
 

--- a/test/unit/filterPlaces.test.ts
+++ b/test/unit/filterPlaces.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { filterPlacesByCategory } from '../../src/lib/filterPlaces';
+import type { Place } from '../../src/types';
+import { placeFixture } from '../fixtures/app-fixtures';
+
+describe('filterPlacesByCategory', () => {
+  const mockPlaces: Place[] = [
+    { ...placeFixture, id: 'place-1', category: 'cafe' },
+    { ...placeFixture, id: 'place-2', category: 'restaurant' },
+    { ...placeFixture, id: 'place-3', category: 'cafe' },
+  ];
+
+  it('should return all places when category is "all"', () => {
+    const result = filterPlacesByCategory(mockPlaces, 'all');
+    expect(result).toHaveLength(3);
+    expect(result).toEqual(mockPlaces);
+  });
+
+  it('should filter places by a specific category', () => {
+    const result = filterPlacesByCategory(mockPlaces, 'cafe');
+    expect(result).toHaveLength(2);
+    expect(result.every((place) => place.category === 'cafe')).toBe(true);
+    expect(result.map((p) => p.id)).toEqual(['place-1', 'place-3']);
+  });
+
+  it('should return an empty array when no places match the category', () => {
+    const result = filterPlacesByCategory(mockPlaces, 'culture');
+    expect(result).toHaveLength(0);
+  });
+
+  it('should handle an empty input array', () => {
+    const result = filterPlacesByCategory([], 'cafe');
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
🎯 **What:** Add missing unit tests for `filterPlacesByCategory` in `src/lib/filterPlaces.ts`.
📊 **Coverage:** All category, specific category filtering, no matches, and empty input array scenarios are now covered.
✨ **Result:** Improved test coverage and reliability for place filtering logic.

---
*PR created automatically by Jules for task [1674777666772148423](https://jules.google.com/task/1674777666772148423) started by @ClarusIubar*