### PR TITLE
Split Worker review domain service

### DIFF
--- a/deploy/api-worker-shell/services/review-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/review-domain/mapper.ts
@@ -1,0 +1,116 @@
+import { formatDateTime } from '../../lib/dates';
+
+export function createReviewMapper(formatVisitLabel: (visitNumber: unknown) => string) {
+  function countComments(comments: any[]): number {
+    let total = 0;
+    for (const comment of comments) {
+      total += 1 + countComments(comment.replies);
+    }
+    return total;
+  }
+
+  function buildCommentTree(commentRows: any[], usersById: Map<any, any>) {
+    const isDeletedCommentRow = (row: any) => {
+      const body = String(row?.body ?? '').trim();
+      return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.';
+    };
+    const commentsById = new Map<string, any>();
+    const rowsById = new Map<string, any>(commentRows.map((row) => [String(row.comment_id), row]));
+    const roots: any[] = [];
+    for (const row of commentRows) {
+      const comment = {
+        id: String(row.comment_id),
+        userId: row.user_id,
+        author: usersById.get(row.user_id)?.nickname ?? '이름 없음',
+        body: isDeletedCommentRow(row) ? '삭제된 댓글입니다.' : row.body,
+        parentId: row.parent_id ? String(row.parent_id) : null,
+        isDeleted: isDeletedCommentRow(row),
+        createdAt: formatDateTime(row.created_at),
+        replies: [],
+      };
+      commentsById.set(comment.id, comment);
+    }
+    for (const comment of commentsById.values()) {
+      const parentRow = comment.parentId ? rowsById.get(comment.parentId) : null;
+      const rootParentId = parentRow ? String(parentRow.parent_id ?? parentRow.comment_id) : null;
+      if (rootParentId && commentsById.has(rootParentId)) {
+        commentsById.get(rootParentId).replies.push(comment);
+      } else {
+        roots.push(comment);
+      }
+    }
+
+    const hasLiveDescendant = (node: any): boolean => node.replies.some((reply: any) => !reply.isDeleted || hasLiveDescendant(reply));
+    const collapseDeletedNodes = (nodes: any[]) =>
+      nodes.reduce((acc: any[], node: any) => {
+        const nextNode = { ...node, replies: collapseDeletedNodes(node.replies) };
+        if (nextNode.isDeleted) {
+          if (hasLiveDescendant(nextNode)) {
+            acc.push(nextNode);
+          }
+          return acc;
+        }
+        acc.push(nextNode);
+        return acc;
+      }, []);
+    return collapseDeletedNodes(roots);
+  }
+
+  function mapReviewRows(
+    feedRows: any[],
+    commentRows: any[],
+    likeRows: any[],
+    usersById: Map<any, any>,
+    placesByPositionId: Map<any, any>,
+    stampRowsById: Map<any, any>,
+    routeRows: any[] = [],
+    likedFeedIds = new Set<any>(),
+  ) {
+    const commentsByFeedId = new Map();
+    for (const row of commentRows) {
+      const feedId = String(row.feed_id);
+      if (!commentsByFeedId.has(feedId)) {
+        commentsByFeedId.set(feedId, []);
+      }
+      commentsByFeedId.get(feedId).push(row);
+    }
+    const likesByFeedId = new Map();
+    for (const row of likeRows) {
+      const feedId = String(row.feed_id);
+      likesByFeedId.set(feedId, (likesByFeedId.get(feedId) ?? 0) + 1);
+    }
+    const publishedRouteIdBySession = new Map(
+      routeRows.filter((row) => row.travel_session_id).map((row) => [String(row.travel_session_id), String(row.route_id)]),
+    );
+    return feedRows.map((row) => {
+      const place = placesByPositionId.get(String(row.position_id));
+      const stamp = row.stamp_id ? stampRowsById.get(String(row.stamp_id)) : null;
+      const reviewComments = buildCommentTree(commentsByFeedId.get(String(row.feed_id)) ?? [], usersById);
+      const visitNumber = stamp?.visit_ordinal ?? 1;
+      const travelSessionId = stamp?.travel_session_id ? String(stamp.travel_session_id) : null;
+      return {
+        id: String(row.feed_id),
+        userId: row.user_id,
+        placeId: place?.id ?? String(row.position_id),
+        placeName: place?.name ?? '장소 정보 없음',
+        author: usersById.get(row.user_id)?.nickname ?? '이름 없음',
+        body: row.body,
+        mood: row.mood,
+        badge: row.badge,
+        visitedAt: formatDateTime(row.created_at),
+        imageUrl: row.image_url ?? null,
+        commentCount: countComments(reviewComments),
+        likeCount: likesByFeedId.get(String(row.feed_id)) ?? 0,
+        likedByMe: likedFeedIds.has(String(row.feed_id)),
+        stampId: row.stamp_id ? String(row.stamp_id) : null,
+        visitNumber,
+        visitLabel: formatVisitLabel(visitNumber),
+        travelSessionId,
+        hasPublishedRoute: travelSessionId ? publishedRouteIdBySession.has(travelSessionId) : false,
+        comments: reviewComments,
+      };
+    });
+  }
+
+  return { buildCommentTree, countComments, mapReviewRows };
+}

--- a/deploy/api-worker-shell/services/review-domain/notifications.ts
+++ b/deploy/api-worker-shell/services/review-domain/notifications.ts
@@ -1,0 +1,22 @@
+import type { WorkerEnv, WorkerNotificationCreatePayload, WorkerReviewInteractionDeps } from '../../types';
+
+export async function publishReviewNotification(
+  env: WorkerEnv,
+  deps: WorkerReviewInteractionDeps,
+  payload: WorkerNotificationCreatePayload,
+): Promise<void> {
+  const createdNotification = await deps.createUserNotification(env, payload);
+  if (!createdNotification?.notification_id) {
+    return;
+  }
+
+  const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
+  if (!notification) {
+    return;
+  }
+
+  await deps.publishNotificationEvent(env, payload.userId, 'notification.created', {
+    notification,
+    unreadCount: await deps.countUnreadNotifications(env, payload.userId),
+  });
+}

