### PR TITLE
Document Worker SOLID hardening traceability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,3 +26,4 @@
 - [account-identity-schema.md](account-identity-schema.md)
 - [code-flow-diagrams.md](code-flow-diagrams.md)
 - [operations-refactor-roadmap.md](operations-refactor-roadmap.md)
+- [worker-backend-solid-traceability.md](worker-backend-solid-traceability.md)

--- a/docs/growgardens-deploy-runbook.md
+++ b/docs/growgardens-deploy-runbook.md
@@ -20,6 +20,21 @@ GitHub main
 - 운영 반영 브랜치: `main`
 - 백엔드 기준: Cloudflare Worker가 운영 진입점이며, FastAPI는 로컬 검증과 레거시 origin fallback 성격으로 유지합니다.
 
+### Worker-first backend 책임 경계
+
+운영 API는 Worker-first BFF입니다. Worker 내부는 아래 경계를 기준으로 유지합니다.
+
+| 계층 | 책임 |
+| --- | --- |
+| `index.ts` | 서비스 조립과 fetch error boundary |
+| `runtime/routing.ts` | preflight, exact route dispatch, pattern route dispatch, fallback handoff |
+| `runtime/route-registry.ts` | route 목록과 handler 연결 |
+| `runtime/proxy.ts` | FastAPI legacy origin fallback proxy |
+| `runtime/base-data-*` | bootstrap/map-bootstrap read-model 조회, 매핑, 조립 |
+| `services/*-domain/repository.ts` | Supabase REST persistence boundary |
+
+FastAPI origin fallback은 운영 기본 경로가 아니라 아직 Worker로 직접 옮기지 않은 legacy 경로의 안전망입니다.
+
 ## 2. GitHub Actions 워크플로
 
 ### `ci.yml`
@@ -166,7 +181,9 @@ Worker 변수/시크릿 대응:
 ```powershell
 cd D:\JamIssue
 npm.cmd install
+npm.cmd run lint
 npm.cmd run typecheck
+npm.cmd run test:unit
 npm.cmd run build
 ```
 
@@ -189,6 +206,14 @@ python -m pytest tests
 ```powershell
 cd D:\JamIssue\backend
 ..\.tools\python313\python.exe -m pytest -p no:cacheprovider tests
+```
+
+Worker source quality와 UTF-8 검증:
+
+```powershell
+cd D:\JamIssue
+npm.cmd run test:unit
+.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged
 ```
 
 ## 7. 장애 점검 포인트

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -205,14 +205,17 @@
 - [ ] facade별 import surface를 더 줄일 필요가 있는지 재평가
 - [ ] 순차 PR 머지 후 `main` 기준으로 잔여 dead code와 문서 drift 재점검
 
-### 현재 순차 PR 권장 순서
-1. `codex/my-page-service-split`
-2. `codex/stamp-service-split`
-3. `codex/place-service-split`
-4. `codex/course-service-split`
-5. `codex/bootstrap-service-split`
-6. `codex/page-boundary-cleanup`
-7. `codex/facade-contract-tests`
+### 과거 순차 PR 기록
+
+아래 작업은 이미 완료된 FastAPI/Repository 정리 흐름입니다. 새 브랜치 예시로 재사용하지 않습니다.
+
+1. `my-page-service-split`
+2. `stamp-service-split`
+3. `place-service-split`
+4. `course-service-split`
+5. `bootstrap-service-split`
+6. `page-boundary-cleanup`
+7. `facade-contract-tests`
 
 ### 완료 조건
 - `repository_normalized.py`가 더 이상 프로젝트의 만능 파일이 아니다.
@@ -221,7 +224,7 @@
 
 ## 4. Worker route/data/security 경계 분리
 
-상태: IN PROGRESS
+상태: DONE
 우선순위: 높음
 성격: 운영 백엔드 구조 안정화
 
@@ -237,12 +240,27 @@
 - [x] Kakao/Naver provider 설정 회귀 테스트 추가
 - [x] OAuth state mismatch, admin 403, public event import token 회귀 테스트 추가
 - [x] Worker 소스가 긴 한 줄 blob으로 돌아가지 않도록 unit 품질 게이트 추가
-- [x] `index.ts` 부트스트랩, `runtime/base-data.ts` 데이터 로딩/매핑, `runtime/routing.ts` 라우팅으로 분리
+- [x] `index.ts` composition root, `runtime/routing.ts` dispatch, `runtime/route-registry.ts` route registry로 분리
+- [x] `runtime/base-data.ts`를 repository, mapper, assembler로 분리
+- [x] review/comment/notification 흐름을 domain repository/mapper/service-use-case로 분리
+- [x] my/community/admin 흐름을 domain repository/mapper/service boundary로 분리
+- [x] fallback proxy를 `runtime/proxy.ts`로 분리
 
