### PR TITLE
Type Worker runtime dependency boundaries

### DIFF
--- a/deploy/api-worker-shell/lib/supabase.ts
+++ b/deploy/api-worker-shell/lib/supabase.ts
@@ -1,4 +1,4 @@
-import type { SupabaseRequestOptions, WorkerEnv } from '../types';
+import type { SupabaseCacheState, SupabaseRequestOptions, WorkerEnv } from '../types';
 
 export function getSupabaseKey(env: WorkerEnv) {
   return env.APP_SUPABASE_SERVICE_ROLE_KEY || env.APP_SUPABASE_ANON_KEY || '';
@@ -75,7 +75,7 @@ export function buildInFilter(values: unknown[]) {
   return `in.(${unique.map((value) => encodeFilterValue(value)).join(',')})`;
 }
 
-export async function rememberPending<T>(cacheState: any, loader: () => Promise<T>): Promise<T> {
+export async function rememberPending<T>(cacheState: SupabaseCacheState<T>, loader: () => Promise<T>): Promise<T> {
   if (cacheState.pending) {
     return cacheState.pending;
   }

--- a/deploy/api-worker-shell/runtime/base-data.ts
+++ b/deploy/api-worker-shell/runtime/base-data.ts
@@ -1,6 +1,18 @@
 import { formatDate, formatDateTime, toSeoulDateKey } from '../lib/dates';
 import { buildInFilter, encodeFilterValue, rememberPending, supabaseRequest } from '../lib/supabase';
-import type { WorkerEnv } from '../types';
+import type {
+  SupabaseCacheState,
+  SupabaseCoursePlaceRow,
+  SupabaseCourseRow,
+  SupabaseMapRow,
+  WorkerBaseData,
+  WorkerCourse,
+  WorkerEnv,
+  WorkerJsonRecord,
+  WorkerPlace,
+  WorkerReviewReadService,
+  WorkerStaticBaseRows,
+} from '../types';
 
 export const BADGE_BY_MOOD = {
   설렘: '첫 방문',
@@ -12,10 +24,8 @@ export const BADGE_BY_MOOD = {
 
 const STATIC_BASE_CACHE_TTL_MS = 5 * 60 * 1000;
 
-let staticBaseCache: {
+let staticBaseCache: SupabaseCacheState<WorkerStaticBaseRows> & {
   expiresAt: number;
-  pending: Promise<any> | null;
-  value: any | null;
 } = {
   expiresAt: 0,
   pending: null,
@@ -148,7 +158,7 @@ export function normalizePlaceCategory(category: string, slug = '') {
   return 'attraction';
 }
 
-function getCategoryPalette(category: string, row: any) {
+function getCategoryPalette(category: string, row: SupabaseMapRow) {
   const fallbackJam = row.jam_color ?? '#FFB3C6';
   const fallbackAccent = row.accent_color ?? '#FF6B9D';
 
@@ -166,7 +176,7 @@ function getCategoryPalette(category: string, row: any) {
   }
 }
 
-export function mapPlace(row: any) {
+export function mapPlace(row: SupabaseMapRow): WorkerPlace {
   const category = normalizePlaceCategory(row.category, row.slug);
   const palette = getCategoryPalette(category, row);
 
@@ -201,7 +211,7 @@ function buildPlaceVisitCountMap(stampRows: any[]) {
   return counts;
 }
 
-export async function loadStaticBaseRows(env: WorkerEnv) {
+export async function loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBaseRows> {
   const now = Date.now();
   if (staticBaseCache.value && staticBaseCache.expiresAt > now) {
     return staticBaseCache.value;
@@ -209,12 +219,12 @@ export async function loadStaticBaseRows(env: WorkerEnv) {
 
   return rememberPending(staticBaseCache, async () => {
     const [placeRows, courseRows, coursePlaceRows] = await Promise.all([
-      supabaseRequest(
+      supabaseRequest<SupabaseMapRow[]>(
         env,
         'map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&is_active=eq.true&order=position_id.asc',
       ),
-      supabaseRequest(env, 'course?select=course_id,title,mood,duration,note,color,display_order&order=display_order.asc'),
-      supabaseRequest(env, 'course_place?select=course_id,position_id,stop_order&order=stop_order.asc'),
+      supabaseRequest<SupabaseCourseRow[]>(env, 'course?select=course_id,title,mood,duration,note,color,display_order&order=display_order.asc'),
+      supabaseRequest<SupabaseCoursePlaceRow[]>(env, 'course_place?select=course_id,position_id,stop_order&order=stop_order.asc'),
     ]);
     const value = { placeRows, courseRows, coursePlaceRows };
     staticBaseCache = { ...staticBaseCache, value, expiresAt: Date.now() + STATIC_BASE_CACHE_TTL_MS, pending: null };
@@ -222,7 +232,11 @@ export async function loadStaticBaseRows(env: WorkerEnv) {
   });
 }
 
-export function mapCourses(courseRows: any[], coursePlaceRows: any[], placesByPositionId: Map<string, any>) {
+export function mapCourses(
+  courseRows: SupabaseCourseRow[],
+  coursePlaceRows: SupabaseCoursePlaceRow[],
+  placesByPositionId: Map<string, WorkerPlace>,
+): WorkerCourse[] {
   const placeIdsByCourseId = new Map<string, Array<{ placeId: string; stopOrder: number }>>();
   for (const row of coursePlaceRows) {
     const courseId = String(row.course_id);
@@ -248,11 +262,11 @@ export function mapCourses(courseRows: any[], coursePlaceRows: any[], placesByPo
   }));
 }
 
-export function createLoadBaseData(reviewReadService: any) {
-  return async function loadBaseData(env: WorkerEnv, sessionUserId: string | null = null) {
+export function createLoadBaseData(reviewReadService: WorkerReviewReadService) {
+  return async function loadBaseData(env: WorkerEnv, sessionUserId: string | null = null): Promise<WorkerBaseData> {
     const [{ placeRows, courseRows, coursePlaceRows }, feedRows] = await Promise.all([
       loadStaticBaseRows(env),
-      supabaseRequest(env, 'feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&order=created_at.desc'),
+      supabaseRequest<WorkerJsonRecord[]>(env, 'feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&order=created_at.desc'),
     ]);
 
     const feedIdsFilter = buildInFilter(feedRows.map((row: any) => row.feed_id));
@@ -329,9 +343,13 @@ export function createLoadBaseData(reviewReadService: any) {
     const placesByPositionId = new Map<string, any>(places.map((place: any) => [place.positionId, place]));
     const usersById = new Map<string, any>(userRows.map((row: any) => [row.user_id, row]));
     const stampRowsById = new Map<string, any>((allStampRows ?? []).map((row: any) => [String(row.stamp_id), row]));
-    const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row: any) => String(row.feed_id)));
+    const likedFeedIds = new Set<string>((userFeedLikeRows ?? []).map((row: any) => String(row.feed_id)));
     const collectedPlaceIds = [
-      ...new Set(userStampRows.map((row: any) => placesByPositionId.get(String(row.position_id))?.id).filter(Boolean)),
+      ...new Set<string>(
+        userStampRows
+          .map((row: any) => placesByPositionId.get(String(row.position_id))?.id)
+          .filter((placeId: unknown): placeId is string => typeof placeId === 'string' && placeId.length > 0),
+      ),
     ];
     const stampLogs = buildStampLogs(userStampRows, placesByPositionId);
     const travelSessions = buildTravelSessions(userSessionRows ?? [], userStampRows, placesByPositionId, ownerRouteRows ?? []);

--- a/deploy/api-worker-shell/runtime/routing.ts
+++ b/deploy/api-worker-shell/runtime/routing.ts
@@ -17,19 +17,12 @@ import {
 import { handleCreateComment, handleCreateReview, handleDeleteComment, handleDeleteReview, handleReviewUpload, handleToggleReviewLike, handleUpdateComment, handleUpdateReview } from '../services/review-interactions';
 import { handleBannerEvents, handleFestivalImport, handleFestivals } from '../services/festivals';
 import { handleDeleteNotification, handleMarkAllNotificationsRead, handleMarkNotificationRead, handleMyNotifications, handleNotificationRealtimeChannel } from '../services/notifications';
-import type { WorkerEnv } from '../types';
+import type { RouteRuntime, WorkerEnv, WorkerPlace } from '../types';
 
-interface RouteRuntime {
-  adminService: any;
-  buildReviewInteractionDeps: () => any;
-  communityRouteService: any;
-  loadBaseData: (env: WorkerEnv, sessionUserId?: string | null) => Promise<any>;
-  loadStaticBaseRows: (env: WorkerEnv) => Promise<any>;
-  mapCourses: (courseRows: any[], coursePlaceRows: any[], placesByPositionId: Map<string, any>) => any[];
-  mapPlace: (row: any) => any;
-  myService: any;
-  reviewReadService: any;
-  stampService: any;
+type PublicWorkerPlace = Omit<WorkerPlace, 'positionId'>;
+
+function toPublicPlace({ positionId: _positionId, ...place }: WorkerPlace): PublicWorkerPlace {
+  return place;
 }
 
 async function handleHealth(request: Request, env: WorkerEnv) {
@@ -68,7 +61,7 @@ async function handleMapBootstrap(request: Request, env: WorkerEnv, runtime: Rou
     200,
     {
       auth: createAuthResponse(sessionUser, env),
-      places: mapData.places.map(({ positionId: _positionId, ...place }: any) => place),
+      places: mapData.places.map(toPublicPlace),
       stamps: {
         collectedPlaceIds: mapData.collectedPlaceIds,
         logs: mapData.stampLogs,
@@ -83,8 +76,8 @@ async function handleMapBootstrap(request: Request, env: WorkerEnv, runtime: Rou
 
 async function handleCuratedCourses(request: Request, env: WorkerEnv, runtime: RouteRuntime) {
   const { placeRows, courseRows, coursePlaceRows } = await runtime.loadStaticBaseRows(env);
-  const places = placeRows.map((row: any) => runtime.mapPlace(row));
-  const placesByPositionId = new Map<string, any>(places.map((place: any) => [place.positionId, place]));
+  const places = placeRows.map((row) => runtime.mapPlace(row));
+  const placesByPositionId = new Map<string, WorkerPlace>(places.map((place) => [place.positionId, place]));
   return jsonResponse(200, { courses: runtime.mapCourses(courseRows, coursePlaceRows, placesByPositionId) }, env, request);
 }
 
@@ -95,7 +88,7 @@ async function handleBootstrap(request: Request, env: WorkerEnv, runtime: RouteR
     200,
     {
       auth: createAuthResponse(sessionUser, env),
-      places: baseData.places.map(({ positionId: _positionId, ...place }: any) => place),
+      places: baseData.places.map(toPublicPlace),
       reviews: baseData.reviews,
       courses: baseData.courses,
       stamps: {

--- a/deploy/api-worker-shell/types.ts
+++ b/deploy/api-worker-shell/types.ts
@@ -1,5 +1,7 @@
 export type AuthProviderKey = 'naver' | 'kakao';
 
+export type WorkerJsonRecord = Record<string, unknown>;
+
 export interface WorkerEnv {
   APP_ADMIN_USER_IDS?: string;
   APP_CORS_ORIGINS?: string;
@@ -53,4 +55,199 @@ export interface SupabaseUserRow {
   email?: string | null;
   provider?: string | null;
   profile_completed_at?: string | null;
+}
+
+export interface SupabaseMapRow extends WorkerJsonRecord {
+  position_id: string | number;
+  slug: string;
+  name: string;
+  district?: string | null;
+  category: string;
+  latitude: number;
+  longitude: number;
+  summary?: string | null;
+  description?: string | null;
+  image_url?: string | null;
+  image_storage_path?: string | null;
+  vibe_tags?: unknown;
+  visit_time?: string | null;
+  route_hint?: string | null;
+  stamp_reward?: string | null;
+  hero_label?: string | null;
+  jam_color?: string | null;
+  accent_color?: string | null;
+  is_active?: boolean | null;
+  total_visit_count?: number | null;
+}
+
+export interface SupabaseCourseRow extends WorkerJsonRecord {
+  course_id: string | number;
+  title: string;
+  mood: string;
+  duration: string;
+  note: string;
+  color: string;
+  display_order?: number | null;
+}
+
+export interface SupabaseCoursePlaceRow extends WorkerJsonRecord {
+  course_id: string | number;
+  position_id: string | number;
+  stop_order: number;
+}
+
+export interface WorkerPlace extends WorkerJsonRecord {
+  id: string;
+  positionId: string;
+  name: string;
+  district?: string | null;
+  category: string;
+  jamColor: string;
+  accentColor: string;
+  imageUrl: string | null;
+  latitude: number;
+  longitude: number;
+  summary?: string | null;
+  description?: string | null;
+  vibeTags: unknown[];
+  visitTime?: string | null;
+  routeHint?: string | null;
+  stampReward?: string | null;
+  heroLabel?: string | null;
+  totalVisitCount: number;
+}
+
+export interface WorkerCourse extends WorkerJsonRecord {
+  id: string;
+  title: string;
+  mood: string;
+  duration: string;
+  note: string;
+  color: string;
+  placeIds: string[];
+}
+
+export interface WorkerReviewComment extends WorkerJsonRecord {
+  id: string;
+  replies?: WorkerReviewComment[];
+}
+
+export interface WorkerReview extends WorkerJsonRecord {
+  id: string;
+  comments?: WorkerReviewComment[];
+}
+
+export interface WorkerTravelSession extends WorkerJsonRecord {
+  id: string;
+  placeIds: string[];
+}
+
+export interface WorkerStampLog extends WorkerJsonRecord {
+  id: string;
+  placeId: string;
+}
+
+export interface WorkerStaticBaseRows {
+  placeRows: SupabaseMapRow[];
+  courseRows: SupabaseCourseRow[];
+  coursePlaceRows: SupabaseCoursePlaceRow[];
+}
+
+export interface WorkerBaseData {
+  places: WorkerPlace[];
+  placesByPositionId: Map<string, WorkerPlace>;
+  reviews: WorkerReview[];
+  courses: WorkerCourse[];
+  collectedPlaceIds: string[];
+  stampLogs: WorkerStampLog[];
+  travelSessions: WorkerTravelSession[];
+}
+
+export interface SupabaseCacheState<T> {
+  pending: Promise<T> | null;
+  value: T | null;
+}
+
+export interface WorkerReviewReadService {
+  handleReviewFeed(request: Request, env: WorkerEnv, url: URL): Promise<Response>;
+  handleReviews(request: Request, env: WorkerEnv, url: URL): Promise<Response>;
+  handleReviewDetail(request: Request, env: WorkerEnv, reviewId: string): Promise<Response>;
+  loadSingleReview(env: WorkerEnv, reviewId: string, sessionUserId?: string | null): Promise<WorkerReview | null>;
+  mapReviewRows(
+    feedRows: WorkerJsonRecord[],
+    commentRows: WorkerJsonRecord[],
+    likeRows: WorkerJsonRecord[],
+    usersById: Map<string, WorkerJsonRecord>,
+    placesByPositionId: Map<string, WorkerPlace>,
+    stampRowsById: Map<string, WorkerJsonRecord>,
+    routeRows: WorkerJsonRecord[],
+    likedFeedIds: Set<string>,
+  ): WorkerReview[];
+}
+
+export interface WorkerCommunityRouteService {
+  handleCommunityRoutes(request: Request, env: WorkerEnv, url: URL): Promise<Response>;
+  handleCreateUserRoute(request: Request, env: WorkerEnv): Promise<Response>;
+  handleMyRoutes(request: Request, env: WorkerEnv): Promise<Response>;
+  handleToggleCommunityRouteLike(request: Request, env: WorkerEnv, routeId: string): Promise<Response>;
+  loadCommunityRoutes(env: WorkerEnv, options?: WorkerJsonRecord): Promise<WorkerJsonRecord[]>;
+}
+
+export interface WorkerMyService {
+  handleMyComments(request: Request, env: WorkerEnv, url: URL): Promise<Response>;
+  handleMySummary(request: Request, env: WorkerEnv): Promise<Response>;
+}
+
+export interface WorkerAdminService {
+  handleAdminSummary(request: Request, env: WorkerEnv): Promise<Response>;
+  handleAdminImportPublicData(request: Request, env: WorkerEnv): Promise<Response>;
+  handleAdminPlaceVisibility(request: Request, env: WorkerEnv, placeId: string): Promise<Response>;
+}
+
+export interface WorkerStampService {
+  handleToggleStamp(request: Request, env: WorkerEnv): Promise<Response>;
+}
+
+export interface WorkerNotificationInsertResult extends WorkerJsonRecord {
+  notification_id?: string | number | null;
+}
+
+export interface WorkerNotificationCreatePayload extends WorkerJsonRecord {
+  userId: string;
+  type: string;
+  title: string;
+  actorUserId?: string | null;
+  body?: string;
+  reviewId?: string | number | null;
+  commentId?: string | number | null;
+  routeId?: string | number | null;
+  metadata?: WorkerJsonRecord;
+}
+
+export interface WorkerReviewInteractionDeps {
+  badgeByMood: Record<string, string>;
+  countUnreadNotifications(env: WorkerEnv, userId: string): Promise<number>;
+  createUserNotification(env: WorkerEnv, payload: WorkerNotificationCreatePayload): Promise<WorkerNotificationInsertResult | null>;
+  loadBaseData(env: WorkerEnv, sessionUserId?: string | null): Promise<WorkerBaseData>;
+  loadNotificationById(env: WorkerEnv, notificationId: string | number): Promise<WorkerJsonRecord | null>;
+  loadSingleReview(env: WorkerEnv, reviewId: string, sessionUserId?: string | null): Promise<WorkerReview | null>;
+  publishNotificationEvent(env: WorkerEnv, userId: string, event: string, payload: WorkerJsonRecord): Promise<void>;
+  readSessionUser(request: Request, env: WorkerEnv): Promise<WorkerSessionUser | null>;
+}
+
+export interface RouteRuntime {
+  adminService: WorkerAdminService;
+  buildReviewInteractionDeps: () => WorkerReviewInteractionDeps;
+  communityRouteService: WorkerCommunityRouteService;
+  loadBaseData: (env: WorkerEnv, sessionUserId?: string | null) => Promise<WorkerBaseData>;
+  loadStaticBaseRows: (env: WorkerEnv) => Promise<WorkerStaticBaseRows>;
+  mapCourses: (
+    courseRows: SupabaseCourseRow[],
+    coursePlaceRows: SupabaseCoursePlaceRow[],
+    placesByPositionId: Map<string, WorkerPlace>,
+  ) => WorkerCourse[];
+  mapPlace: (row: SupabaseMapRow) => WorkerPlace;
+  myService: WorkerMyService;
+  reviewReadService: WorkerReviewReadService;
+  stampService: WorkerStampService;
 }

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -38,4 +38,11 @@ describe('worker source quality gates', () => {
       expect(longestLine, `${relativePath} has a suspiciously long line`).toBeLessThanOrEqual(maxWorkerLineLength);
     }
   });
+
+  it('keeps the Worker route runtime contract centralized', () => {
+    const routingSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/runtime/routing.ts'), 'utf8');
+
+    expect(routingSource).toContain("import type { RouteRuntime, WorkerEnv, WorkerPlace } from '../types';");
+    expect(routingSource).not.toContain('interface RouteRuntime');
+  });
 });


### PR DESCRIPTION
﻿## Summary
- centralize the Worker routing runtime dependency contract in `types.ts`
- type static base row/read-model boundaries used by bootstrap, map-bootstrap, and curated courses
- type the Supabase pending-cache helper and add a source-quality guard so `RouteRuntime` is not reintroduced inside `routing.ts`

## Contract Safety
- External REST API paths: unchanged
- Response shape: unchanged
- DB schema: unchanged
- User-facing copy: unchanged
- Kakao/Naver REST OAuth success path: unchanged

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`
- [x] `git diff --cached --check`

Closes #201