--- a/deploy/api-worker-shell/services/review-domain/repository.ts
+++ b/deploy/api-worker-shell/services/review-domain/repository.ts
@@ -1,0 +1,101 @@
+import { encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+
+export async function readFeedRow(env: WorkerEnv, reviewId: string | number): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `feed?select=feed_id,position_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function readCommentRow(env: WorkerEnv, commentId: string | number): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_comment?select=comment_id,feed_id,user_id,parent_id,is_deleted&comment_id=eq.${encodeFilterValue(commentId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function readStampRow(env: WorkerEnv, stampId: string | number): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,visit_ordinal,stamp_date,created_at&stamp_id=eq.${encodeFilterValue(stampId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function createReviewRow(env: WorkerEnv, payload: WorkerJsonRecord): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(env, 'feed?select=feed_id', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return rows?.[0] ?? null;
+}
+
+export async function updateReviewRow(env: WorkerEnv, reviewId: string | number, payload: WorkerJsonRecord): Promise<void> {
+  await supabaseRequest(env, `feed?feed_id=eq.${encodeFilterValue(reviewId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function deleteReviewRow(env: WorkerEnv, reviewId: string | number): Promise<void> {
+  await supabaseRequest(env, `feed?feed_id=eq.${encodeFilterValue(reviewId)}`, {
+    method: 'DELETE',
+    headers: { Prefer: 'return=minimal' },
+  });
+}
+
+export async function createCommentRow(env: WorkerEnv, payload: WorkerJsonRecord): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(env, 'user_comment?select=comment_id', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return rows?.[0] ?? null;
+}
+
+export async function updateCommentRow(env: WorkerEnv, commentId: string | number, payload: WorkerJsonRecord): Promise<void> {
+  await supabaseRequest(env, `user_comment?comment_id=eq.${encodeFilterValue(commentId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  });
+}
+
+export async function softDeleteCommentRow(env: WorkerEnv, commentId: string | number): Promise<void> {
+  await updateCommentRow(env, commentId, {
+    body: '[deleted]',
+    is_deleted: true,
+    updated_at: new Date().toISOString(),
+  });
+}
+
+export async function readReviewLikeRow(env: WorkerEnv, reviewId: string | number, userId: string): Promise<WorkerJsonRecord | null> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `feed_like?select=feed_like_id&feed_id=eq.${encodeFilterValue(reviewId)}&user_id=eq.${encodeFilterValue(userId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function createReviewLikeRow(env: WorkerEnv, reviewId: string | number, userId: string): Promise<void> {
+  await supabaseRequest(env, 'feed_like?select=feed_like_id', {
+    method: 'POST',
+    body: JSON.stringify({ feed_id: Number(reviewId), user_id: userId }),
+  });
+}
+
+export async function deleteReviewLikeRow(env: WorkerEnv, feedLikeId: string | number): Promise<void> {
+  await supabaseRequest(env, `feed_like?feed_like_id=eq.${encodeFilterValue(feedLikeId)}`, {
+    method: 'DELETE',
+    headers: { Prefer: 'return=minimal' },
+  });
+}
+
+export async function countReviewLikes(env: WorkerEnv, reviewId: string | number): Promise<number> {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `feed_like?select=feed_like_id&feed_id=eq.${encodeFilterValue(reviewId)}`,
+  );
+  return rows.length;
+}

--- a/deploy/api-worker-shell/services/review-interactions.ts
+++ b/deploy/api-worker-shell/services/review-interactions.ts
@@ -1,134 +1,352 @@
 import { jsonResponse } from '../lib/http';
-import { encodeFilterValue, getSupabaseKey, supabaseRequest } from '../lib/supabase';
-function sanitizeFileName(fileName) { return String(fileName || 'upload.jpg').replace(/[^a-zA-Z0-9._-]+/g, '-'); }
-function buildPublicStorageUrl(env, objectPath) { const normalizedPath = objectPath.split('/').map((segment) => encodeURIComponent(segment)).join('/'); return `${env.APP_SUPABASE_URL}/storage/v1/object/public/${env.APP_SUPABASE_STORAGE_BUCKET}/${normalizedPath}`; }
-async function uploadReviewFile(env, sessionUser, file) { if (!env.APP_SUPABASE_URL || !env.APP_SUPABASE_STORAGE_BUCKET) {
+import { getSupabaseKey } from '../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord, WorkerReviewInteractionDeps, WorkerSessionUser } from '../types';
+import { publishReviewNotification } from './review-domain/notifications';
+import {
+  countReviewLikes,
+  createCommentRow,
+  createReviewLikeRow,
+  createReviewRow,
+  deleteReviewLikeRow,
+  deleteReviewRow,
+  readCommentRow,
+  readFeedRow,
+  readReviewLikeRow,
+  readStampRow,
+  softDeleteCommentRow,
+  updateCommentRow,
+  updateReviewRow,
+} from './review-domain/repository';
+
+function sanitizeFileName(fileName: string) {
+  return String(fileName || 'upload.jpg').replace(/[^a-zA-Z0-9._-]+/g, '-');
+}
+
+function buildPublicStorageUrl(env: WorkerEnv, objectPath: string) {
+  const normalizedPath = objectPath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  return `${env.APP_SUPABASE_URL}/storage/v1/object/public/${env.APP_SUPABASE_STORAGE_BUCKET}/${normalizedPath}`;
+}
+
+async function uploadReviewFile(env: WorkerEnv, sessionUser: WorkerSessionUser, file: File) {
+  if (!env.APP_SUPABASE_URL || !env.APP_SUPABASE_STORAGE_BUCKET) {
     throw new Error('Supabase Storage 설정이 비어 있어요.');
-} const storageKey = env.APP_SUPABASE_SERVICE_ROLE_KEY || getSupabaseKey(env); if (!storageKey) {
+  }
+  const storageKey = env.APP_SUPABASE_SERVICE_ROLE_KEY || getSupabaseKey(env);
+  if (!storageKey) {
     throw new Error('Supabase Storage 권한 키가 비어 있어요.');
-} const safeFileName = sanitizeFileName(file.name); const objectPath = `reviews/${sessionUser.id.replace(/[^a-zA-Z0-9_-]+/g, '_')}/${Date.now()}-${safeFileName}`; const uploadUrl = `${env.APP_SUPABASE_URL}/storage/v1/object/${env.APP_SUPABASE_STORAGE_BUCKET}/${objectPath.split('/').map((segment) => encodeURIComponent(segment)).join('/')}`; const response = await fetch(uploadUrl, { method: 'POST', headers: { apikey: storageKey, Authorization: `Bearer ${storageKey}`, 'x-upsert': 'true', 'content-type': file.type || 'application/octet-stream', }, body: file, }); if (!response.ok) {
+  }
+
+  const safeFileName = sanitizeFileName(file.name);
+  const objectPath = `reviews/${sessionUser.id.replace(/[^a-zA-Z0-9_-]+/g, '_')}/${Date.now()}-${safeFileName}`;
+  const uploadPath = objectPath.split('/').map((segment) => encodeURIComponent(segment)).join('/');
+  const uploadUrl = `${env.APP_SUPABASE_URL}/storage/v1/object/${env.APP_SUPABASE_STORAGE_BUCKET}/${uploadPath}`;
+  const response = await fetch(uploadUrl, {
+    method: 'POST',
+    headers: {
+      apikey: storageKey,
+      Authorization: `Bearer ${storageKey}`,
+      'x-upsert': 'true',
+      'content-type': file.type || 'application/octet-stream',
+    },
+    body: file,
+  });
+  if (!response.ok) {
     const detail = await response.text();
     throw new Error(`이미지 업로드에 실패했어요. (${response.status}) ${detail}`);
-} return { url: buildPublicStorageUrl(env, objectPath), fileName: safeFileName, contentType: file.type || 'application/octet-stream', }; }
-async function readJsonBody(request) { try {
-    return await request.json();
+  }
+  return { url: buildPublicStorageUrl(env, objectPath), fileName: safeFileName, contentType: file.type || 'application/octet-stream' };
 }
-catch {
+
+async function readJsonBody(request: Request): Promise<any> {
+  try {
+    return await request.json();
+  } catch {
     throw new Error('요청 형식이 올바르지 않아요.');
-} }
-async function requireSessionUser(request, env, deps) { const sessionUser = await deps.readSessionUser(request, env); if (!sessionUser) {
+  }
+}
+
+async function requireSessionUser(request: Request, env: WorkerEnv, deps: WorkerReviewInteractionDeps) {
+  const sessionUser = await deps.readSessionUser(request, env);
+  if (!sessionUser) {
     return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
-} return { sessionUser }; }
-async function readFeedRow(env, reviewId) { const rows = await supabaseRequest(env, `feed?select=feed_id,position_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`); return rows?.[0] ?? null; }
-async function readCommentRow(env, commentId) { const rows = await supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,is_deleted&comment_id=eq.${encodeFilterValue(commentId)}&limit=1`); return rows?.[0] ?? null; }
-export async function handleReviewUpload(request, env, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
+  }
+  return { sessionUser };
+}
+
+export async function handleReviewUpload(request: Request, env: WorkerEnv, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
     return sessionResult.response;
-} const formData = await request.formData(); const file = formData.get('file'); if (!(file instanceof File)) {
+  }
+
+  const formData = await request.formData();
+  const file = formData.get('file');
+  if (!(file instanceof File)) {
     return jsonResponse(400, { detail: '업로드할 이미지 파일이 필요해요.' }, env, request);
-} if (!(file.type || '').startsWith('image/')) {
+  }
+  if (!(file.type || '').startsWith('image/')) {
     return jsonResponse(400, { detail: '이미지 파일만 업로드할 수 있어요.' }, env, request);
-} const maxUploadSize = Number(env.APP_MAX_UPLOAD_SIZE_BYTES ?? '5242880'); if (file.size > maxUploadSize) {
+  }
+  const maxUploadSize = Number(env.APP_MAX_UPLOAD_SIZE_BYTES ?? '5242880');
+  if (file.size > maxUploadSize) {
     return jsonResponse(413, { detail: '이미지는 5MB 이하로 올려 주세요.' }, env, request);
-} const uploaded = await uploadReviewFile(env, sessionResult.sessionUser, file); return jsonResponse(200, uploaded, env, request); }
-export async function handleCreateReview(request, env, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
+  }
+
+  const uploaded = await uploadReviewFile(env, sessionResult.sessionUser, file);
+  return jsonResponse(200, uploaded, env, request);
+}
+
+export async function handleCreateReview(request: Request, env: WorkerEnv, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
     return sessionResult.response;
-} const payload = await readJsonBody(request); const placeId = String(payload.placeId ?? '').trim(); const stampId = String(payload.stampId ?? '').trim(); const body = String(payload.body ?? '').trim(); const mood = String(payload.mood ?? '설렘').trim(); const imageUrl = payload.imageUrl ? String(payload.imageUrl) : null; if (!placeId) {
+  }
+
+  const payload = await readJsonBody(request);
+  const placeId = String(payload.placeId ?? '').trim();
+  const stampId = String(payload.stampId ?? '').trim();
+  const body = String(payload.body ?? '').trim();
+  const mood = String(payload.mood ?? '설렘').trim();
+  const imageUrl = payload.imageUrl ? String(payload.imageUrl) : null;
+  if (!placeId) {
     return jsonResponse(400, { detail: '장소 정보가 필요해요.' }, env, request);
-} if (!stampId) {
+  }
+  if (!stampId) {
     return jsonResponse(400, { detail: '피드를 쓰려면 해당 방문 스탬프가 필요해요.' }, env, request);
-} if (!body) {
+  }
+  if (!body) {
     return jsonResponse(400, { detail: '후기를 조금 더 적어 주세요.' }, env, request);
-} const baseData = await deps.loadBaseData(env, sessionResult.sessionUser.id); const place = baseData.places.find((item) => item.id === placeId); if (!place) {
+  }
+
+  const baseData = await deps.loadBaseData(env, sessionResult.sessionUser.id);
+  const place = baseData.places.find((item) => item.id === placeId);
+  if (!place) {
     return jsonResponse(404, { detail: '장소를 찾지 못했어요.' }, env, request);
-} const stampRows = await supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,visit_ordinal,stamp_date,created_at&stamp_id=eq.${encodeFilterValue(stampId)}&limit=1`); const stampRow = stampRows?.[0] ?? null; if (!stampRow) {
+  }
+  const stampRow = await readStampRow(env, stampId);
+  if (!stampRow) {
     return jsonResponse(404, { detail: '방문 스탬프를 찾지 못했어요.' }, env, request);
-} if (stampRow.user_id !== sessionResult.sessionUser.id || String(stampRow.position_id) !== String(place.positionId)) {
+  }
+  if (stampRow.user_id !== sessionResult.sessionUser.id || String(stampRow.position_id) !== String(place.positionId)) {
     return jsonResponse(403, { detail: '해당 장소의 방문 스탬프가 확인되어야 피드를 쓸 수 있어요.' }, env, request);
-} const insertedRows = await supabaseRequest(env, 'feed?select=feed_id', { method: 'POST', body: JSON.stringify({ position_id: Number(place.positionId), user_id: sessionResult.sessionUser.id, stamp_id: Number(stampId), body, mood, badge: deps.badgeByMood[mood] ?? '현장 방문', image_url: imageUrl, }), }); const createdReview = await deps.loadSingleReview(env, insertedRows?.[0]?.feed_id, sessionResult.sessionUser.id); const createdNotification = await deps.createUserNotification(env, { userId: sessionResult.sessionUser.id, actorUserId: sessionResult.sessionUser.id, type: 'review-created', title: '피드 작성이 완료되었습니다.', body: `${place.name} 피드를 남겼어요.`, reviewId: insertedRows?.[0]?.feed_id ?? null, metadata: { placeId: place.id }, }); if (createdNotification?.notification_id) {
-    const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
-    if (notification) {
-        await deps.publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.created', { notification, unreadCount: await deps.countUnreadNotifications(env, sessionResult.sessionUser.id), });
-    }
-} return jsonResponse(201, createdReview, env, request); }
-export async function handleUpdateReview(request, env, reviewId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
+  }
+
+  const insertedRow = await createReviewRow(env, {
+    position_id: Number(place.positionId),
+    user_id: sessionResult.sessionUser.id,
+    stamp_id: Number(stampId),
+    body,
+    mood,
+    badge: deps.badgeByMood[mood] ?? '현장 방문',
+    image_url: imageUrl,
+  });
+  const createdReviewId = insertedRow?.feed_id as string | number | undefined;
+  const createdReview = await deps.loadSingleReview(env, createdReviewId as string, sessionResult.sessionUser.id);
+
+  await publishReviewNotification(env, deps, {
+    userId: sessionResult.sessionUser.id,
+    actorUserId: sessionResult.sessionUser.id,
+    type: 'review-created',
+    title: '피드 작성이 완료되었습니다.',
+    body: `${place.name} 피드를 남겼어요.`,
+    reviewId: createdReviewId ?? null,
+    metadata: { placeId: place.id },
+  });
+
+  return jsonResponse(201, createdReview, env, request);
+}
+
+export async function handleUpdateReview(request: Request, env: WorkerEnv, reviewId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
     return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
     return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} if (reviewRow.user_id !== sessionResult.sessionUser.id) {
+  }
+  if (reviewRow.user_id !== sessionResult.sessionUser.id) {
     return jsonResponse(403, { detail: '내가 쓴 피드만 수정할 수 있어요.' }, env, request);
-} const payload = await readJsonBody(request); const body = String(payload.body ?? '').trim(); const mood = String(payload.mood ?? '').trim(); const imageUrlProvided = Object.prototype.hasOwnProperty.call(payload, 'imageUrl'); const imageUrl = imageUrlProvided ? (payload.imageUrl ? String(payload.imageUrl) : null) : undefined; if (!body) {
+  }
+
+  const payload = await readJsonBody(request);
+  const body = String(payload.body ?? '').trim();
+  const mood = String(payload.mood ?? '').trim();
+  const imageUrlProvided = Object.prototype.hasOwnProperty.call(payload, 'imageUrl');
+  const imageUrl = imageUrlProvided ? (payload.imageUrl ? String(payload.imageUrl) : null) : undefined;
+  if (!body) {
     return jsonResponse(400, { detail: '후기를 조금 더 적어 주세요.' }, env, request);
-} if (!mood) {
+  }
+  if (!mood) {
     return jsonResponse(400, { detail: '무드 태그를 선택해 주세요.' }, env, request);
-} await supabaseRequest(env, `feed?feed_id=eq.${encodeFilterValue(reviewId)}`, { method: 'PATCH', body: JSON.stringify({ body, mood, ...(imageUrlProvided ? { image_url: imageUrl } : {}), badge: deps.badgeByMood[mood] ?? '현장 방문', updated_at: new Date().toISOString(), }), }); const updatedReview = await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id); return jsonResponse(200, updatedReview, env, request); }
-export async function handleCreateComment(request, env, reviewId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
+  }
+
+  await updateReviewRow(env, reviewId, {
+    body,
+    mood,
+    ...(imageUrlProvided ? { image_url: imageUrl } : {}),
+    badge: deps.badgeByMood[mood] ?? '현장 방문',
+    updated_at: new Date().toISOString(),
+  });
+  const updatedReview = await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id);
+  return jsonResponse(200, updatedReview, env, request);
+}
+
+export async function handleCreateComment(request: Request, env: WorkerEnv, reviewId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
     return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
     return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} const payload = await readJsonBody(request); const body = String(payload.body ?? '').trim(); let parentId = payload.parentId ? Number(payload.parentId) : null; let parentComment = null; if (!body) {
+  }
+  const payload = await readJsonBody(request);
+  const body = String(payload.body ?? '').trim();
+  let parentId = payload.parentId ? Number(payload.parentId) : null;
+  let parentComment: WorkerJsonRecord | null = null;
+  if (!body) {
     return jsonResponse(400, { detail: '댓글을 조금 더 적어 주세요.' }, env, request);
-} if (parentId) {
+  }
+  if (parentId) {
     parentComment = await readCommentRow(env, parentId);
     if (!parentComment || String(parentComment.feed_id) !== String(reviewId)) {
-        return jsonResponse(400, { detail: '같은 후기 안의 댓글에만 답글을 달 수 있어요.' }, env, request);
+      return jsonResponse(400, { detail: '같은 후기 안의 댓글에만 답글을 달 수 있어요.' }, env, request);
     }
     if (parentComment.parent_id) {
-        parentId = Number(parentComment.parent_id);
+      parentId = Number(parentComment.parent_id);
     }
-} const insertedRows = await supabaseRequest(env, 'user_comment?select=comment_id', { method: 'POST', body: JSON.stringify({ feed_id: Number(reviewId), user_id: sessionResult.sessionUser.id, parent_id: parentId, body, is_deleted: false, }), }); const createdCommentId = insertedRows?.[0]?.comment_id ?? null; const actorUserId = sessionResult.sessionUser.id; const reviewOwnerId = reviewRow.user_id; if (parentComment && parentComment.user_id && parentComment.user_id !== actorUserId) {
-    const createdNotification = await deps.createUserNotification(env, { userId: parentComment.user_id, actorUserId, type: 'comment-reply', title: '내 댓글에 답글이 달렸습니다.', body, reviewId, commentId: createdCommentId, });
-    if (createdNotification?.notification_id) {
-        const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
-        if (notification) {
-            await deps.publishNotificationEvent(env, parentComment.user_id, 'notification.created', { notification, unreadCount: await deps.countUnreadNotifications(env, parentComment.user_id), });
-        }
-    }
-} if (reviewOwnerId && reviewOwnerId !== actorUserId && (!parentComment || parentComment.user_id !== reviewOwnerId)) {
-    const createdNotification = await deps.createUserNotification(env, { userId: reviewOwnerId, actorUserId, type: 'review-comment', title: '내 피드에 댓글이 달렸습니다.', body, reviewId, commentId: createdCommentId, });
-    if (createdNotification?.notification_id) {
-        const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
-        if (notification) {
-            await deps.publishNotificationEvent(env, reviewOwnerId, 'notification.created', { notification, unreadCount: await deps.countUnreadNotifications(env, reviewOwnerId), });
-        }
-    }
-} const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? []; return jsonResponse(200, comments, env, request); }
-export async function handleUpdateComment(request, env, reviewId, commentId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
-    return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
-    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} const commentRow = await readCommentRow(env, commentId); if (!commentRow || String(commentRow.feed_id) !== String(reviewId)) {
-    return jsonResponse(404, { detail: '댓글을 찾지 못했어요.' }, env, request);
-} if (commentRow.user_id !== sessionResult.sessionUser.id) {
-    return jsonResponse(403, { detail: '내 댓글만 수정할 수 있어요.' }, env, request);
-} if (commentRow.is_deleted) {
-    return jsonResponse(400, { detail: '삭제된 댓글은 수정할 수 없어요.' }, env, request);
-} const payload = await readJsonBody(request); const body = String(payload.body ?? '').trim(); if (!body) {
-    return jsonResponse(400, { detail: '댓글을 조금 더 적어 주세요.' }, env, request);
-} await supabaseRequest(env, `user_comment?comment_id=eq.${encodeFilterValue(commentId)}`, { method: 'PATCH', body: JSON.stringify({ body, updated_at: new Date().toISOString(), }), }); const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? []; return jsonResponse(200, comments, env, request); }
-export async function handleDeleteComment(request, env, reviewId, commentId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
-    return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
-    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} const commentRow = await readCommentRow(env, commentId); if (!commentRow || String(commentRow.feed_id) !== String(reviewId)) {
-    return jsonResponse(404, { detail: '댓글을 찾지 못했어요.' }, env, request);
-} if (commentRow.user_id !== sessionResult.sessionUser.id) {
-    return jsonResponse(403, { detail: '내 댓글만 삭제할 수 있어요.' }, env, request);
-} await supabaseRequest(env, `user_comment?comment_id=eq.${encodeFilterValue(commentId)}`, { method: 'PATCH', body: JSON.stringify({ body: '[deleted]', is_deleted: true, updated_at: new Date().toISOString(), }), }); const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? []; return jsonResponse(200, comments, env, request); }
-export async function handleDeleteReview(request, env, reviewId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
-    return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
-    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} if (reviewRow.user_id !== sessionResult.sessionUser.id) {
-    return jsonResponse(403, { detail: '내가 쓴 피드만 삭제할 수 있어요.' }, env, request);
-} await supabaseRequest(env, `feed?feed_id=eq.${encodeFilterValue(reviewId)}`, { method: 'DELETE', headers: { Prefer: 'return=minimal' }, }); return jsonResponse(200, { reviewId: String(reviewId), deleted: true }, env, request); }
-export async function handleToggleReviewLike(request, env, reviewId, deps) { const sessionResult = await requireSessionUser(request, env, deps); if (sessionResult.response) {
-    return sessionResult.response;
-} const reviewRow = await readFeedRow(env, reviewId); if (!reviewRow) {
-    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
-} const existingRows = await supabaseRequest(env, `feed_like?select=feed_like_id&feed_id=eq.${encodeFilterValue(reviewId)}&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&limit=1`); const existing = existingRows?.[0] ?? null; if (existing) {
-    await supabaseRequest(env, `feed_like?feed_like_id=eq.${encodeFilterValue(existing.feed_like_id)}`, { method: 'DELETE', headers: { Prefer: 'return=minimal' }, });
-}
-else {
-    await supabaseRequest(env, 'feed_like?select=feed_like_id', { method: 'POST', body: JSON.stringify({ feed_id: Number(reviewId), user_id: sessionResult.sessionUser.id, }), });
-} const likeRows = await supabaseRequest(env, `feed_like?select=feed_like_id&feed_id=eq.${encodeFilterValue(reviewId)}`); return jsonResponse(200, { reviewId: String(reviewId), likeCount: likeRows.length, likedByMe: !existing, }, env, request); }
+  }
 
