### PR TITLE
Fix GitHub security alerts

### DIFF
--- a/backend/app/config_database.py
+++ b/backend/app/config_database.py
@@ -40,14 +40,18 @@ def is_mysql_database(database_url: str) -> bool:
     return database_url.lower().startswith("mysql")
 
 
+def host_matches_domain(host: str, domain: str) -> bool:
+    lowered_host = host.strip(".").lower()
+    lowered_domain = domain.strip(".").lower()
+    return lowered_host == lowered_domain or lowered_host.endswith(f".{lowered_domain}")
+
+
 def is_supabase_database(host: str) -> bool:
-    lowered = host.lower()
-    return "supabase.co" in lowered or "pooler.supabase.com" in lowered
+    return host_matches_domain(host, "supabase.co") or host_matches_domain(host, "pooler.supabase.com")
 
 
 def uses_supabase_pooler(host: str, url: URL | None) -> bool:
-    lowered = host.lower()
-    return lowered.endswith("pooler.supabase.com") or (url.port == 6543 if url else False)
+    return host_matches_domain(host, "pooler.supabase.com") or (host_matches_domain(host, "supabase.co") and (url.port == 6543 if url else False))
 
 
 def prefer_sqlalchemy_null_pool(*, env: str, uses_pooler: bool, is_postgres: bool) -> bool:

--- a/backend/requirements.local.txt
+++ b/backend/requirements.local.txt
@@ -8,5 +8,5 @@ psycopg[binary]==3.2.9
 itsdangerous==2.2.0
 cryptography==46.0.7
 PyJWT==2.12.0
-python-multipart==0.0.26
+python-multipart==0.0.27
 pytest==9.0.3

--- a/backend/tests/test_config_db.py
+++ b/backend/tests/test_config_db.py
@@ -37,6 +37,28 @@ def test_engine_options_use_nullpool_for_supabase_pooler():
     assert engine_options['pool_recycle'] == 1800
 
 