-### 남은 TODO
-- [ ] `services/reviews.ts`, `services/my.ts`, `services/community-routes.ts`의 긴 라인 포맷을 추가 정리
-- [ ] Supabase row 타입을 리뷰/마이/커뮤니티 경로까지 점진 확장
+### 완료 근거
+
+| Issue | PR | Main merge SHA |
+| --- | --- | --- |
+| #200 | #224 | `64bd982e1ca8880d81ff3e9608a77ab8f9ce06c3` |
+| #201 | #225 | `4583b15985f832790e3399306f7ba2f7f4ac24a3` |
+| #202 | #226 | `cdf774a4ec1ea39f332e9c8a3f0fe085c05e5bcc` |
+| #203 | #227 | `93d13f7ab58908727c291028486bd6b7159a26e7` |
+| #204 | #228 | `21dd8d58ac51ea3a980018e68261e493a47d7264` |
+| #205 | #229 | `3da0fdd7bf9aafadd0aeaa5300169ddab7036fd3` |
+
+### 남은 후속
 - [ ] 운영 protected smoke 토큰 발급/로테이션 절차와 Worker 세션 시크릿 로테이션 절차 연결
+- [ ] Worker `services/festivals.ts`의 public data adapter 경계 재평가
+- [ ] Supabase realtime adapter 경계 분리 여부 검토
 
 ### 완료 조건
 - Worker `index.ts`가 부트스트랩과 fetch error boundary 중심으로 유지된다.
@@ -256,9 +274,9 @@
   - `npm run build`
   - `backend/.venv/Scripts/python.exe -m pytest tests`
 - 프론트 훅/스토어 리팩토링 중 실제로 쓰이지 않는 중복 모듈은 즉시 제거합니다.
-- 한 번에 전부 하지 않고, 도메인 하나씩 독립 커밋으로 나눕니다.
+- 한 번에 전부 하지 않고, 도메인 하나씩 독립 PR로 나눕니다.
 - 운영 경로를 건드리는 작업은 배포 전 smoke 절차가 먼저 있어야 합니다.
 
 ## 지금 결론
-현재 브랜치는 안정화/구조 정리의 1차 마감선까지는 도달했습니다.
-이 문서의 항목들은 그 다음 단계의 운영 체계 리팩터링이며, 팀이 합의한 뒤 계획적으로 진행하는 것이 맞습니다.
+Worker-first backend SOLID hardening은 1차 마감선까지 도달했습니다.
+다음 리팩터링은 기능 추가와 섞지 말고, 별도 parent issue와 sub-issue를 먼저 만든 뒤 진행합니다.

--- a/docs/worker-backend-solid-traceability.md
+++ b/docs/worker-backend-solid-traceability.md
@@ -46,7 +46,7 @@ request
 | #203 | `worker-review-domain-service` | [#227](https://github.com/STH-1-Class-One-Group/JamIssue/pull/227) | `93d13f7ab58908727c291028486bd6b7159a26e7` | review/comment/notification domain 분리 |
 | #204 | `worker-account-community-admin-boundaries` | [#228](https://github.com/STH-1-Class-One-Group/JamIssue/pull/228) | `21dd8d58ac51ea3a980018e68261e493a47d7264` | my/community/admin repository boundary 분리 |
 | #205 | `worker-routing-runtime-cleanup` | [#229](https://github.com/STH-1-Class-One-Group/JamIssue/pull/229) | `3da0fdd7bf9aafadd0aeaa5300169ddab7036fd3` | route registry/proxy/handler 분리 |
-| #206 | `worker-docs-release-traceability` | TBD in PR | TBD after merge | Wiki/런북/릴리즈 노트 최신화 |
+| #206 | `worker-docs-release-traceability` | [#230](https://github.com/STH-1-Class-One-Group/JamIssue/pull/230) | merge 후 #206에 기록 | Wiki/런북/릴리즈 노트 최신화 |
 
 ## 검증 기준
 