+  const insertedRow = await createCommentRow(env, {
+    feed_id: Number(reviewId),
+    user_id: sessionResult.sessionUser.id,
+    parent_id: parentId,
+    body,
+    is_deleted: false,
+  });
+  const createdCommentId = insertedRow?.comment_id ?? null;
+  const actorUserId = sessionResult.sessionUser.id;
+  const reviewOwnerId = reviewRow.user_id;
+  if (parentComment && parentComment.user_id && parentComment.user_id !== actorUserId) {
+    await publishReviewNotification(env, deps, {
+      userId: String(parentComment.user_id),
+      actorUserId,
+      type: 'comment-reply',
+      title: '내 댓글에 답글이 달렸습니다.',
+      body,
+      reviewId,
+      commentId: createdCommentId as string | number | null,
+    });
+  }
+  if (reviewOwnerId && reviewOwnerId !== actorUserId && (!parentComment || parentComment.user_id !== reviewOwnerId)) {
+    await publishReviewNotification(env, deps, {
+      userId: String(reviewOwnerId),
+      actorUserId,
+      type: 'review-comment',
+      title: '내 피드에 댓글이 달렸습니다.',
+      body,
+      reviewId,
+      commentId: createdCommentId as string | number | null,
+    });
+  }
+
+  const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? [];
+  return jsonResponse(200, comments, env, request);
+}
+
+export async function handleUpdateComment(request: Request, env: WorkerEnv, reviewId: string, commentId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
+    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
+  }
+  const commentRow = await readCommentRow(env, commentId);
+  if (!commentRow || String(commentRow.feed_id) !== String(reviewId)) {
+    return jsonResponse(404, { detail: '댓글을 찾지 못했어요.' }, env, request);
+  }
+  if (commentRow.user_id !== sessionResult.sessionUser.id) {
+    return jsonResponse(403, { detail: '내 댓글만 수정할 수 있어요.' }, env, request);
+  }
+  if (commentRow.is_deleted) {
+    return jsonResponse(400, { detail: '삭제된 댓글은 수정할 수 없어요.' }, env, request);
+  }
+
+  const payload = await readJsonBody(request);
+  const body = String(payload.body ?? '').trim();
+  if (!body) {
+    return jsonResponse(400, { detail: '댓글을 조금 더 적어 주세요.' }, env, request);
+  }
+
+  await updateCommentRow(env, commentId, { body, updated_at: new Date().toISOString() });
+  const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? [];
+  return jsonResponse(200, comments, env, request);
+}
+
+export async function handleDeleteComment(request: Request, env: WorkerEnv, reviewId: string, commentId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
+    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
+  }
+  const commentRow = await readCommentRow(env, commentId);
+  if (!commentRow || String(commentRow.feed_id) !== String(reviewId)) {
+    return jsonResponse(404, { detail: '댓글을 찾지 못했어요.' }, env, request);
+  }
+  if (commentRow.user_id !== sessionResult.sessionUser.id) {
+    return jsonResponse(403, { detail: '내 댓글만 삭제할 수 있어요.' }, env, request);
+  }
+
+  await softDeleteCommentRow(env, commentId);
+  const comments = (await deps.loadSingleReview(env, reviewId, sessionResult.sessionUser.id))?.comments ?? [];
+  return jsonResponse(200, comments, env, request);
+}
+
+export async function handleDeleteReview(request: Request, env: WorkerEnv, reviewId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
+    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
+  }
+  if (reviewRow.user_id !== sessionResult.sessionUser.id) {
+    return jsonResponse(403, { detail: '내가 쓴 피드만 삭제할 수 있어요.' }, env, request);
+  }
+
+  await deleteReviewRow(env, reviewId);
+  return jsonResponse(200, { reviewId: String(reviewId), deleted: true }, env, request);
+}
+
+export async function handleToggleReviewLike(request: Request, env: WorkerEnv, reviewId: string, deps: WorkerReviewInteractionDeps) {
+  const sessionResult = await requireSessionUser(request, env, deps);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const reviewRow = await readFeedRow(env, reviewId);
+  if (!reviewRow) {
+    return jsonResponse(404, { detail: '후기를 찾지 못했어요.' }, env, request);
+  }
+
+  const existing = await readReviewLikeRow(env, reviewId, sessionResult.sessionUser.id);
+  if (existing) {
+    await deleteReviewLikeRow(env, existing.feed_like_id as string | number);
+  } else {
+    await createReviewLikeRow(env, reviewId, sessionResult.sessionUser.id);
+  }
+
+  return jsonResponse(200, { reviewId: String(reviewId), likeCount: await countReviewLikes(env, reviewId), likedByMe: !existing }, env, request);
+}

