### PR TITLE
Split Worker account community admin boundaries

### DIFF
--- a/deploy/api-worker-shell/services/admin-domain/repository.ts
+++ b/deploy/api-worker-shell/services/admin-domain/repository.ts
@@ -1,0 +1,60 @@
+import { encodeFilterValue, getSupabaseKey, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+
+export async function supabaseCount(env: WorkerEnv, table: string) {
+  if (!env.APP_SUPABASE_URL) {
+    throw new Error('APP_SUPABASE_URL is empty.');
+  }
+  const apiKey = getSupabaseKey(env);
+  if (!apiKey) {
+    throw new Error('Supabase API key is missing.');
+  }
+  const response = await fetch(`${env.APP_SUPABASE_URL}/rest/v1/${table}?select=*`, {
+    method: 'HEAD',
+    headers: { apikey: apiKey, Authorization: `Bearer ${apiKey}`, Prefer: 'count=exact' },
+  });
+  if (!response.ok) {
+    const detail = await response.text();
+    throw new Error(`Supabase count failed (${response.status}): ${detail}`);
+  }
+  const contentRange = response.headers.get('content-range') ?? '0-0/0';
+  const total = Number(contentRange.split('/')[1] ?? '0');
+  return Number.isFinite(total) ? total : 0;
+}
+
+export async function loadAdminSummaryRows(env: WorkerEnv) {
+  const [userCount, placeCount, reviewCount, commentCount, stampCount, placeRows, feedRows] = await Promise.all([
+    supabaseCount(env, 'user'),
+    supabaseCount(env, 'map'),
+    supabaseCount(env, 'feed'),
+    supabaseCount(env, 'user_comment'),
+    supabaseCount(env, 'user_stamp'),
+    supabaseRequest<WorkerJsonRecord[]>(
+      env,
+      'map?select=position_id,slug,name,district,category,is_active,is_manual_override,updated_at&order=is_active.desc,name.asc',
+    ),
+    supabaseRequest<WorkerJsonRecord[]>(env, 'feed?select=position_id'),
+  ]);
+
+  return { userCount, placeCount, reviewCount, commentCount, stampCount, placeRows, feedRows };
+}
+
+export async function updateAdminPlaceVisibility(env: WorkerEnv, placeId: string, body: WorkerJsonRecord) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(env, `map?slug=eq.${encodeFilterValue(placeId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(body),
+  });
+  return Array.isArray(rows) ? rows[0] ?? null : null;
+}
+
+export async function loadPlaceReviewRows(env: WorkerEnv, positionId: string | number) {
+  return supabaseRequest<WorkerJsonRecord[]>(env, `feed?select=feed_id&position_id=eq.${encodeFilterValue(positionId)}`);
+}
+
+export async function loadPublicDataSource(env: WorkerEnv, sourceKey: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(sourceKey)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}

--- a/deploy/api-worker-shell/services/admin.ts
+++ b/deploy/api-worker-shell/services/admin.ts
@@ -1,31 +1,118 @@
 import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
-import { encodeFilterValue, getSupabaseKey, supabaseRequest } from '../lib/supabase';
 import { readSessionUser } from './auth';
-async function supabaseCount(env: any, table: string) { if (!env.APP_SUPABASE_URL) {
-    throw new Error('APP_SUPABASE_URL is empty.');
-} const apiKey = getSupabaseKey(env); if (!apiKey) {
-    throw new Error('Supabase API key is missing.');
-} const response = await fetch(`${env.APP_SUPABASE_URL}/rest/v1/${table}?select=*`, { method: 'HEAD', headers: { apikey: apiKey, Authorization: `Bearer ${apiKey}`, Prefer: 'count=exact', }, }); if (!response.ok) {
-    const detail = await response.text();
-    throw new Error(`Supabase count failed (${response.status}): ${detail}`);
-} const contentRange = response.headers.get('content-range') ?? '0-0/0'; const total = Number(contentRange.split('/')[1] ?? '0'); return Number.isFinite(total) ? total : 0; }
-export function createAdminService({ normalizePlaceCategory }: {
-    normalizePlaceCategory: (category: any, slug?: string) => string;
-}) { async function requireAdmin(request: Request, env: any) { const sessionUser = await readSessionUser(request, env); if (!sessionUser || !sessionUser.isAdmin) {
-    return { response: jsonResponse(403, { detail: '관리자만 접근할 수 있어요.' }, env, request) };
-} return { sessionUser }; } async function buildAdminSummary(env: any) { const [userCount, placeCount, reviewCount, commentCount, stampCount, placeRows, feedRows] = await Promise.all([supabaseCount(env, 'user'), supabaseCount(env, 'map'), supabaseCount(env, 'feed'), supabaseCount(env, 'user_comment'), supabaseCount(env, 'user_stamp'), supabaseRequest(env, 'map?select=position_id,slug,name,district,category,is_active,is_manual_override,updated_at&order=is_active.desc,name.asc'), supabaseRequest(env, 'feed?select=position_id'),]); const reviewCountByPosition = new Map(); for (const row of feedRows ?? []) {
-    const key = String(row.position_id);
-    reviewCountByPosition.set(key, (reviewCountByPosition.get(key) ?? 0) + 1);
-} return { userCount, placeCount, reviewCount, commentCount, stampCount, sourceReady: true, places: (placeRows ?? []).map((row) => ({ id: row.slug, name: row.name, district: row.district, category: normalizePlaceCategory(row.category, row.slug), isActive: Boolean(row.is_active), isManualOverride: Boolean(row.is_manual_override), reviewCount: reviewCountByPosition.get(String(row.position_id)) ?? 0, updatedAt: formatDateTime(row.updated_at), })), }; } async function handleAdminSummary(request: Request, env: any) { const auth = await requireAdmin(request, env); if (auth.response) {
-    return auth.response;
-} return jsonResponse(200, await buildAdminSummary(env), env, request); } async function handleAdminPlaceVisibility(request: Request, env: any, placeId: string) { const auth = await requireAdmin(request, env); if (auth.response) {
-    return auth.response;
-} const payload = await request.json().catch(() => null); const body: Record<string, unknown> = {}; if (typeof payload?.isActive === 'boolean')
-    body.is_active = payload.isActive; if (typeof payload?.isManualOverride === 'boolean')
-    body.is_manual_override = payload.isManualOverride; body.updated_at = new Date().toISOString(); const updatedRows = await supabaseRequest(env, `map?slug=eq.${encodeFilterValue(placeId)}`, { method: 'PATCH', body: JSON.stringify(body), }); const updatedRow = Array.isArray(updatedRows) ? updatedRows[0] : null; if (!updatedRow) {
-    return jsonResponse(404, { detail: '장소를 찾을 수 없어요.' }, env, request);
-} const reviewRows = await supabaseRequest(env, `feed?select=feed_id&position_id=eq.${encodeFilterValue(updatedRow.position_id)}`); return jsonResponse(200, { id: updatedRow.slug, name: updatedRow.name, district: updatedRow.district, category: normalizePlaceCategory(updatedRow.category, updatedRow.slug), isActive: Boolean(updatedRow.is_active), isManualOverride: Boolean(updatedRow.is_manual_override), reviewCount: (reviewRows ?? []).length, updatedAt: formatDateTime(updatedRow.updated_at), }, env, request); } async function handleAdminImportPublicData(request: Request, env: any) { const auth = await requireAdmin(request, env); if (auth.response) {
-    return auth.response;
-} const sourceRows = await supabaseRequest(env, `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue('jamissue-public-event-feed')}&limit=1`); const source = sourceRows?.[0] ?? null; return jsonResponse(200, { importedPlaces: 0, importedCourses: 0, importedEvents: 0, mode: 'scheduled', detail: '공공 행사는 GitHub Actions 주간 작업으로 처리돼요.', importedAt: source?.last_imported_at ?? null, }, env, request); } return { handleAdminImportPublicData, handleAdminPlaceVisibility, handleAdminSummary, }; }
+import {
+  loadAdminSummaryRows,
+  loadPlaceReviewRows,
+  loadPublicDataSource,
+  updateAdminPlaceVisibility,
+} from './admin-domain/repository';
 
+export function createAdminService({ normalizePlaceCategory }: {
+  normalizePlaceCategory: (category: any, slug?: string) => string;
+}) {
+  async function requireAdmin(request: Request, env: any) {
+    const sessionUser = await readSessionUser(request, env);
+    if (!sessionUser || !sessionUser.isAdmin) {
+      return { response: jsonResponse(403, { detail: '관리자만 접근할 수 있어요.' }, env, request) };
+    }
+    return { sessionUser };
+  }
+
+  async function buildAdminSummary(env: any) {
+    const { userCount, placeCount, reviewCount, commentCount, stampCount, placeRows, feedRows } = await loadAdminSummaryRows(env);
+    const reviewCountByPosition = new Map();
+    for (const row of feedRows ?? []) {
+      const key = String(row.position_id);
+      reviewCountByPosition.set(key, (reviewCountByPosition.get(key) ?? 0) + 1);
+    }
+    return {
+      userCount,
+      placeCount,
+      reviewCount,
+      commentCount,
+      stampCount,
+      sourceReady: true,
+      places: (placeRows ?? []).map((row) => ({
+        id: row.slug,
+        name: row.name,
+        district: row.district,
+        category: normalizePlaceCategory(String(row.category), row.slug ? String(row.slug) : undefined),
+        isActive: Boolean(row.is_active),
+        isManualOverride: Boolean(row.is_manual_override),
+        reviewCount: reviewCountByPosition.get(String(row.position_id)) ?? 0,
+        updatedAt: formatDateTime(row.updated_at),
+      })),
+    };
+  }
+
+  async function handleAdminSummary(request: Request, env: any) {
+    const auth = await requireAdmin(request, env);
+    if (auth.response) {
+      return auth.response;
+    }
+    return jsonResponse(200, await buildAdminSummary(env), env, request);
+  }
+
+  async function handleAdminPlaceVisibility(request: Request, env: any, placeId: string) {
+    const auth = await requireAdmin(request, env);
+    if (auth.response) {
+      return auth.response;
+    }
+
+    const payload = await request.json().catch(() => null);
+    const body: Record<string, unknown> = {};
+    if (typeof payload?.isActive === 'boolean') {
+      body.is_active = payload.isActive;
+    }
+    if (typeof payload?.isManualOverride === 'boolean') {
+      body.is_manual_override = payload.isManualOverride;
+    }
+    body.updated_at = new Date().toISOString();
+
+    const updatedRow = await updateAdminPlaceVisibility(env, placeId, body);
+    if (!updatedRow) {
+      return jsonResponse(404, { detail: '장소를 찾을 수 없어요.' }, env, request);
+    }
+
+    const reviewRows = await loadPlaceReviewRows(env, updatedRow.position_id as string | number);
+    return jsonResponse(
+      200,
+      {
+        id: updatedRow.slug,
+        name: updatedRow.name,
+        district: updatedRow.district,
+        category: normalizePlaceCategory(String(updatedRow.category), updatedRow.slug ? String(updatedRow.slug) : undefined),
+        isActive: Boolean(updatedRow.is_active),
+        isManualOverride: Boolean(updatedRow.is_manual_override),
+        reviewCount: (reviewRows ?? []).length,
+        updatedAt: formatDateTime(updatedRow.updated_at),
+      },
+      env,
+      request,
+    );
+  }
+
+  async function handleAdminImportPublicData(request: Request, env: any) {
+    const auth = await requireAdmin(request, env);
+    if (auth.response) {
+      return auth.response;
+    }
+    const source = await loadPublicDataSource(env, 'jamissue-public-event-feed');
+    return jsonResponse(
+      200,
+      {
+        importedPlaces: 0,
+        importedCourses: 0,
+        importedEvents: 0,
+        mode: 'scheduled',
+        detail: '공공 행사는 GitHub Actions 주간 작업으로 처리돼요.',
+        importedAt: source?.last_imported_at ?? null,
+      },
+      env,
+      request,
+    );
+  }
+
+  return { handleAdminImportPublicData, handleAdminPlaceVisibility, handleAdminSummary };
+}

--- a/deploy/api-worker-shell/services/community-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/community-domain/mapper.ts
@@ -1,0 +1,45 @@
+import { formatDateTime } from '../../lib/dates';
+
+export function mapCommunityRoutes(
+  routeRows: any[],
+  routePlaceRows: any[],
+  usersById: Map<any, any>,
+  placesByPositionId: Map<any, any>,
+  likedRouteIds = new Set<any>(),
+) {
+  const placeRowsByRouteId = new Map();
+  for (const row of routePlaceRows) {
+    const routeId = String(row.route_id);
+    if (!placeRowsByRouteId.has(routeId)) {
+      placeRowsByRouteId.set(routeId, []);
+    }
+    placeRowsByRouteId.get(routeId).push({ stopOrder: row.stop_order, placeId: placesByPositionId.get(String(row.position_id))?.id ?? String(row.position_id) });
+  }
+
+  return routeRows.map((row) => {
+    const placeRows = (placeRowsByRouteId.get(String(row.route_id)) ?? []).sort((left, right) => left.stopOrder - right.stopOrder);
+    const placeIds = placeRows.map((item) => item.placeId);
+    return {
+      id: String(row.route_id),
+      authorId: row.user_id,
+      author: usersById.get(row.user_id)?.nickname ?? '이름 없음',
+      title: row.title,
+      description: row.description,
+      mood: row.mood,
+      likeCount: row.like_count ?? 0,
+      likedByMe: likedRouteIds.has(String(row.route_id)),
+      createdAt: formatDateTime(row.created_at),
+      placeIds,
+      placeNames: placeIds.map((placeId) => {
+        for (const place of placesByPositionId.values()) {
+          if (place.id === placeId) {
+            return place.name;
+          }
+        }
+        return placeId;
+      }),
+      isUserGenerated: row.is_user_generated ?? false,
+      travelSessionId: row.travel_session_id ? String(row.travel_session_id) : null,
+    };
+  });
+}

--- a/deploy/api-worker-shell/services/community-domain/repository.ts
+++ b/deploy/api-worker-shell/services/community-domain/repository.ts
@@ -1,0 +1,110 @@
+import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+
+export async function readRouteRow(env: WorkerEnv, routeId: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_route?select=route_id,user_id,like_count&route_id=eq.${encodeFilterValue(routeId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function loadRouteRows(env: WorkerEnv, options: { sort?: string; ownerUserId?: string | null }) {
+  const { sort = 'popular', ownerUserId = null } = options;
+  const routeFilter = ownerUserId
+    ? `user_id=eq.${encodeFilterValue(ownerUserId)}&order=created_at.desc`
+    : `is_public=eq.true&order=${sort === 'popular' ? 'like_count.desc,created_at.desc' : 'created_at.desc'}`;
+  return supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_route?select=route_id,user_id,travel_session_id,title,description,mood,like_count,created_at,is_public,is_user_generated&${routeFilter}`,
+  );
+}
+
+export async function loadRouteDetailRows(env: WorkerEnv, routeRows: WorkerJsonRecord[], sessionUserId: string | null) {
+  const routeIdsFilter = buildInFilter(routeRows.map((row: any) => row.route_id));
+  if (!routeIdsFilter) {
+    return { routePlaceRows: [], userRouteLikeRows: [], userRows: [] };
+  }
+
+  const [routePlaceRows, userRouteLikeRows = []] = await Promise.all([
+    supabaseRequest<WorkerJsonRecord[]>(env, `user_route_place?select=route_id,position_id,stop_order&route_id=${routeIdsFilter}&order=stop_order.asc`),
+    sessionUserId
+      ? supabaseRequest<WorkerJsonRecord[]>(env, `user_route_like?select=route_id&user_id=eq.${encodeFilterValue(sessionUserId)}&route_id=${routeIdsFilter}`)
+      : Promise.resolve([]),
+  ]);
+  const userIdsFilter = buildInFilter(routeRows.map((row: any) => row.user_id));
+  const userRows = userIdsFilter ? await supabaseRequest<WorkerJsonRecord[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+  return { routePlaceRows, userRouteLikeRows, userRows };
+}
+
+export async function readTravelSessionForOwner(env: WorkerEnv, travelSessionId: string, userId: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `travel_session?select=travel_session_id,user_id&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&user_id=eq.${encodeFilterValue(userId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function readExistingRouteForSession(env: WorkerEnv, travelSessionId: string, userId: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_route?select=route_id&user_id=eq.${encodeFilterValue(userId)}&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function loadSessionStampRows(env: WorkerEnv, travelSessionId: string, userId: string) {
+  return supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_stamp?select=position_id,created_at&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&user_id=eq.${encodeFilterValue(userId)}&order=created_at.asc`,
+  );
+}
+
+export async function createUserRoute(env: WorkerEnv, payload: WorkerJsonRecord) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(env, 'user_route?select=route_id', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+  return rows?.[0]?.route_id ?? null;
+}
+
+export async function createUserRoutePlaces(env: WorkerEnv, routeId: string | number, orderedPositionIds: string[]) {
+  await supabaseRequest(env, 'user_route_place?select=user_route_place_id', {
+    method: 'POST',
+    body: JSON.stringify(orderedPositionIds.map((positionId, index) => ({ route_id: Number(routeId), position_id: Number(positionId), stop_order: index + 1 }))),
+  });
+}
+
+export async function readRouteLikeRow(env: WorkerEnv, routeId: string, userId: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_route_like?select=route_like_id&route_id=eq.${encodeFilterValue(routeId)}&user_id=eq.${encodeFilterValue(userId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function createRouteLike(env: WorkerEnv, routeId: string, userId: string) {
+  await supabaseRequest(env, 'user_route_like?select=route_like_id', {
+    method: 'POST',
+    body: JSON.stringify({ route_id: Number(routeId), user_id: userId }),
+  });
+}
+
+export async function deleteRouteLike(env: WorkerEnv, routeLikeId: string | number) {
+  await supabaseRequest(env, `user_route_like?route_like_id=eq.${encodeFilterValue(routeLikeId)}`, {
+    method: 'DELETE',
+    headers: { Prefer: 'return=minimal' },
+  });
+}
+
+export async function countRouteLikes(env: WorkerEnv, routeId: string) {
+  const rows = await supabaseRequest<WorkerJsonRecord[]>(env, `user_route_like?select=route_like_id&route_id=eq.${encodeFilterValue(routeId)}`);
+  return rows.length;
+}
+
+export async function updateRouteLikeCount(env: WorkerEnv, routeId: string, likeCount: number) {
+  await supabaseRequest(env, `user_route?route_id=eq.${encodeFilterValue(routeId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ like_count: likeCount, updated_at: new Date().toISOString() }),
+  });
+}

--- a/deploy/api-worker-shell/services/community-routes.ts
+++ b/deploy/api-worker-shell/services/community-routes.ts
@@ -1,65 +1,175 @@
-import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
-import { buildInFilter, encodeFilterValue, supabaseRequest } from '../lib/supabase';
 import { readSessionUser } from './auth';
-import { countUnreadNotifications, createUserNotification, loadNotificationById, publishNotificationEvent, } from './notifications';
-export function createCommunityRouteService({ loadStaticBaseRows }: {
-    loadStaticBaseRows: (env: any) => Promise<any>;
-}) { function mapCommunityRoutes(routeRows: any[], routePlaceRows: any[], usersById: Map<any, any>, placesByPositionId: Map<any, any>, likedRouteIds = new Set<any>()) { const placeRowsByRouteId = new Map(); for (const row of routePlaceRows) {
-    const routeId = String(row.route_id);
-    if (!placeRowsByRouteId.has(routeId)) {
-        placeRowsByRouteId.set(routeId, []);
-    }
-    placeRowsByRouteId.get(routeId).push({ stopOrder: row.stop_order, placeId: placesByPositionId.get(String(row.position_id))?.id ?? String(row.position_id), });
-} return routeRows.map((row) => { const placeRows = (placeRowsByRouteId.get(String(row.route_id)) ?? []).sort((left, right) => left.stopOrder - right.stopOrder); const placeIds = placeRows.map((item) => item.placeId); return { id: String(row.route_id), authorId: row.user_id, author: usersById.get(row.user_id)?.nickname ?? '이름 없음', title: row.title, description: row.description, mood: row.mood, likeCount: row.like_count ?? 0, likedByMe: likedRouteIds.has(String(row.route_id)), createdAt: formatDateTime(row.created_at), placeIds, placeNames: placeIds.map((placeId) => { for (const place of placesByPositionId.values()) {
-        if (place.id === placeId) {
-            return place.name;
-        }
-    } return placeId; }), isUserGenerated: row.is_user_generated ?? false, travelSessionId: row.travel_session_id ? String(row.travel_session_id) : null, }; }); } async function requireSessionUser(request: Request, env: any) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
-    return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
-} return { sessionUser }; } async function readJsonBody(request: Request): Promise<any> { try {
-    return await request.json();
-}
-catch {
-    throw new Error('요청 형식이 올바르지 않아요.');
-} } async function readRouteRow(env: any, routeId: string) { const rows = await supabaseRequest(env, `user_route?select=route_id,user_id,like_count&route_id=eq.${encodeFilterValue(routeId)}&limit=1`); return rows?.[0] ?? null; } async function loadCommunityRoutes(env: any, options: any = {}) { const { sort = 'popular', sessionUserId = null, ownerUserId = null } = options; const routeFilter = ownerUserId ? `user_id=eq.${encodeFilterValue(ownerUserId)}&order=created_at.desc` : `is_public=eq.true&order=${sort === 'popular' ? 'like_count.desc,created_at.desc' : 'created_at.desc'}`; const routeRows = await supabaseRequest(env, `user_route?select=route_id,user_id,travel_session_id,title,description,mood,like_count,created_at,is_public,is_user_generated&${routeFilter}`); const routeIdsFilter = buildInFilter(routeRows.map((row) => row.route_id)); if (!routeIdsFilter) {
-    return [];
-} const [routePlaceRows, userRouteLikeRows = []] = await Promise.all([supabaseRequest(env, `user_route_place?select=route_id,position_id,stop_order&route_id=${routeIdsFilter}&order=stop_order.asc`), sessionUserId ? supabaseRequest(env, `user_route_like?select=route_id&user_id=eq.${encodeFilterValue(sessionUserId)}&route_id=${routeIdsFilter}`) : Promise.resolve([]),]); const userIdsFilter = buildInFilter(routeRows.map((row) => row.user_id)); const [{ placeRows }, userRows] = await Promise.all([loadStaticBaseRows(env), userIdsFilter ? supabaseRequest(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : Promise.resolve([]),]); const neededPositionIds = new Set(routePlaceRows.map((row) => String(row.position_id))); const placesByPositionId = new Map(placeRows.filter((row) => neededPositionIds.has(String(row.position_id))).map((row) => [String(row.position_id), { id: row.slug, name: row.name }])); const usersById = new Map(userRows.map((row) => [row.user_id, row])); const likedRouteIds = new Set(userRouteLikeRows.map((row) => String(row.route_id))); return mapCommunityRoutes(routeRows, routePlaceRows, usersById, placesByPositionId, likedRouteIds); } async function handleCommunityRoutes(request: Request, env: any, url: URL) { const sessionUser = await readSessionUser(request, env); const sort = url.searchParams.get('sort') === 'latest' ? 'latest' : 'popular'; const routes = await loadCommunityRoutes(env, { sort, sessionUserId: sessionUser?.id ?? null }); return jsonResponse(200, routes, env, request); } async function handleMyRoutes(request: Request, env: any) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
-    return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
-} return jsonResponse(200, await loadCommunityRoutes(env, { ownerUserId: sessionUser.id, sessionUserId: sessionUser.id }), env, request); } async function handleCreateUserRoute(request: Request, env: any) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const payload = await readJsonBody(request); const travelSessionId = String(payload.travelSessionId ?? '').trim(); const title = String(payload.title ?? '').trim(); const description = String(payload.description ?? '').trim(); const mood = String(payload.mood ?? '').trim(); const isPublic = payload.isPublic !== false; if (!travelSessionId) {
-    return jsonResponse(400, { detail: '방향을 묶을 여행 세션이 필요해요.' }, env, request);
-} if (!title) {
-    return jsonResponse(400, { detail: '경로 제목을 적어 주세요.' }, env, request);
-} if (!description) {
-    return jsonResponse(400, { detail: '한 줄 소개를 적어 주세요.' }, env, request);
-} const sessionRows = await supabaseRequest(env, `travel_session?select=travel_session_id,user_id&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&limit=1`); if (!sessionRows?.[0]) {
-    return jsonResponse(404, { detail: '여행 세션을 찾지 못했어요.' }, env, request);
-} const existingRouteRows = await supabaseRequest(env, `user_route?select=route_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&limit=1`); if (existingRouteRows?.[0]) {
-    return jsonResponse(409, { detail: '이미 발행된 여행 코스예요.' }, env, request);
-} const sessionStampRows = await supabaseRequest(env, `user_stamp?select=position_id,created_at&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&order=created_at.asc`); const orderedPositionIds = []; const seenPositionIds = new Set(); for (const stampRow of sessionStampRows ?? []) {
-    const positionId = String(stampRow.position_id);
-    if (seenPositionIds.has(positionId)) {
-        continue;
-    }
-    seenPositionIds.add(positionId);
-    orderedPositionIds.push(positionId);
-} if (orderedPositionIds.length < 2) {
-    return jsonResponse(400, { detail: '코스에는 최소 두 곳 이상의 스탬프 기록이 필요해요.' }, env, request);
-} const routeRows = await supabaseRequest(env, 'user_route?select=route_id', { method: 'POST', body: JSON.stringify({ user_id: sessionResult.sessionUser.id, travel_session_id: Number(travelSessionId), title, description, mood, is_public: isPublic, is_user_generated: true, like_count: 0, }), }); const routeId = routeRows?.[0]?.route_id; await supabaseRequest(env, 'user_route_place?select=user_route_place_id', { method: 'POST', body: JSON.stringify(orderedPositionIds.map((positionId, index) => ({ route_id: Number(routeId), position_id: Number(positionId), stop_order: index + 1, }))), }); const routes = await loadCommunityRoutes(env, { ownerUserId: sessionResult.sessionUser.id, sessionUserId: sessionResult.sessionUser.id }); const createdRoute = routes.find((route) => route.id === String(routeId)) ?? null; const createdNotification = await createUserNotification(env, { userId: sessionResult.sessionUser.id, actorUserId: sessionResult.sessionUser.id, type: 'route-published', title: '새로운 코스가 발행되었습니다.', body: title, routeId, metadata: { travelSessionId }, }); if (createdNotification?.notification_id) {
-    const notification = await loadNotificationById(env, createdNotification.notification_id);
-    if (notification) {
-        await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.created', { notification, unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id), });
-    }
-} return jsonResponse(201, createdRoute, env, request); } async function handleToggleCommunityRouteLike(request, env, routeId) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const routeRow = await readRouteRow(env, routeId); if (!routeRow) {
-    return jsonResponse(404, { detail: '경로를 찾지 못했어요.' }, env, request);
-} const existingRows = await supabaseRequest(env, `user_route_like?select=route_like_id&route_id=eq.${encodeFilterValue(routeId)}&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&limit=1`); const existing = existingRows?.[0] ?? null; if (existing) {
-    await supabaseRequest(env, `user_route_like?route_like_id=eq.${encodeFilterValue(existing.route_like_id)}`, { method: 'DELETE', headers: { Prefer: 'return=minimal' }, });
-}
-else {
-    await supabaseRequest(env, 'user_route_like?select=route_like_id', { method: 'POST', body: JSON.stringify({ route_id: Number(routeId), user_id: sessionResult.sessionUser.id, }), });
-} const likeRows = await supabaseRequest(env, `user_route_like?select=route_like_id&route_id=eq.${encodeFilterValue(routeId)}`); const likeCount = likeRows.length; await supabaseRequest(env, `user_route?route_id=eq.${encodeFilterValue(routeId)}`, { method: 'PATCH', body: JSON.stringify({ like_count: likeCount, updated_at: new Date().toISOString(), }), }); return jsonResponse(200, { routeId: String(routeId), likeCount, likedByMe: !existing, }, env, request); } return { handleCommunityRoutes, handleCreateUserRoute, handleMyRoutes, handleToggleCommunityRouteLike, loadCommunityRoutes, }; }
+import { mapCommunityRoutes } from './community-domain/mapper';
+import {
+  countRouteLikes,
+  createRouteLike,
+  createUserRoute,
+  createUserRoutePlaces,
+  deleteRouteLike,
+  loadRouteDetailRows,
+  loadRouteRows,
+  loadSessionStampRows,
+  readExistingRouteForSession,
+  readRouteLikeRow,
+  readRouteRow,
+  readTravelSessionForOwner,
+  updateRouteLikeCount,
+} from './community-domain/repository';
+import { countUnreadNotifications, createUserNotification, loadNotificationById, publishNotificationEvent } from './notifications';
 
+export function createCommunityRouteService({ loadStaticBaseRows }: {
+  loadStaticBaseRows: (env: any) => Promise<any>;
+}) {
+  async function requireSessionUser(request: Request, env: any) {
+    const sessionUser = await readSessionUser(request, env);
+    if (!sessionUser) {
+      return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
+    }
+    return { sessionUser };
+  }
+
+  async function readJsonBody(request: Request): Promise<any> {
+    try {
+      return await request.json();
+    } catch {
+      throw new Error('요청 형식이 올바르지 않아요.');
+    }
+  }
+
+  async function loadCommunityRoutes(env: any, options: any = {}) {
+    const { sort = 'popular', sessionUserId = null, ownerUserId = null } = options;
+    const routeRows = await loadRouteRows(env, { sort, ownerUserId });
+    const { routePlaceRows, userRouteLikeRows, userRows } = await loadRouteDetailRows(env, routeRows, sessionUserId);
+    if (routePlaceRows.length === 0) {
+      return [];
+    }
+
+    const { placeRows } = await loadStaticBaseRows(env);
+    const neededPositionIds = new Set(routePlaceRows.map((row) => String(row.position_id)));
+    const placesByPositionId = new Map(placeRows.filter((row) => neededPositionIds.has(String(row.position_id))).map((row) => [String(row.position_id), { id: row.slug, name: row.name }]));
+    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const likedRouteIds = new Set(userRouteLikeRows.map((row) => String(row.route_id)));
+    return mapCommunityRoutes(routeRows, routePlaceRows, usersById, placesByPositionId, likedRouteIds);
+  }
+
+  async function handleCommunityRoutes(request: Request, env: any, url: URL) {
+    const sessionUser = await readSessionUser(request, env);
+    const sort = url.searchParams.get('sort') === 'latest' ? 'latest' : 'popular';
+    const routes = await loadCommunityRoutes(env, { sort, sessionUserId: sessionUser?.id ?? null });
+    return jsonResponse(200, routes, env, request);
+  }
+
+  async function handleMyRoutes(request: Request, env: any) {
+    const sessionUser = await readSessionUser(request, env);
+    if (!sessionUser) {
+      return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
+    }
+    return jsonResponse(200, await loadCommunityRoutes(env, { ownerUserId: sessionUser.id, sessionUserId: sessionUser.id }), env, request);
+  }
+
+  async function handleCreateUserRoute(request: Request, env: any) {
+    const sessionResult = await requireSessionUser(request, env);
+    if (sessionResult.response) {
+      return sessionResult.response;
+    }
+
+    const payload = await readJsonBody(request);
+    const travelSessionId = String(payload.travelSessionId ?? '').trim();
+    const title = String(payload.title ?? '').trim();
+    const description = String(payload.description ?? '').trim();
+    const mood = String(payload.mood ?? '').trim();
+    const isPublic = payload.isPublic !== false;
+    if (!travelSessionId) {
+      return jsonResponse(400, { detail: '방향을 묶을 여행 세션이 필요해요.' }, env, request);
+    }
+    if (!title) {
+      return jsonResponse(400, { detail: '경로 제목을 적어 주세요.' }, env, request);
+    }
+    if (!description) {
+      return jsonResponse(400, { detail: '한 줄 소개를 적어 주세요.' }, env, request);
+    }
+
+    const sessionRow = await readTravelSessionForOwner(env, travelSessionId, sessionResult.sessionUser.id);
+    if (!sessionRow) {
+      return jsonResponse(404, { detail: '여행 세션을 찾지 못했어요.' }, env, request);
+    }
+    const existingRoute = await readExistingRouteForSession(env, travelSessionId, sessionResult.sessionUser.id);
+    if (existingRoute) {
+      return jsonResponse(409, { detail: '이미 발행된 여행 코스예요.' }, env, request);
+    }
+
+    const sessionStampRows = await loadSessionStampRows(env, travelSessionId, sessionResult.sessionUser.id);
+    const orderedPositionIds = [];
+    const seenPositionIds = new Set();
+    for (const stampRow of sessionStampRows ?? []) {
+      const positionId = String(stampRow.position_id);
+      if (seenPositionIds.has(positionId)) {
+        continue;
+      }
+      seenPositionIds.add(positionId);
+      orderedPositionIds.push(positionId);
+    }
+    if (orderedPositionIds.length < 2) {
+      return jsonResponse(400, { detail: '코스에는 최소 두 곳 이상의 스탬프 기록이 필요해요.' }, env, request);
+    }
+
+    const routeId = await createUserRoute(env, {
+      user_id: sessionResult.sessionUser.id,
+      travel_session_id: Number(travelSessionId),
+      title,
+      description,
+      mood,
+      is_public: isPublic,
+      is_user_generated: true,
+      like_count: 0,
+    });
+    await createUserRoutePlaces(env, routeId as string | number, orderedPositionIds);
+    const routes = await loadCommunityRoutes(env, { ownerUserId: sessionResult.sessionUser.id, sessionUserId: sessionResult.sessionUser.id });
+    const createdRoute = routes.find((route) => route.id === String(routeId)) ?? null;
+
+    const createdNotification = await createUserNotification(env, {
+      userId: sessionResult.sessionUser.id,
+      actorUserId: sessionResult.sessionUser.id,
+      type: 'route-published',
+      title: '새로운 코스가 발행되었습니다.',
+      body: title,
+      routeId,
+      metadata: { travelSessionId },
+    });
+    if (createdNotification?.notification_id) {
+      const notification = await loadNotificationById(env, createdNotification.notification_id);
+      if (notification) {
+        await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.created', {
+          notification,
+          unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id),
+        });
+      }
+    }
+    return jsonResponse(201, createdRoute, env, request);
+  }
+
+  async function handleToggleCommunityRouteLike(request: Request, env: any, routeId: string) {
+    const sessionResult = await requireSessionUser(request, env);
+    if (sessionResult.response) {
+      return sessionResult.response;
+    }
+
+    const routeRow = await readRouteRow(env, routeId);
+    if (!routeRow) {
+      return jsonResponse(404, { detail: '경로를 찾지 못했어요.' }, env, request);
+    }
+
+    const existing = await readRouteLikeRow(env, routeId, sessionResult.sessionUser.id);
+    if (existing) {
+      await deleteRouteLike(env, existing.route_like_id as string | number);
+    } else {
+      await createRouteLike(env, routeId, sessionResult.sessionUser.id);
+    }
+    const likeCount = await countRouteLikes(env, routeId);
+    await updateRouteLikeCount(env, routeId, likeCount);
+    return jsonResponse(200, { routeId: String(routeId), likeCount, likedByMe: !existing }, env, request);
+  }
+
+  return { handleCommunityRoutes, handleCreateUserRoute, handleMyRoutes, handleToggleCommunityRouteLike, loadCommunityRoutes };
+}

--- a/deploy/api-worker-shell/services/my-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/my-domain/mapper.ts
@@ -1,0 +1,26 @@
+import { formatDateTime } from '../../lib/dates';
+
+export function mapMyComments(commentRows: any[], feedRows: any, placesByPositionId: Map<any, any>) {
+  const isDeletedCommentRow = (row: any) => {
+    const body = String(row?.body ?? '').trim();
+    return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.';
+  };
+  const feedById = feedRows instanceof Map ? feedRows : new Map((feedRows ?? []).map((row) => [String(row.feed_id ?? row.id), row]));
+  return commentRows
+    .filter((row) => !isDeletedCommentRow(row))
+    .map((row) => {
+      const feed = feedById.get(String(row.feed_id));
+      const place = feed && feed.position_id ? placesByPositionId.get(String(feed.position_id)) : feed?.placeId ? { id: feed.placeId, name: feed.placeName ?? '장소 정보 없음' } : null;
+      return {
+        id: String(row.comment_id),
+        reviewId: String(row.feed_id),
+        placeId: place?.id ?? String(feed?.position_id ?? feed?.placeId ?? ''),
+        placeName: place?.name ?? '장소 정보 없음',
+        body: row.body,
+        isDeleted: false,
+        parentId: row.parent_id ? String(row.parent_id) : null,
+        createdAt: formatDateTime(row.created_at),
+        reviewBody: feed?.body ?? '',
+      };
+    });
+}

--- a/deploy/api-worker-shell/services/my-domain/repository.ts
+++ b/deploy/api-worker-shell/services/my-domain/repository.ts
@@ -1,0 +1,30 @@
+import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+
+export async function loadMyCommentRows(env: WorkerEnv, userId: string, cursor: string | null, limit: number) {
+  const query = [
+    'select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at',
+    `user_id=eq.${encodeFilterValue(userId)}`,
+    'order=created_at.desc',
+    `limit=${limit + 1}`,
+  ];
+  if (cursor) {
+    query.push(`created_at=lt.${encodeFilterValue(cursor)}`);
+  }
+  return supabaseRequest<WorkerJsonRecord[]>(env, `user_comment?${query.join('&')}`);
+}
+
+export async function loadFeedsForCommentRows(env: WorkerEnv, commentRows: WorkerJsonRecord[]) {
+  const feedIdsFilter = buildInFilter(commentRows.map((row: any) => row.feed_id));
+  if (!feedIdsFilter) {
+    return [];
+  }
+  return supabaseRequest<WorkerJsonRecord[]>(env, `feed?select=feed_id,position_id,body&feed_id=${feedIdsFilter}`);
+}
+
+export async function loadMySummaryCommentRows(env: WorkerEnv, userId: string) {
+  return supabaseRequest<WorkerJsonRecord[]>(
+    env,
+    `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc`,
+  );
+}

--- a/deploy/api-worker-shell/services/my.ts
+++ b/deploy/api-worker-shell/services/my.ts
@@ -1,14 +1,80 @@
-import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
-import { buildInFilter, encodeFilterValue, parseListLimit, supabaseRequest } from '../lib/supabase';
+import { parseListLimit } from '../lib/supabase';
 import { readSessionUser } from './auth';
-export function createMyService({ communityRouteService, loadBaseData, loadStaticBaseRows, loadUserNotifications }: any) { function mapMyComments(commentRows: any[], feedRows: any, placesByPositionId: Map<any, any>) { const isDeletedCommentRow = (row: any) => { const body = String(row?.body ?? '').trim(); return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.'; }; const feedById = feedRows instanceof Map ? feedRows : new Map((feedRows ?? []).map((row) => [String(row.feed_id ?? row.id), row])); return commentRows.filter((row) => !isDeletedCommentRow(row)).map((row) => { const feed = feedById.get(String(row.feed_id)); const place = feed && feed.position_id ? placesByPositionId.get(String(feed.position_id)) : feed?.placeId ? { id: feed.placeId, name: feed.placeName ?? '장소 정보 없음' } : null; return { id: String(row.comment_id), reviewId: String(row.feed_id), placeId: place?.id ?? String(feed?.position_id ?? feed?.placeId ?? ''), placeName: place?.name ?? '장소 정보 없음', body: row.body, isDeleted: false, parentId: row.parent_id ? String(row.parent_id) : null, createdAt: formatDateTime(row.created_at), reviewBody: feed?.body ?? '', }; }); } async function loadMyCommentPageData(env: any, userId: string, options: any = {}) { const { cursor = null, limit = 10 } = options; const query = ['select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at', `user_id=eq.${encodeFilterValue(userId)}`, 'order=created_at.desc', `limit=${limit + 1}`,]; if (cursor) {
-    query.push(`created_at=lt.${encodeFilterValue(cursor)}`);
-} const commentRows = await supabaseRequest(env, `user_comment?${query.join('&')}`); const nextCursor = commentRows.length > limit ? String(commentRows[limit].created_at) : null; const pageRows = commentRows.slice(0, limit); const feedIdsFilter = buildInFilter(pageRows.map((row) => row.feed_id)); if (!feedIdsFilter) {
-    return { items: [], nextCursor };
-} const [feedRows, { placeRows }] = await Promise.all([supabaseRequest(env, `feed?select=feed_id,position_id,body&feed_id=${feedIdsFilter}`), loadStaticBaseRows(env),]); const placesByPositionId = new Map(placeRows.map((row) => [String(row.position_id), { id: row.slug, name: row.name }])); return { items: mapMyComments(pageRows, feedRows ?? [], placesByPositionId), nextCursor, }; } async function handleMyComments(request: Request, env: any, url: URL) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
-    return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
-} const payload = await loadMyCommentPageData(env, sessionUser.id, { cursor: url.searchParams.get('cursor') ?? null, limit: parseListLimit(url, 10, 20), }); return jsonResponse(200, payload, env, request); } async function handleMySummary(request: Request, env: any) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
-    return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
-} const baseData = await loadBaseData(env, sessionUser.id); const routes = await communityRouteService.loadCommunityRoutes(env, { ownerUserId: sessionUser.id, sessionUserId: sessionUser.id }); const reviewItems = baseData.reviews.filter((review) => review.userId === sessionUser.id); const reviewById = new Map(baseData.reviews.map((review) => [String(review.id), review])); const notifications = await loadUserNotifications(env, sessionUser.id); const myCommentRows = await supabaseRequest(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&user_id=eq.${encodeFilterValue(sessionUser.id)}&order=created_at.desc`); const placesByPositionId = new Map(baseData.places.map((place: any) => [String(place.positionId), { id: place.id, name: place.name }])); const myComments = mapMyComments(myCommentRows ?? [], reviewById, placesByPositionId); const collectedSet = new Set(baseData.collectedPlaceIds); const visitedPlaces = baseData.places.filter((place) => collectedSet.has(place.id)).map(({ positionId, ...place }) => place); const unvisitedPlaces = baseData.places.filter((place) => !collectedSet.has(place.id)).map(({ positionId, ...place }) => place); return jsonResponse(200, { user: sessionUser, stats: { reviewCount: reviewItems.length, stampCount: baseData.stampLogs.length, uniquePlaceCount: collectedSet.size, totalPlaceCount: baseData.places.length, routeCount: routes.length, }, reviews: reviewItems, comments: myComments, notifications, unreadNotificationCount: notifications.filter((notification) => !notification.isRead).length, stampLogs: baseData.stampLogs, travelSessions: baseData.travelSessions, visitedPlaces, unvisitedPlaces, collectedPlaces: visitedPlaces, routes, }, env, request); } return { handleMyComments, handleMySummary, }; }
+import { mapMyComments } from './my-domain/mapper';
+import { loadFeedsForCommentRows, loadMyCommentRows, loadMySummaryCommentRows } from './my-domain/repository';
 
+export function createMyService({ communityRouteService, loadBaseData, loadStaticBaseRows, loadUserNotifications }: any) {
+  async function loadMyCommentPageData(env: any, userId: string, options: any = {}) {
+    const { cursor = null, limit = 10 } = options;
+    const commentRows = await loadMyCommentRows(env, userId, cursor, limit);
+    const nextCursor = commentRows.length > limit ? String(commentRows[limit].created_at) : null;
+    const pageRows = commentRows.slice(0, limit);
+    const feedRows = await loadFeedsForCommentRows(env, pageRows);
+    if (feedRows.length === 0) {
+      return { items: [], nextCursor };
+    }
+
+    const { placeRows } = await loadStaticBaseRows(env);
+    const placesByPositionId = new Map(placeRows.map((row) => [String(row.position_id), { id: row.slug, name: row.name }]));
+    return { items: mapMyComments(pageRows, feedRows ?? [], placesByPositionId), nextCursor };
+  }
+
+  async function handleMyComments(request: Request, env: any, url: URL) {
+    const sessionUser = await readSessionUser(request, env);
+    if (!sessionUser) {
+      return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
+    }
+    const payload = await loadMyCommentPageData(env, sessionUser.id, {
+      cursor: url.searchParams.get('cursor') ?? null,
+      limit: parseListLimit(url, 10, 20),
+    });
+    return jsonResponse(200, payload, env, request);
+  }
+
+  async function handleMySummary(request: Request, env: any) {
+    const sessionUser = await readSessionUser(request, env);
+    if (!sessionUser) {
+      return jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request);
+    }
+
+    const baseData = await loadBaseData(env, sessionUser.id);
+    const routes = await communityRouteService.loadCommunityRoutes(env, { ownerUserId: sessionUser.id, sessionUserId: sessionUser.id });
+    const reviewItems = baseData.reviews.filter((review) => review.userId === sessionUser.id);
+    const reviewById = new Map(baseData.reviews.map((review) => [String(review.id), review]));
+    const notifications = await loadUserNotifications(env, sessionUser.id);
+    const myCommentRows = await loadMySummaryCommentRows(env, sessionUser.id);
+    const placesByPositionId = new Map(baseData.places.map((place: any) => [String(place.positionId), { id: place.id, name: place.name }]));
+    const myComments = mapMyComments(myCommentRows ?? [], reviewById, placesByPositionId);
+    const collectedSet = new Set(baseData.collectedPlaceIds);
+    const visitedPlaces = baseData.places.filter((place) => collectedSet.has(place.id)).map(({ positionId, ...place }) => place);
+    const unvisitedPlaces = baseData.places.filter((place) => !collectedSet.has(place.id)).map(({ positionId, ...place }) => place);
+    return jsonResponse(
+      200,
+      {
+        user: sessionUser,
+        stats: {
+          reviewCount: reviewItems.length,
+          stampCount: baseData.stampLogs.length,
+          uniquePlaceCount: collectedSet.size,
+          totalPlaceCount: baseData.places.length,
+          routeCount: routes.length,
+        },
+        reviews: reviewItems,
+        comments: myComments,
+        notifications,
+        unreadNotificationCount: notifications.filter((notification) => !notification.isRead).length,
+        stampLogs: baseData.stampLogs,
+        travelSessions: baseData.travelSessions,
+        visitedPlaces,
+        unvisitedPlaces,
+        collectedPlaces: visitedPlaces,
+        routes,
+      },
+      env,
+      request,
+    );
+  }
+
+  return { handleMyComments, handleMySummary };
+}

--- a/test/unit/worker-account-community-admin-boundaries.test.ts
+++ b/test/unit/worker-account-community-admin-boundaries.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { createAdminService } from '../../deploy/api-worker-shell/services/admin';
+import { createCommunityRouteService } from '../../deploy/api-worker-shell/services/community-routes';
+import { createMyService } from '../../deploy/api-worker-shell/services/my';
+import type { WorkerEnv, WorkerSessionUser } from '../../deploy/api-worker-shell/types';
+
+const authMock = vi.hoisted(() => ({
+  readSessionUser: vi.fn(),
+}));
+
+const supabaseMock = vi.hoisted(() => ({
+  buildInFilter: (values: unknown[]) => {
+    const unique = [...new Set(values.filter((value) => value !== null && value !== undefined && value !== ''))];
+    return unique.length > 0 ? `in.(${unique.map((value) => encodeURIComponent(String(value))).join(',')})` : null;
+  },
+  encodeFilterValue: (value: unknown) => encodeURIComponent(String(value)),
+  getSupabaseKey: vi.fn(() => 'service-role-key'),
+  parseListLimit: vi.fn(() => 10),
+  supabaseRequest: vi.fn(),
+}));
+
+vi.mock('../../deploy/api-worker-shell/services/auth', () => authMock);
+vi.mock('../../deploy/api-worker-shell/lib/supabase', () => supabaseMock);
+
+const env: WorkerEnv = {
+  APP_FRONTEND_URL: 'https://daejeon.jamissue.com',
+  APP_SUPABASE_URL: 'https://supabase.example',
+};
+
+const sessionUser: WorkerSessionUser = {
+  id: 'actor',
+  nickname: 'Actor',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+};
+
+async function readJson(response: Response) {
+  return (await response.json()) as Record<string, any>;
+}
+
+describe('worker account/community/admin boundaries', () => {
+  beforeEach(() => {
+    authMock.readSessionUser.mockReset();
+    supabaseMock.supabaseRequest.mockReset();
+  });
+
+  it('keeps admin guard in front of admin repository calls', async () => {
+    authMock.readSessionUser.mockResolvedValue(sessionUser);
+    const adminService = createAdminService({ normalizePlaceCategory: (category) => String(category || 'attraction') });
+
+    const response = await adminService.handleAdminSummary(new Request('https://api.daejeon.jamissue.com/api/admin/summary'), env);
+
+    expect(response.status).toBe(403);
+    expect(await readJson(response)).toEqual({ detail: '관리자만 접근할 수 있어요.' });
+    expect(supabaseMock.supabaseRequest).not.toHaveBeenCalled();
+  });
+
+  it('scopes community route publishing to the owner travel session', async () => {
+    authMock.readSessionUser.mockResolvedValue(sessionUser);
+    supabaseMock.supabaseRequest.mockResolvedValueOnce([]);
+    const service = createCommunityRouteService({ loadStaticBaseRows: vi.fn() });
+
+    const response = await service.handleCreateUserRoute(
+      new Request('https://api.daejeon.jamissue.com/api/community-routes', {
+        method: 'POST',
+        body: JSON.stringify({ travelSessionId: '77', title: 'Route', description: 'Desc', mood: 'walk' }),
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(404);
+    expect(await readJson(response)).toEqual({ detail: '여행 세션을 찾지 못했어요.' });
+    expect(supabaseMock.supabaseRequest).toHaveBeenCalledWith(
+      env,
+      expect.stringContaining('travel_session_id=eq.77&user_id=eq.actor'),
+    );
+  });
+
+  it('scopes my summary routes and reviews to the current session user', async () => {
+    authMock.readSessionUser.mockResolvedValue(sessionUser);
+    supabaseMock.supabaseRequest.mockResolvedValue([]);
+    const loadCommunityRoutes = vi.fn(async () => [{ id: 'route-1' }]);
+    const service = createMyService({
+      communityRouteService: { loadCommunityRoutes },
+      loadBaseData: vi.fn(async () => ({
+        places: [],
+        placesByPositionId: new Map(),
+        reviews: [
+          { id: 'review-1', userId: 'actor' },
+          { id: 'review-2', userId: 'other' },
+        ],
+        courses: [],
+        collectedPlaceIds: [],
+        stampLogs: [],
+        travelSessions: [],
+      })),
+      loadStaticBaseRows: vi.fn(),
+      loadUserNotifications: vi.fn(async () => []),
+    });
+
+    const response = await service.handleMySummary(new Request('https://api.daejeon.jamissue.com/api/my/summary'), env);
+    const payload = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(loadCommunityRoutes).toHaveBeenCalledWith(env, { ownerUserId: 'actor', sessionUserId: 'actor' });
+    expect(payload.stats.reviewCount).toBe(1);
+  });
+});

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -70,4 +70,21 @@ describe('worker source quality gates', () => {
     expect(reviewReadSource).not.toContain('function mapReviewRows');
     expect(repositorySource).toContain('supabaseRequest');
   });
+
+  it('keeps account, community, and admin service persistence behind domain repositories', () => {
+    const serviceFiles = [
+      'deploy/api-worker-shell/services/admin.ts',
+      'deploy/api-worker-shell/services/community-routes.ts',
+      'deploy/api-worker-shell/services/my.ts',
+    ];
+
+    for (const file of serviceFiles) {
+      const source = readFileSync(join(workspaceRoot, file), 'utf8');
+      expect(source, file).not.toContain('supabaseRequest');
+    }
+
+    expect(readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/admin-domain/repository.ts'), 'utf8')).toContain('supabaseRequest');
+    expect(readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/community-domain/repository.ts'), 'utf8')).toContain('supabaseRequest');
+    expect(readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/my-domain/repository.ts'), 'utf8')).toContain('supabaseRequest');
+  });
 });


### PR DESCRIPTION
﻿## Summary
- split admin persistence/counting into `services/admin-domain/repository.ts`
- split community route mapping and persistence into `services/community-domain/*`
- split my-page comment mapping and repository reads into `services/my-domain/*`
- keep service files focused on auth/owner/admin guards, request validation, and response assembly
- add boundary tests for admin guard, community route owner-scope, and my summary user scope

## Contract Safety
- External REST API paths: unchanged
- Response shape: unchanged
- DB schema: unchanged
- User-facing copy: unchanged
- Kakao/Naver REST OAuth success path: unchanged

## Validation
- [x] `npm run lint`
- [x] `npm run typecheck`
- [x] `npm run test:unit`
- [x] `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`
- [x] `git diff --cached --check`

Closes #204
