### PR TITLE
Fix remaining Dependabot and CodeQL alerts

### DIFF
--- a/deploy/api-worker-shell/lib/http.ts
+++ b/deploy/api-worker-shell/lib/http.ts
@@ -30,7 +30,47 @@ export function jsonResponse(
   });
 
   applyCorsHeaders(headers, env, request);
-  return new Response(JSON.stringify(payload), { status, headers });
+  return new Response(JSON.stringify(toJsonSafePayload(payload)), { status, headers });
+}
+
+function toJsonSafePayload(payload: unknown, seen = new WeakSet<object>()): unknown {
+  if (payload instanceof Error) {
+    return { message: 'Internal error' };
+  }
+
+  if (payload === null || typeof payload === 'string' || typeof payload === 'number' || typeof payload === 'boolean') {
+    return payload;
+  }
+
+  if (typeof payload === 'bigint') {
+    return payload.toString();
+  }
+
+  if (Array.isArray(payload)) {
+    if (seen.has(payload)) {
+      return '[Circular]';
+    }
+    seen.add(payload);
+    return payload.map((value) => toJsonSafePayload(value, seen));
+  }
+
+  if (typeof payload === 'object') {
+    if (seen.has(payload)) {
+      return '[Circular]';
+    }
+
+    seen.add(payload);
+    const safePayload: Record<string, unknown> = {};
+    for (const [key, value] of Object.entries(payload)) {
+      if (/^stack(trace)?$/iu.test(key)) {
+        continue;
+      }
+      safePayload[key] = toJsonSafePayload(value, seen);
+    }
+    return safePayload;
+  }
+
+  return null;
 }
 
 export function redirectResponse(location: string, env: WorkerEnv, request: Request, cookies: string[] = []) {

--- a/deploy/api-worker-shell/services/auth.ts
+++ b/deploy/api-worker-shell/services/auth.ts
@@ -78,10 +78,10 @@ export async function handleUpdateProfile(request: Request, env: WorkerEnv) {
   try {
     nickname = await ensureUniqueNickname(env, payload.nickname, sessionResult.sessionUser.id);
   } catch (error) {
-    const profileError = error as { message?: string; status?: number };
+    const profileError = error as { status?: number };
     return jsonResponse(
       profileError.status ?? 400,
-      { detail: profileError.message ?? '닉네임을 저장할 수 없어요.' },
+      { detail: getProfileUpdateErrorMessage(profileError.status) },
       env,
       request,
     );
@@ -116,6 +116,16 @@ export async function handleUpdateProfile(request: Request, env: WorkerEnv) {
     }
     throw error;
   }
+}
+
+function getProfileUpdateErrorMessage(status?: number) {
+  if (status === 409) {
+    return '이미 사용 중인 닉네임이에요.';
+  }
+  if (status === 400) {
+    return '닉네임은 두 글자 이상으로 적어 주세요.';
+  }
+  return '닉네임을 저장할 수 없어요.';
 }
 
 async function buildStateLoginResponse(
@@ -217,7 +227,7 @@ async function finishSocialLogin({ request, env, url, provider, exchangeCode, fe
     if (isMissingSigningSecretError(errorValue)) {
       return sessionSecretUnavailableResponse(request, env, { 'set-cookie': cleanupCookie });
     }
-    const reason = errorValue instanceof Error ? errorValue.message : String(errorValue);
+    const reason = `${provider}-callback-failed`;
     return redirectResponse(buildRedirectUrl(redirectTarget, { auth: `${provider}-error`, reason }), env, request, [
       cleanupCookie,
     ]);

--- a/deploy/api-worker-shell/services/festivals.ts
+++ b/deploy/api-worker-shell/services/festivals.ts
@@ -187,7 +187,7 @@ export async function handleFestivalImport(request, env) { const configuredToken
     importedItems = await upsertImportedFestivalItems(env, payload.items, { sourceName: payload.sourceName, sourceUrl: payload.sourceUrl, importedAt: payload.importedAt, });
 }
 catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return jsonResponse(422, { detail: message }, env, request);
+    console.error('[worker] festival import failed', error);
+    return jsonResponse(422, { detail: '공공 행사 데이터를 정리할 수 없어요.' }, env, request);
 } festivalsCache = { expiresAt: 0, syncAt: Date.now(), value: null, pending: null, }; return jsonResponse(200, { importedEvents: importedItems.length, sourceName: String(payload.sourceName || INTERNAL_FESTIVAL_SOURCE_NAME), importedAt: parseFestivalDate(payload.importedAt)?.toISOString() || new Date().toISOString(), }, env, request); }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "eslint": "^10.2.0",
         "globals": "^17.5.0",
         "jsdom": "^29.0.1",
+        "postcss": "^8.5.10",
         "tsx": "^4.21.0",
         "typescript": "5.6.3",
         "typescript-eslint": "^8.58.2",
@@ -3259,6 +3260,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3267,9 +3269,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "eslint": "^10.2.0",
     "globals": "^17.5.0",
     "jsdom": "^29.0.1",
+    "postcss": "^8.5.10",
     "tsx": "^4.21.0",
     "typescript": "5.6.3",
     "typescript-eslint": "^8.58.2",

--- a/test/unit/security-alert-regressions.test.ts
+++ b/test/unit/security-alert-regressions.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { buildWorkerErrorPayload } from '../../deploy/api-worker-shell/index';
+import { jsonResponse } from '../../deploy/api-worker-shell/lib/http';
 import { parseEventRows } from '../../scripts/daejeon-event-sync/normalize';
 import { decodeHtml, parseSamplePlaceRows } from '../../scripts/sample-place/parse';
 
@@ -14,6 +15,19 @@ describe('security alert regressions', () => {
       message: 'Internal worker error',
     });
     expect(JSON.stringify(payload)).not.toContain('stack');
+  });
+
+  it('strips stack fields from generic JSON responses', async () => {
+    const response = jsonResponse(
+      500,
+      { detail: 'safe', stack: 'secret stack', nested: { stackTrace: 'nested secret' }, error: new Error('raw failure') },
+      {},
+      new Request('https://api.daejeon.jamissue.com/api/test'),
+    );
+
+    const body = await response.json();
+
+    expect(body).toEqual({ detail: 'safe', nested: {}, error: { message: 'Internal error' } });
   });
 
   it('does not double-unescape encoded sample place cell content into markup', () => {


### PR DESCRIPTION
## Summary
- Upgrade postcss to 8.5.10 so Dependabot #11 is patched.
- Sanitize Worker JSON response payloads so stack fields and Error objects are not exposed.
- Stop forwarding caught Error.message values into Worker profile, OAuth callback, and festival import responses.

## Validation
- npm run lint
- npm run typecheck
- npm run test:unit
- npm run build
- npm ls postcss
- UTF-8 integrity check passed
- git diff --cached --check

Closes #234