--- a/deploy/api-worker-shell/services/reviews.ts
+++ b/deploy/api-worker-shell/services/reviews.ts
@@ -1,48 +1,189 @@
-import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
 import { buildInFilter, encodeFilterValue, parseListLimit, supabaseRequest } from '../lib/supabase';
 import { readSessionUser } from './auth';
-export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, mapPlace }: any) { function countComments(comments: any[]) { let total = 0; for (const comment of comments) {
-    total += 1 + countComments(comment.replies);
-} return total; } function buildCommentTree(commentRows: any[], usersById: Map<any, any>) { const isDeletedCommentRow = (row: any) => { const body = String(row?.body ?? '').trim(); return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.'; }; const commentsById = new Map<string, any>(); const rowsById = new Map<string, any>(commentRows.map((row) => [String(row.comment_id), row])); const roots: any[] = []; for (const row of commentRows) {
-    const comment = { id: String(row.comment_id), userId: row.user_id, author: usersById.get(row.user_id)?.nickname ?? '이름 없음', body: isDeletedCommentRow(row) ? '삭제된 댓글입니다.' : row.body, parentId: row.parent_id ? String(row.parent_id) : null, isDeleted: isDeletedCommentRow(row), createdAt: formatDateTime(row.created_at), replies: [], };
-    commentsById.set(comment.id, comment);
-} for (const comment of commentsById.values()) {
-    const parentRow = comment.parentId ? rowsById.get(comment.parentId) : null;
-    const rootParentId = parentRow ? String(parentRow.parent_id ?? parentRow.comment_id) : null;
-    if (rootParentId && commentsById.has(rootParentId)) {
-        commentsById.get(rootParentId).replies.push(comment);
-    }
-    else {
-        roots.push(comment);
-    }
-} const hasLiveDescendant = (node: any) => node.replies.some((reply: any) => !reply.isDeleted || hasLiveDescendant(reply)); const collapseDeletedNodes = (nodes: any[]) => nodes.reduce((acc: any[], node: any) => { const nextNode = { ...node, replies: collapseDeletedNodes(node.replies), }; if (nextNode.isDeleted) {
-    if (hasLiveDescendant(nextNode)) {
-        acc.push(nextNode);
-    }
-    return acc;
-} acc.push(nextNode); return acc; }, []); return collapseDeletedNodes(roots); } function mapReviewRows(feedRows: any[], commentRows: any[], likeRows: any[], usersById: Map<any, any>, placesByPositionId: Map<any, any>, stampRowsById: Map<any, any>, routeRows: any[] = [], likedFeedIds = new Set<any>()) { const commentsByFeedId = new Map(); for (const row of commentRows) {
-    const feedId = String(row.feed_id);
-    if (!commentsByFeedId.has(feedId)) {
-        commentsByFeedId.set(feedId, []);
-    }
-    commentsByFeedId.get(feedId).push(row);
-} const likesByFeedId = new Map(); for (const row of likeRows) {
-    const feedId = String(row.feed_id);
-    likesByFeedId.set(feedId, (likesByFeedId.get(feedId) ?? 0) + 1);
-} const publishedRouteIdBySession = new Map(routeRows.filter((row) => row.travel_session_id).map((row) => [String(row.travel_session_id), String(row.route_id)])); return feedRows.map((row) => { const place = placesByPositionId.get(String(row.position_id)); const stamp = row.stamp_id ? stampRowsById.get(String(row.stamp_id)) : null; const reviewComments = buildCommentTree(commentsByFeedId.get(String(row.feed_id)) ?? [], usersById); const visitNumber = stamp?.visit_ordinal ?? 1; const travelSessionId = stamp?.travel_session_id ? String(stamp.travel_session_id) : null; return { id: String(row.feed_id), userId: row.user_id, placeId: place?.id ?? String(row.position_id), placeName: place?.name ?? '장소 정보 없음', author: usersById.get(row.user_id)?.nickname ?? '이름 없음', body: row.body, mood: row.mood, badge: row.badge, visitedAt: formatDateTime(row.created_at), imageUrl: row.image_url ?? null, commentCount: countComments(reviewComments), likeCount: likesByFeedId.get(String(row.feed_id)) ?? 0, likedByMe: likedFeedIds.has(String(row.feed_id)), stampId: row.stamp_id ? String(row.stamp_id) : null, visitNumber, visitLabel: formatVisitLabel(visitNumber), travelSessionId, hasPublishedRoute: travelSessionId ? publishedRouteIdBySession.has(travelSessionId) : false, comments: reviewComments, }; }); } async function loadReviewData(env: any, sessionUserId: string | null = null, filters: any = {}) { const { placeRows } = await loadStaticBaseRows(env); const places = placeRows.map(mapPlace); const placesByPositionId = new Map(places.map((place) => [place.positionId, place])); const placeIdToPositionId = new Map(places.map((place) => [place.id, place.positionId])); const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc',]; if (filters.placeId) {
-    const positionId = placeIdToPositionId.get(filters.placeId);
-    if (!positionId) {
-        return [];
-    }
-    reviewQuery.push(`position_id=eq.${encodeFilterValue(positionId)}`);
-} if (filters.userId) {
-    reviewQuery.push(`user_id=eq.${encodeFilterValue(filters.userId)}`);
-} const feedRows = await supabaseRequest(env, `feed?${reviewQuery.join('&')}`); const feedIdsFilter = buildInFilter(feedRows.map((row) => row.feed_id)); const reviewStampIdsFilter = buildInFilter(feedRows.map((row) => row.stamp_id).filter(Boolean)); const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([feedIdsFilter ? supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`) : Promise.resolve([]), feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]), reviewStampIdsFilter ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`) : Promise.resolve([]), sessionUserId && feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`) : Promise.resolve([]),]); const reviewTravelSessionIds = [...new Set((reviewStampRows ?? []).map((row) => row.travel_session_id).filter(Boolean).map((value) => String(value))),]; const reviewRouteRows = reviewTravelSessionIds.length > 0 ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`) : []; const userIdsFilter = buildInFilter([...feedRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]); const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : []; const usersById = new Map(userRows.map((row) => [row.user_id, row])); const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row])); const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id))); return mapReviewRows(feedRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds); } async function loadReviewPageData(env: any, sessionUserId: string | null = null, options: any = {}) { const { cursor = null, limit = 10 } = options; const { placeRows } = await loadStaticBaseRows(env); const places = placeRows.map(mapPlace); const placesByPositionId = new Map(places.map((place) => [place.positionId, place])); const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc', `limit=${limit + 1}`,]; if (cursor) {
-    reviewQuery.push(`created_at=lt.${encodeFilterValue(cursor)}`);
-} const feedRows = await supabaseRequest(env, `feed?${reviewQuery.join('&')}`); const nextCursor = feedRows.length > limit ? String(feedRows[limit].created_at) : null; const pageRows = feedRows.slice(0, limit); const feedIdsFilter = buildInFilter(pageRows.map((row) => row.feed_id)); const reviewStampIdsFilter = buildInFilter(pageRows.map((row) => row.stamp_id).filter(Boolean)); const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([feedIdsFilter ? supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`) : Promise.resolve([]), feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]), reviewStampIdsFilter ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`) : Promise.resolve([]), sessionUserId && feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`) : Promise.resolve([]),]); const reviewTravelSessionIds = [...new Set((reviewStampRows ?? []).map((row) => row.travel_session_id).filter(Boolean).map((value) => String(value))),]; const reviewRouteRows = reviewTravelSessionIds.length > 0 ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`) : []; const userIdsFilter = buildInFilter([...pageRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]); const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : []; const usersById = new Map(userRows.map((row) => [row.user_id, row])); const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row])); const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id))); return { items: mapReviewRows(pageRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds), nextCursor, }; } async function loadSingleReview(env, reviewId, sessionUserId = null) { const reviewRows = await supabaseRequest(env, `feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`); const reviewRow = reviewRows?.[0] ?? null; if (!reviewRow) {
-    return null;
-} const [commentRows, likeRows, placeRows, stampRows, userFeedLikeRows = []] = await Promise.all([supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&order=created_at.asc`), supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}`), supabaseRequest(env, `map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&position_id=eq.${encodeFilterValue(reviewRow.position_id)}&limit=1`), reviewRow.stamp_id ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=eq.${encodeFilterValue(reviewRow.stamp_id)}&limit=1`) : Promise.resolve([]), sessionUserId ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`) : Promise.resolve([]),]); const reviewTravelSessionIds = [...new Set((stampRows ?? []).map((row) => row.travel_session_id).filter(Boolean).map((value) => String(value))),]; const reviewRouteRows = reviewTravelSessionIds.length > 0 ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`) : []; const userIdsFilter = buildInFilter([reviewRow.user_id, ...commentRows.map((row) => row.user_id)]); const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : []; const places = placeRows.map(mapPlace); const placesByPositionId = new Map(places.map((place) => [place.positionId, place])); const usersById = new Map(userRows.map((row) => [row.user_id, row])); const stampRowsById = new Map((stampRows ?? []).map((row) => [String(row.stamp_id), row])); const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id))); return (mapReviewRows([reviewRow], commentRows ?? [], likeRows ?? [], usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds)[0] ?? null); } async function handleReviews(request, env, url) { const sessionUser = await readSessionUser(request, env); const reviews = await loadReviewData(env, sessionUser?.id ?? null, { placeId: url.searchParams.get('placeId') ?? undefined, userId: url.searchParams.get('userId') ?? undefined, }); return jsonResponse(200, reviews, env, request); } async function handleReviewFeed(request, env, url) { const sessionUser = await readSessionUser(request, env); const payload = await loadReviewPageData(env, sessionUser?.id ?? null, { cursor: url.searchParams.get('cursor') ?? null, limit: parseListLimit(url, 10, 20), }); return jsonResponse(200, payload, env, request); } async function handleReviewDetail(request, env, reviewId) { const sessionUser = await readSessionUser(request, env); const review = await loadSingleReview(env, reviewId, sessionUser?.id ?? null); if (!review) {
-    return jsonResponse(404, { detail: '리뷰를 찾을 수 없어요.' }, env, request);
-} return jsonResponse(200, review, env, request); } return { countComments, buildCommentTree, handleReviewDetail, handleReviewFeed, handleReviews, loadReviewData, loadReviewPageData, loadSingleReview, mapReviewRows, }; }
+import { createReviewMapper } from './review-domain/mapper';
 
+export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, mapPlace }: any) {
+  const { buildCommentTree, countComments, mapReviewRows } = createReviewMapper(formatVisitLabel);
+
+  async function loadReviewData(env: any, sessionUserId: string | null = null, filters: any = {}) {
+    const { placeRows } = await loadStaticBaseRows(env);
+    const places = placeRows.map(mapPlace);
+    const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
+    const placeIdToPositionId = new Map(places.map((place) => [place.id, place.positionId]));
+    const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc'];
+    if (filters.placeId) {
+      const positionId = placeIdToPositionId.get(filters.placeId);
+      if (!positionId) {
+        return [];
+      }
+      reviewQuery.push(`position_id=eq.${encodeFilterValue(positionId)}`);
+    }
+    if (filters.userId) {
+      reviewQuery.push(`user_id=eq.${encodeFilterValue(filters.userId)}`);
+    }
+
+    const feedRows = await supabaseRequest(env, `feed?${reviewQuery.join('&')}`);
+    const feedIdsFilter = buildInFilter(feedRows.map((row) => row.feed_id));
+    const reviewStampIdsFilter = buildInFilter(feedRows.map((row) => row.stamp_id).filter(Boolean));
+    const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
+      feedIdsFilter
+        ? supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
+        : Promise.resolve([]),
+      feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
+      reviewStampIdsFilter
+        ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
+        : Promise.resolve([]),
+      sessionUserId && feedIdsFilter
+        ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
+        : Promise.resolve([]),
+    ]);
+    const reviewTravelSessionIds = [
+      ...new Set(
+        (reviewStampRows ?? [])
+          .map((row) => row.travel_session_id)
+          .filter(Boolean)
+          .map((value) => String(value)),
+      ),
+    ];
+    const reviewRouteRows =
+      reviewTravelSessionIds.length > 0
+        ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        : [];
+    const userIdsFilter = buildInFilter([...feedRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
+    const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
+    const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
+    return mapReviewRows(feedRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds);
+  }
+
+  async function loadReviewPageData(env: any, sessionUserId: string | null = null, options: any = {}) {
+    const { cursor = null, limit = 10 } = options;
+    const { placeRows } = await loadStaticBaseRows(env);
+    const places = placeRows.map(mapPlace);
+    const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
+    const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc', `limit=${limit + 1}`];
+    if (cursor) {
+      reviewQuery.push(`created_at=lt.${encodeFilterValue(cursor)}`);
+    }
+
+    const feedRows = await supabaseRequest(env, `feed?${reviewQuery.join('&')}`);
+    const nextCursor = feedRows.length > limit ? String(feedRows[limit].created_at) : null;
+    const pageRows = feedRows.slice(0, limit);
+    const feedIdsFilter = buildInFilter(pageRows.map((row) => row.feed_id));
+    const reviewStampIdsFilter = buildInFilter(pageRows.map((row) => row.stamp_id).filter(Boolean));
+    const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
+      feedIdsFilter
+        ? supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
+        : Promise.resolve([]),
+      feedIdsFilter ? supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
+      reviewStampIdsFilter
+        ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
+        : Promise.resolve([]),
+      sessionUserId && feedIdsFilter
+        ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
+        : Promise.resolve([]),
+    ]);
+    const reviewTravelSessionIds = [
+      ...new Set(
+        (reviewStampRows ?? [])
+          .map((row) => row.travel_session_id)
+          .filter(Boolean)
+          .map((value) => String(value)),
+      ),
+    ];
+    const reviewRouteRows =
+      reviewTravelSessionIds.length > 0
+        ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        : [];
+    const userIdsFilter = buildInFilter([...pageRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
+    const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
+    const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
+    return { items: mapReviewRows(pageRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds), nextCursor };
+  }
+
+  async function loadSingleReview(env: any, reviewId: string, sessionUserId: string | null = null) {
+    const reviewRows = await supabaseRequest(
+      env,
+      `feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`,
+    );
+    const reviewRow = reviewRows?.[0] ?? null;
+    if (!reviewRow) {
+      return null;
+    }
+    const [commentRows, likeRows, placeRows, stampRows, userFeedLikeRows = []] = await Promise.all([
+      supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&order=created_at.asc`),
+      supabaseRequest(env, `feed_like?select=feed_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}`),
+      supabaseRequest(
+        env,
+        `map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&position_id=eq.${encodeFilterValue(reviewRow.position_id)}&limit=1`,
+      ),
+      reviewRow.stamp_id
+        ? supabaseRequest(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=eq.${encodeFilterValue(reviewRow.stamp_id)}&limit=1`)
+        : Promise.resolve([]),
+      sessionUserId ? supabaseRequest(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`) : Promise.resolve([]),
+    ]);
+    const reviewTravelSessionIds = [
+      ...new Set(
+        (stampRows ?? [])
+          .map((row) => row.travel_session_id)
+          .filter(Boolean)
+          .map((value) => String(value)),
+      ),
+    ];
+    const reviewRouteRows =
+      reviewTravelSessionIds.length > 0
+        ? await supabaseRequest(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        : [];
+    const userIdsFilter = buildInFilter([reviewRow.user_id, ...commentRows.map((row) => row.user_id)]);
+    const userRows = userIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const places = placeRows.map(mapPlace);
+    const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
+    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const stampRowsById = new Map((stampRows ?? []).map((row) => [String(row.stamp_id), row]));
+    const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
+    return mapReviewRows([reviewRow], commentRows ?? [], likeRows ?? [], usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds)[0] ?? null;
+  }
+
+  async function handleReviews(request: Request, env: any, url: URL) {
+    const sessionUser = await readSessionUser(request, env);
+    const reviews = await loadReviewData(env, sessionUser?.id ?? null, {
+      placeId: url.searchParams.get('placeId') ?? undefined,
+      userId: url.searchParams.get('userId') ?? undefined,
+    });
+    return jsonResponse(200, reviews, env, request);
+  }
+
+  async function handleReviewFeed(request: Request, env: any, url: URL) {
+    const sessionUser = await readSessionUser(request, env);
+    const payload = await loadReviewPageData(env, sessionUser?.id ?? null, {
+      cursor: url.searchParams.get('cursor') ?? null,
+      limit: parseListLimit(url, 10, 20),
+    });
+    return jsonResponse(200, payload, env, request);
+  }
+
+  async function handleReviewDetail(request: Request, env: any, reviewId: string) {
+    const sessionUser = await readSessionUser(request, env);
+    const review = await loadSingleReview(env, reviewId, sessionUser?.id ?? null);
+    if (!review) {
+      return jsonResponse(404, { detail: '리뷰를 찾을 수 없어요.' }, env, request);
+    }
+    return jsonResponse(200, review, env, request);
+  }
+
+  return {
+    buildCommentTree,
+    countComments,
+    handleReviewDetail,
+    handleReviewFeed,
+    handleReviews,
+    loadReviewData,
+    loadReviewPageData,
+    loadSingleReview,
+    mapReviewRows,
+  };
+}