+def test_supabase_host_matching_requires_domain_boundary():
+    settings = Settings(
+        env='worker',
+        database_url='postgres://jamissue:secret@pooler.supabase.com.attacker.example:6543/postgres',
+    )
+
+    assert settings.database_provider == 'postgresql'
+    assert settings.is_supabase_database is False
+    assert settings.uses_supabase_pooler is False
+
+
+def test_supabase_pooler_host_allows_subdomain_boundary():
+    settings = Settings(
+        env='worker',
+        database_url='postgres://postgres.demo:secret@aws-0-ap-northeast-2.pooler.supabase.com:6543/postgres',
+    )
+
+    assert settings.database_provider == 'supabase-postgres'
+    assert settings.is_supabase_database is True
+    assert settings.uses_supabase_pooler is True
+
+
 def test_sqlite_connect_args_and_storage_target_label(tmp_path):
     settings = Settings(
         database_url=f"sqlite:///{tmp_path / 'test.db'}",

--- a/deploy/api-worker-shell/index.ts
+++ b/deploy/api-worker-shell/index.ts
@@ -66,21 +66,21 @@ const routeRequest = createRouteRequest({
   stampService,
 });
 
+export function buildWorkerErrorPayload() {
+  return {
+    service: 'daejeon-jamissue-api',
+    status: 'worker-error',
+    message: 'Internal worker error',
+  };
+}
+
 export default {
   async fetch(request: Request, env: WorkerEnv) {
     try {
       return await routeRequest(request, env);
     } catch (error) {
-      return jsonResponse(
-        500,
-        {
-          service: 'daejeon-jamissue-api',
-          status: 'worker-error',
-          message: error instanceof Error ? error.message : String(error),
-        },
-        env,
-        request,
-      );
+      console.error('Worker request failed', error);
+      return jsonResponse(500, buildWorkerErrorPayload(), env, request);
     }
   },
 };

--- a/scripts/daejeon-event-sync/normalize.ts
+++ b/scripts/daejeon-event-sync/normalize.ts
@@ -1,18 +1,39 @@
 import { DETAIL_BASE_URL } from './constants';
 import type { ImportedEvent } from './types';
 
-function escapeHtml(text: string) {
-  return String(text || '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ');
+const SAFE_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  quot: '"',
+  '#39': "'",
+  nbsp: ' ',
+};
+
+function decodeSafeHtmlEntities(text: string) {
+  return String(text || '').replace(/&(amp|quot|#39|nbsp);/g, (entity, key: string) => SAFE_ENTITY_MAP[key] ?? entity);
+}
+
+function stripMarkup(text: string) {
+  let output = '';
+  let insideTag = false;
+  for (const char of String(text || '')) {
+    if (char === '<') {
+      insideTag = true;
+      output += ' ';
+      continue;
+    }
+    if (char === '>') {
+      insideTag = false;
+      continue;
+    }
+    if (!insideTag) {
+      output += char;
+    }
+  }
+  return output;
 }
 
 function stripHtml(text: string) {
-  return escapeHtml(String(text || '').replace(/<[^>]+>/g, ' '))
+  return decodeSafeHtmlEntities(stripMarkup(text))
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/scripts/sample-place/parse.ts
+++ b/scripts/sample-place/parse.ts
@@ -6,16 +6,38 @@ export interface RawSamplePlaceRow {
   latitude: number;
 }
 
+const SAFE_ENTITY_MAP: Record<string, string> = {
+  amp: '&',
+  quot: '"',
+  '#39': "'",
+  nbsp: ' ',
+};
+
+function decodeSafeHtmlEntities(value: string) {
+  return value.replace(/&(amp|quot|#39|nbsp);/g, (entity, key: string) => SAFE_ENTITY_MAP[key] ?? entity);
+}
+
+function stripMarkup(value: string) {
+  let output = '';
+  let insideTag = false;
+  for (const char of value) {
+    if (char === '<') {
+      insideTag = true;
+      continue;
+    }
+    if (char === '>') {
+      insideTag = false;
+      continue;
+    }
+    if (!insideTag) {
+      output += char;
+    }
+  }
+  return output;
+}
+
 export function decodeHtml(value: string) {
-  return value
-    .replace(/<[^>]+>/g, '')
-    .replace(/&amp;/g, '&')
-    .replace(/&lt;/g, '<')
-    .replace(/&gt;/g, '>')
-    .replace(/&quot;/g, '"')
-    .replace(/&#39;/g, "'")
-    .replace(/&nbsp;/g, ' ')
-    .trim();
+  return decodeSafeHtmlEntities(stripMarkup(value)).trim();
 }
 
 export function parseSamplePlaceRows(html: string): RawSamplePlaceRow[] {

--- a/test/unit/security-alert-regressions.test.ts
+++ b/test/unit/security-alert-regressions.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { buildWorkerErrorPayload } from '../../deploy/api-worker-shell/index';
+import { parseEventRows } from '../../scripts/daejeon-event-sync/normalize';
+import { decodeHtml, parseSamplePlaceRows } from '../../scripts/sample-place/parse';
+
+describe('security alert regressions', () => {
+  it('does not expose raw worker error details in generic error payloads', () => {
+    const payload = buildWorkerErrorPayload();
+
+    expect(payload).toEqual({
+      service: 'daejeon-jamissue-api',
+      status: 'worker-error',
+      message: 'Internal worker error',
+    });
+    expect(JSON.stringify(payload)).not.toContain('stack');
+  });
+
+  it('does not double-unescape encoded sample place cell content into markup', () => {
+    expect(decodeHtml('&amp;lt;script&amp;gt;alert(1)&amp;lt;/script&amp;gt;')).toBe('&lt;script&gt;alert(1)&lt;/script&gt;');
+
+    const rows = parseSamplePlaceRows(`
+      <table>
+        <tr>
+          <td>1</td>
+          <td>&amp;lt;script&amp;gt;Jam&amp;lt;/script&amp;gt;</td>
+          <td>cafe</td>
+          <td>127.38</td>
+          <td>36.35</td>
+        </tr>
+      </table>
+    `);
+
+    expect(rows[0]?.name).toBe('&lt;script&gt;Jam&lt;/script&gt;');
+  });
+
+  it('does not double-unescape encoded public event cell content into markup', () => {
+    const rows = parseEventRows(`
+      <table>
+        <tbody>
+          <tr>
+            <td class="subject"><a href="/event?eventSeq=123">&amp;lt;script&amp;gt;Jam&amp;lt;/script&amp;gt;</a></td>
+            <td class="theme">주제 : &amp;lt;img src=x&amp;gt;</td>
+            <td class="location">대전시청</td>
+            <td class="date3">2026-05-01</td>
+            <td class="date3">2026-05-02</td>
+          </tr>
+        </tbody>
+      </table>
+    `);
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.title).toBe('&lt;script&gt;Jam&lt;/script&gt;');
+    expect(rows[0]?.summary).toContain('&lt;img src=x&gt;');
+    expect(rows[0]?.summary).not.toContain('<img');
+  });
+});


### PR DESCRIPTION
## Summary

- Upgrade `python-multipart` to `0.0.27` for Dependabot alert #10.
- Harden database host checks so Supabase/pooler detection requires a real domain boundary.
- Replace script HTML decoding with single-pass safe entity decoding and state-machine markup stripping.
- Stop returning raw Worker exception messages in generic 500 responses.
- Add regression tests for DB host boundaries, safe entity decoding, and generic Worker error payloads.

## Alerts Addressed

- Dependabot #10: `python-multipart < 0.0.27`
- CodeQL #1: `backend/app/config_database.py`
- CodeQL #2: `backend/app/config_database.py`
- CodeQL #3: `scripts/sample-place/parse.ts`
- CodeQL #4: `scripts/daejeon-event-sync/normalize.ts`
- CodeQL #5: `scripts/sample-place/parse.ts`
- CodeQL #6: `deploy/api-worker-shell/lib/http.ts`

## Scope Guard

- External REST API paths unchanged.
- Response shape unchanged except generic Worker 500 no longer includes raw exception detail.
- DB schema unchanged.
- User-facing copy unchanged except the security-required generic Worker 500 message.
- Kakao/Naver REST OAuth success path unchanged.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm run test:unit`
- `npm run build`
- `..\\.tools\\python313\\python.exe -m pytest -p no:cacheprovider tests`
- `.\\.tools\\python313\\python.exe .tmp/check_utf8_integrity.py --staged`
- `git diff --cached --check`

Closes #232