--- a/docs/worker-backend-solid-traceability.md
+++ b/docs/worker-backend-solid-traceability.md
@@ -1,0 +1,92 @@
+# Worker Backend SOLID Traceability
+
+Scope: GitHub issue #206, `worker-docs-release-traceability`
+
+이 문서는 #199 Worker-first backend SOLID hardening 묶음의 완료 근거를 추적하기 위한 repo 기준 문서입니다.
+
+## 운영 기준
+
+JamIssue 운영 백엔드는 Cloudflare Worker입니다. FastAPI는 폐기 대상이 아니라 로컬 검증, 레거시 origin fallback, 일부 과거 구조 비교용 계층으로 유지합니다.
+
+현재 운영 흐름:
+
+```text
+React web app
+-> Cloudflare Pages
+-> Cloudflare Worker API
+-> Supabase REST / Storage
+```
+
+Worker 내부 책임 목표:
+
+```text
+request
+-> routing
+-> service / use case
+-> repository / external adapter
+-> mapper / DTO assembler
+-> response
+```
+
+## 변경 금지 범위
+
+- 외부 REST API 경로 변경 없음
+- 응답 shape 변경 없음
+- DB schema 변경 없음
+- 사용자-facing copy 변경 없음
+- Kakao/Naver REST OAuth 성공 경로 변경 없음
+
+## Sub-Issue Trace
+
+| Issue | Branch | PR | Main merge SHA | 완료 근거 |
+| --- | --- | --- | --- | --- |
+| #200 | `worker-baseline-refactor-gate` | [#224](https://github.com/STH-1-Class-One-Group/JamIssue/pull/224) | `64bd982e1ca8880d81ff3e9608a77ab8f9ce06c3` | 기준선/품질 게이트 문서화 |
+| #201 | `worker-contract-boundaries` | [#225](https://github.com/STH-1-Class-One-Group/JamIssue/pull/225) | `4583b15985f832790e3399306f7ba2f7f4ac24a3` | Worker runtime/type contract 정리 |
+| #202 | `worker-base-data-read-model` | [#226](https://github.com/STH-1-Class-One-Group/JamIssue/pull/226) | `cdf774a4ec1ea39f332e9c8a3f0fe085c05e5bcc` | base data repository/mapper/assembler 분리 |
+| #203 | `worker-review-domain-service` | [#227](https://github.com/STH-1-Class-One-Group/JamIssue/pull/227) | `93d13f7ab58908727c291028486bd6b7159a26e7` | review/comment/notification domain 분리 |
+| #204 | `worker-account-community-admin-boundaries` | [#228](https://github.com/STH-1-Class-One-Group/JamIssue/pull/228) | `21dd8d58ac51ea3a980018e68261e493a47d7264` | my/community/admin repository boundary 분리 |
+| #205 | `worker-routing-runtime-cleanup` | [#229](https://github.com/STH-1-Class-One-Group/JamIssue/pull/229) | `3da0fdd7bf9aafadd0aeaa5300169ddab7036fd3` | route registry/proxy/handler 분리 |
+| #206 | `worker-docs-release-traceability` | TBD in PR | TBD after merge | Wiki/런북/릴리즈 노트 최신화 |
+
+## 검증 기준
+
+각 구현 PR에서 공통으로 확인한 기준:
+
+- `npm run lint`
+- `npm run typecheck`
+- `npm run test:unit`
+- UTF-8 integrity check
+- Worker tracked-source one-line blob 방지 검사
+- GitHub Actions checks
+- CodeQL/Security/Quality checks
+
+FastAPI 파일을 변경한 경우에는 backend pytest를 추가 기준으로 둡니다.
+
+## 1.2.8 후보 범위
+
+`1.2.8` 후보는 `1.2.7` 이후 변경 중 사용자 경험, 운영 안정성, 백엔드 유지보수성에 의미가 있는 변경을 묶습니다.
+
+포함 범위:
+
+- ReviewList/ReviewListItem 렌더링 안정화 추가 보강
+- route preview place lookup 성능 개선
+- production secret 검증 보강
+- filter/place selection 회귀 테스트 보강
+- Worker-first backend SOLID hardening #200~#206
+
+제외 범위:
+
+- `1.2.7`에 이미 포함된 #207~#213 변경
+- 사용자-facing copy 변경
+- DB schema 변경
+- 외부 API shape 변경
+
+## 완료 판단
+
+#199 parent issue는 아래 조건을 만족할 때 닫을 수 있습니다.
+
+- #200~#206이 PR, main merge SHA, CI 링크와 함께 닫힘
+- Wiki Release Notes에 `1.2.8` 후보가 기록됨
+- 배포 런북에 Worker-first 운영 기준이 유지됨
+- `Refactor-Roadmap`에 완료된 Worker hardening 결과가 반영됨
+- 신규 CodeQL/Security/Quality finding 없음


### PR DESCRIPTION
## Summary

- Document the Worker-first backend SOLID hardening trace for #199/#200~#206.
- Update the deploy runbook with Worker-first runtime boundaries and validation gates.
- Update the refactor roadmap so the Worker route/data/security boundary is marked done with PR/SHA evidence.
- Add a repo traceability document for the 1.2.8 candidate scope.

## Wiki Work

The matching Wiki updates are prepared in `.tmp-wiki/` and will be pushed to the Wiki repository as part of #206 traceability:

- `Release-Notes`
- `Refactor-Roadmap`
- `Architecture-Overview`
- `Deploy-Runbook`
- `Refactor-Agent-Handoff`
- `Home`

## Scope Guard

- External REST API paths unchanged.
- Response shape unchanged.
- DB schema unchanged.
- User-facing copy unchanged.
- Kakao/Naver REST OAuth success path unchanged.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `.\\.tools\\python313\\python.exe .tmp/check_utf8_integrity.py --staged`
- `git diff --cached --check`

Closes #206