--- a/test/unit/worker-review-domain.test.ts
+++ b/test/unit/worker-review-domain.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  handleCreateComment,
+  handleToggleReviewLike,
+  handleUpdateReview,
+} from '../../deploy/api-worker-shell/services/review-interactions';
+import type { WorkerEnv, WorkerReviewInteractionDeps, WorkerSessionUser } from '../../deploy/api-worker-shell/types';
+
+const supabaseMock = vi.hoisted(() => ({
+  encodeFilterValue: (value: unknown) => encodeURIComponent(String(value)),
+  getSupabaseKey: vi.fn(() => 'service-role-key'),
+  supabaseRequest: vi.fn(),
+}));
+
+vi.mock('../../deploy/api-worker-shell/lib/supabase', () => supabaseMock);
+
+const env: WorkerEnv = {
+  APP_FRONTEND_URL: 'https://daejeon.jamissue.com',
+  APP_SUPABASE_URL: 'https://supabase.example',
+};
+
+const sessionUser: WorkerSessionUser = {
+  id: 'actor',
+  nickname: 'Actor',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+};
+
+function createDeps(overrides: Partial<WorkerReviewInteractionDeps> = {}): WorkerReviewInteractionDeps {
+  return {
+    badgeByMood: { 설렘: '첫 방문' },
+    countUnreadNotifications: vi.fn(async () => 1),
+    createUserNotification: vi.fn(async () => ({ notification_id: 88 })),
+    loadBaseData: vi.fn(async () => ({
+      places: [],
+      placesByPositionId: new Map(),
+      reviews: [],
+      courses: [],
+      collectedPlaceIds: [],
+      stampLogs: [],
+      travelSessions: [],
+    })),
+    loadNotificationById: vi.fn(async () => ({ id: '88', title: 'notice' })),
+    loadSingleReview: vi.fn(async () => ({ id: '1', comments: [{ id: '22' }] })),
+    publishNotificationEvent: vi.fn(async () => undefined),
+    readSessionUser: vi.fn(async () => sessionUser),
+    ...overrides,
+  };
+}
+
+async function readJson(response: Response) {
+  return (await response.json()) as Record<string, any>;
+}
+
+describe('worker review domain service boundaries', () => {
+  beforeEach(() => {
+    supabaseMock.supabaseRequest.mockReset();
+  });
+
+  it('keeps review owner checks before update persistence', async () => {
+    supabaseMock.supabaseRequest.mockResolvedValueOnce([{ feed_id: 1, position_id: 101, user_id: 'owner' }]);
+    const deps = createDeps();
+
+    const response = await handleUpdateReview(
+      new Request('https://api.daejeon.jamissue.com/api/reviews/1', {
+        method: 'PATCH',
+        body: JSON.stringify({ body: 'updated', mood: '설렘' }),
+      }),
+      env,
+      '1',
+      deps,
+    );
+
+    expect(response.status).toBe(403);
+    expect(await readJson(response)).toEqual({ detail: '내가 쓴 피드만 수정할 수 있어요.' });
+    expect(deps.loadSingleReview).not.toHaveBeenCalled();
+    expect(supabaseMock.supabaseRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('publishes review-owner notifications when a comment is created', async () => {
+    supabaseMock.supabaseRequest.mockImplementation(async (_env, path: string) => {
+      if (path.startsWith('feed?select=')) {
+        return [{ feed_id: 1, position_id: 101, user_id: 'owner' }];
+      }
+      if (path === 'user_comment?select=comment_id') {
+        return [{ comment_id: 22 }];
+      }
+      return [];
+    });
+    const deps = createDeps();
+
+    const response = await handleCreateComment(
+      new Request('https://api.daejeon.jamissue.com/api/reviews/1/comments', {
+        method: 'POST',
+        body: JSON.stringify({ body: '좋아요' }),
+      }),
+      env,
+      '1',
+      deps,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual([{ id: '22' }]);
+    expect(deps.createUserNotification).toHaveBeenCalledWith(
+      env,
+      expect.objectContaining({
+        userId: 'owner',
+        actorUserId: 'actor',
+        type: 'review-comment',
+        reviewId: '1',
+        commentId: 22,
+      }),
+    );
+    expect(deps.publishNotificationEvent).toHaveBeenCalledWith(
+      env,
+      'owner',
+      'notification.created',
+      expect.objectContaining({ unreadCount: 1 }),
+    );
+  });
+
+  it('toggles review likes through the repository boundary', async () => {
+    supabaseMock.supabaseRequest
+      .mockResolvedValueOnce([{ feed_id: 1, position_id: 101, user_id: 'owner' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{ feed_like_id: 44 }])
+      .mockResolvedValueOnce([{ feed_like_id: 44 }, { feed_like_id: 45 }]);
+
+    const response = await handleToggleReviewLike(
+      new Request('https://api.daejeon.jamissue.com/api/reviews/1/like', { method: 'POST' }),
+      env,
+      '1',
+      createDeps(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual({ reviewId: '1', likeCount: 2, likedByMe: true });
+  });
+});

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -58,4 +58,16 @@ describe('worker source quality gates', () => {
     expect(assemblerSource).not.toContain('supabaseRequest');
     expect(repositorySource).toContain('supabaseRequest');
   });
+
+  it('keeps review interaction persistence behind the review repository boundary', () => {
+    const interactionSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/review-interactions.ts'), 'utf8');
+    const repositorySource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/review-domain/repository.ts'), 'utf8');
+    const reviewReadSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/reviews.ts'), 'utf8');
+
+    expect(interactionSource).not.toContain('supabaseRequest');
+    expect(interactionSource).not.toContain('feed?select=');
+    expect(reviewReadSource).toContain("import { createReviewMapper } from './review-domain/mapper';");
+    expect(reviewReadSource).not.toContain('function mapReviewRows');
+    expect(repositorySource).toContain('supabaseRequest');
+  });
 });


### PR DESCRIPTION
﻿## Summary
- split review write/comment/like persistence into `services/review-domain/repository.ts`
- split review notification side effects into `services/review-domain/notifications.ts`
- split review DTO/comment-tree mapping into `services/review-domain/mapper.ts`
- keep review handlers focused on session/permission validation and use-case flow
- add unit tests for owner 403, comment notification side effects, and like toggle persistence flow

## Contract Safety
- External REST API paths: unchanged
- Response shape: unchanged
- DB schema: unchanged
- User-facing copy: unchanged
- Kakao/Naver REST OAuth success path: unchanged

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`
- [x] `git diff --cached --check`

Closes #203
