### PR TITLE
TSK-002-01 하드코딩 수치 audit 기준선 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "test:smoke:ui": "node --max-old-space-size=8192 ./node_modules/vitest/vitest.mjs run test/smoke",
     "test:all": "npm run test:unit && npm run test:integration && npm run test:regression && npm run test:smoke:ui",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.scripts.json --noEmit && tsc -p tsconfig.worker.json --noEmit",
+    "check:numeric-literals": "tsx scripts/numeric-literal-audit.ts --check",
     "smoke": "tsx scripts/run-public-smoke-checks.ts",
     "smoke:public": "tsx scripts/run-public-smoke-checks.ts",
     "smoke:protected": "tsx scripts/run-protected-smoke-checks.ts"

--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -1,0 +1,237 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+export interface NumericLiteralFinding {
+  value: string;
+  line: number;
+  column: number;
+}
+
+export interface NumericLiteralFileAudit {
+  path: string;
+  count: number;
+  owner: string;
+  category: string;
+  scopeId: string;
+  reason: string;
+  examples: NumericLiteralFinding[];
+}
+
+export interface NumericLiteralBaseline {
+  version: number;
+  generatedFrom: string;
+  policy: string;
+  files: NumericLiteralFileAudit[];
+}
+
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..');
+const baselinePath = join(workspaceRoot, 'scripts', 'numeric-literal-baseline.json');
+const numericLiteralPattern = /(^|[^\w.])([-+]?\d[\d_]*(?:\.\d+)?(?:px|rem|em|vh|vw|%|ms|s|m|deg)?)(?![\w])/g;
+const maxExamplesPerFile = 6;
+
+function isAuditedProductionFile(path: string) {
+  const normalized = path.replace(/\\/g, '/');
+  if (normalized === 'scripts/numeric-literal-audit.ts') {
+    return false;
+  }
+  if (normalized.startsWith('test/') || normalized.startsWith('backend/tests/')) {
+    return false;
+  }
+  if (normalized.startsWith('backend/data/')) {
+    return false;
+  }
+
+  return (
+    /^src\/.+\.(ts|tsx|css)$/.test(normalized)
+    || /^deploy\/api-worker-shell\/.+\.ts$/.test(normalized)
+    || /^backend\/app\/.+\.py$/.test(normalized)
+    || normalized === 'backend/run_appserver.py'
+    || /^scripts\/.+\.(ts|mjs|ps1)$/.test(normalized)
+  );
+}
+
+function listTrackedProductionFiles() {
+  const output = execFileSync('git', ['ls-files'], { cwd: workspaceRoot, encoding: 'utf8' });
+  return output
+    .split(/\r?\n/)
+    .filter(Boolean)
+    .filter(isAuditedProductionFile)
+    .sort();
+}
+
+function locateOffset(source: string, offset: number) {
+  const before = source.slice(0, offset);
+  const lines = before.split(/\r?\n/);
+  return {
+    line: lines.length,
+    column: lines[lines.length - 1].length + 1,
+  };
+}
+
+function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner' | 'category' | 'scopeId' | 'reason'> {
+  if (path.endsWith('.css')) {
+    return {
+      owner: 'frontend-ui',
+      category: 'css-layout-token-baseline',
+      scopeId: 'TSK-002-03-FRONTEND-UI-TOKEN-CONFIG',
+      reason: 'CSS layout, spacing, radius, color, shadow, or motion values are migrated through UI token work.',
+    };
+  }
+  if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
+    return {
+      owner: 'frontend-map',
+      category: 'map-coordinate-marker-baseline',
+      scopeId: 'TSK-002-02-FRONTEND-MAP-GEO-CONFIG',
+      reason: 'Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.',
+    };
+  }
+  if (path.includes('geolocation') || path.includes('visits')) {
+    return {
+      owner: 'frontend-map',
+      category: 'geolocation-threshold-baseline',
+      scopeId: 'TSK-002-02-FRONTEND-MAP-GEO-CONFIG',
+      reason: 'Distance, radius, accuracy, and timeout values are migrated through geolocation config work.',
+    };
+  }
+  if (path.includes('imageUpload') || path.includes('/api/') || path.includes('useAutoLoadMore') || path.includes('floating-back-button')) {
+    return {
+      owner: 'frontend-runtime',
+      category: 'frontend-runtime-limit-baseline',
+      scopeId: 'TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG',
+      reason: 'Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.',
+    };
+  }
+  if (path.startsWith('deploy/api-worker-shell/')) {
+    return {
+      owner: 'worker-backend',
+      category: 'worker-runtime-limit-baseline',
+      scopeId: 'TSK-002-05-WORKER-RUNTIME-CONFIG',
+      reason: 'Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.',
+    };
+  }
+  if (path.startsWith('backend/')) {
+    return {
+      owner: 'fastapi-backend',
+      category: 'fastapi-runtime-config-baseline',
+      scopeId: 'TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW',
+      reason: 'FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.',
+    };
+  }
+  if (path.startsWith('src/')) {
+    return {
+      owner: 'frontend-ui',
+      category: 'frontend-ui-inline-token-baseline',
+      scopeId: 'TSK-002-03-FRONTEND-UI-TOKEN-CONFIG',
+      reason: 'Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.',
+    };
+  }
+  if (path.startsWith('scripts/')) {
+    return {
+      owner: 'tooling',
+      category: 'tooling-script-baseline',
+      scopeId: 'TSK-002-01-HARDCODED-VALUE-AUDIT',
+      reason: 'Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.',
+    };
+  }
+  return {
+    owner: 'unknown',
+    category: 'unclassified-production-literal',
+    scopeId: 'TSK-002-01-HARDCODED-VALUE-AUDIT',
+    reason: 'This file must be assigned to a concrete config hardening child issue before implementation proceeds.',
+  };
+}
+
+export function auditNumericLiterals() {
+  return listTrackedProductionFiles()
+    .map((path): NumericLiteralFileAudit | null => {
+      const source = readFileSync(join(workspaceRoot, path), 'utf8');
+      const findings: NumericLiteralFinding[] = [];
+      let match: RegExpExecArray | null;
+
+      numericLiteralPattern.lastIndex = 0;
+      while ((match = numericLiteralPattern.exec(source)) !== null) {
+        const value = match[2];
+        const offset = match.index + match[1].length;
+        const location = locateOffset(source, offset);
+        findings.push({ value, ...location });
+      }
+
+      if (findings.length === 0) {
+        return null;
+      }
+
+      return {
+        path,
+        count: findings.length,
+        ...inferClassification(path),
+        examples: findings.slice(0, maxExamplesPerFile),
+      };
+    })
+    .filter((entry): entry is NumericLiteralFileAudit => entry !== null)
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export function createNumericLiteralBaseline(generatedFrom: string): NumericLiteralBaseline {
+  return {
+    version: 1,
+    generatedFrom,
+    policy: 'TSK-002 requires every production numeric literal file to be classified before config extraction work starts.',
+    files: auditNumericLiterals(),
+  };
+}
+
+export function loadNumericLiteralBaseline(): NumericLiteralBaseline {
+  if (!existsSync(baselinePath)) {
+    throw new Error(`Numeric literal baseline is missing: ${relative(workspaceRoot, baselinePath)}`);
+  }
+  return JSON.parse(readFileSync(baselinePath, 'utf8')) as NumericLiteralBaseline;
+}
+
+export function compareAuditToBaseline(current: NumericLiteralFileAudit[], baseline: NumericLiteralBaseline) {
+  const baselineCounts = new Map(baseline.files.map((file) => [file.path, file.count]));
+  const currentCounts = new Map(current.map((file) => [file.path, file.count]));
+  const failures: string[] = [];
+
+  for (const file of current) {
+    const expectedCount = baselineCounts.get(file.path);
+    if (expectedCount === undefined) {
+      failures.push(`${file.path}: has ${file.count} numeric literals but is missing from the baseline`);
+      continue;
+    }
+    if (expectedCount !== file.count) {
+      failures.push(`${file.path}: expected ${expectedCount} numeric literals, found ${file.count}`);
+    }
+  }
+
+  for (const file of baseline.files) {
+    if (!currentCounts.has(file.path)) {
+      failures.push(`${file.path}: exists in baseline but is no longer audited`);
+    }
+  }
+
+  return failures;
+}
+
+function currentMainSha() {
+  return execFileSync('git', ['rev-parse', 'HEAD'], { cwd: workspaceRoot, encoding: 'utf8' }).trim();
+}
+
+function writeBaseline() {
+  const baseline = createNumericLiteralBaseline(currentMainSha());
+  writeFileSync(baselinePath, `${JSON.stringify(baseline, null, 2)}\n`, 'utf8');
+  return baseline;
+}
+
+if (process.argv.includes('--write')) {
+  const baseline = writeBaseline();
+  console.log(`Wrote ${relative(workspaceRoot, baselinePath)} with ${baseline.files.length} classified files.`);
+} else if (process.argv.includes('--check')) {
+  const failures = compareAuditToBaseline(auditNumericLiterals(), loadNumericLiteralBaseline());
+  if (failures.length > 0) {
+    console.error(failures.join('\n'));
+    process.exit(1);
+  }
+  console.log('Numeric literal baseline is current.');
+}

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,0 +1,4842 @@
+{
+  "version": 1,
+  "generatedFrom": "ee6cf17cbe5dc2ac189d1486b2ae31ed7754c750",
+  "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
+  "files": [
+    {
+      "path": "backend/app/config_database.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "6543",
+          "line": 54,
+          "column": 123
+        }
+      ]
+    },
+    {
+      "path": "backend/app/config.py",
+      "count": 24,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "127.0",
+          "line": 36,
+          "column": 18
+        },
+        {
+          "value": "8001",
+          "line": 37,
+          "column": 17
+        },
+        {
+          "value": "8000",
+          "line": 38,
+          "column": 43
+        },
+        {
+          "value": "127.0",
+          "line": 38,
+          "column": 55
+        },
+        {
+          "value": "8000",
+          "line": 38,
+          "column": 65
+        },
+        {
+          "value": "8000",
+          "line": 39,
+          "column": 43
+        }
+      ]
+    },
+    {
+      "path": "backend/app/db_model_defs/auth_models.py",
+      "count": 8,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "64",
+          "line": 12,
+          "column": 49
+        },
+        {
+          "value": "255",
+          "line": 13,
+          "column": 47
+        },
+        {
+          "value": "100",
+          "line": 14,
+          "column": 50
+        },
+        {
+          "value": "50",
+          "line": 15,
+          "column": 50
+        },
+        {
+          "value": "50",
+          "line": 82,
+          "column": 50
+        },
+        {
+          "value": "120",
+          "line": 83,
+          "column": 58
+        }
+      ]
+    },
+    {
+      "path": "backend/app/db_model_defs/content_models.py",
+      "count": 6,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "20",
+          "line": 17,
+          "column": 46
+        },
+        {
+          "value": "50",
+          "line": 18,
+          "column": 47
+        },
+        {
+          "value": "255",
+          "line": 19,
+          "column": 51
+        },
+        {
+          "value": "30",
+          "line": 76,
+          "column": 46
+        },
+        {
+          "value": "120",
+          "line": 77,
+          "column": 47
+        },
+        {
+          "value": "255",
+          "line": 78,
+          "column": 46
+        }
+      ]
+    },
+    {
+      "path": "backend/app/db_model_defs/public_data_models.py",
+      "count": 44,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "100",
+          "line": 13,
+          "column": 46
+        },
+        {
+          "value": "120",
+          "line": 14,
+          "column": 46
+        },
+        {
+          "value": "50",
+          "line": 15,
+          "column": 50
+        },
+        {
+          "value": "20",
+          "line": 16,
+          "column": 50
+        },
+        {
+          "value": "255",
+          "line": 19,
+          "column": 49
+        },
+        {
+          "value": "255",
+          "line": 21,
+          "column": 51
+        }
+      ]
+    },
+    {
+      "path": "backend/app/db_model_defs/route_models.py",
+      "count": 13,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "80",
+          "line": 13,
+          "column": 46
+        },
+        {
+          "value": "120",
+          "line": 14,
+          "column": 47
+        },
+        {
+          "value": "20",
+          "line": 15,
+          "column": 46
+        },
+        {
+          "value": "40",
+          "line": 16,
+          "column": 50
+        },
+        {
+          "value": "255",
+          "line": 17,
+          "column": 46
+        },
+        {
+          "value": "20",
+          "line": 18,
+          "column": 47
+        }
+      ]
+    },
+    {
+      "path": "backend/app/db.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1800",
+          "line": 33,
+          "column": 42
+        }
+      ]
+    },
+    {
+      "path": "backend/app/main.py",
+      "count": 3,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1.0",
+          "line": 27,
+          "column": 14
+        },
+        {
+          "value": "60",
+          "line": 43,
+          "column": 13
+        },
+        {
+          "value": "60",
+          "line": 43,
+          "column": 18
+        }
+      ]
+    },
+    {
+      "path": "backend/app/model_contracts/content.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 31,
+          "column": 44
+        }
+      ]
+    },
+    {
+      "path": "backend/app/model_contracts/my_page.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 55,
+          "column": 38
+        },
+        {
+          "value": "0",
+          "line": 64,
+          "column": 52
+        }
+      ]
+    },
+    {
+      "path": "backend/app/model_contracts/review.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 34,
+          "column": 37
+        },
+        {
+          "value": "1",
+          "line": 37,
+          "column": 39
+        }
+      ]
+    },
+    {
+      "path": "backend/app/naver_oauth.py",
+      "count": 5,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "24",
+          "line": 36,
+          "column": 34
+        },
+        {
+          "value": "00",
+          "line": 95,
+          "column": 38
+        },
+        {
+          "value": "8",
+          "line": 113,
+          "column": 55
+        },
+        {
+          "value": "10",
+          "line": 121,
+          "column": 39
+        },
+        {
+          "value": "8",
+          "line": 122,
+          "column": 59
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/client.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 36,
+          "column": 63
+        },
+        {
+          "value": "8",
+          "line": 41,
+          "column": 82
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/event_client.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 56,
+          "column": 63
+        },
+        {
+          "value": "8",
+          "line": 61,
+          "column": 83
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/event_import.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 55,
+          "column": 22
+        },
+        {
+          "value": "1",
+          "line": 104,
+          "column": 31
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/event_matching.py",
+      "count": 4,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0.0",
+          "line": 27,
+          "column": 28
+        },
+        {
+          "value": "1.0",
+          "line": 32,
+          "column": 41
+        },
+        {
+          "value": "0.82",
+          "line": 34,
+          "column": 45
+        },
+        {
+          "value": "0.0",
+          "line": 35,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/event_normalizer.py",
+      "count": 20,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 74,
+          "column": 40
+        },
+        {
+          "value": "23",
+          "line": 76,
+          "column": 39
+        },
+        {
+          "value": "59",
+          "line": 76,
+          "column": 51
+        },
+        {
+          "value": "59",
+          "line": 76,
+          "column": 63
+        },
+        {
+          "value": "23",
+          "line": 90,
+          "column": 47
+        },
+        {
+          "value": "59",
+          "line": 90,
+          "column": 59
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/normalizer.py",
+      "count": 14,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "40",
+          "line": 29,
+          "column": 24
+        },
+        {
+          "value": "1",
+          "line": 29,
+          "column": 30
+        },
+        {
+          "value": "20",
+          "line": 29,
+          "column": 34
+        },
+        {
+          "value": "30",
+          "line": 38,
+          "column": 24
+        },
+        {
+          "value": "1",
+          "line": 38,
+          "column": 30
+        },
+        {
+          "value": "40",
+          "line": 47,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/schemas.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 63,
+          "column": 40
+        }
+      ]
+    },
+    {
+      "path": "backend/app/public_data/service.py",
+      "count": 6,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1.0",
+          "line": 100,
+          "column": 29
+        },
+        {
+          "value": "0",
+          "line": 119,
+          "column": 24
+        },
+        {
+          "value": "1",
+          "line": 135,
+          "column": 33
+        },
+        {
+          "value": "1",
+          "line": 146,
+          "column": 62
+        },
+        {
+          "value": "0",
+          "line": 166,
+          "column": 23
+        },
+        {
+          "value": "1",
+          "line": 208,
+          "column": 36
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/admin_data_repository.py",
+      "count": 6,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 12,
+          "column": 71
+        },
+        {
+          "value": "0",
+          "line": 13,
+          "column": 76
+        },
+        {
+          "value": "0",
+          "line": 14,
+          "column": 73
+        },
+        {
+          "value": "0",
+          "line": 15,
+          "column": 81
+        },
+        {
+          "value": "0",
+          "line": 16,
+          "column": 77
+        },
+        {
+          "value": "0",
+          "line": 55,
+          "column": 118
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/notification_data_repository.py",
+      "count": 4,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "50",
+          "line": 25,
+          "column": 72
+        },
+        {
+          "value": "0",
+          "line": 43,
+          "column": 12
+        },
+        {
+          "value": "0",
+          "line": 59,
+          "column": 42
+        },
+        {
+          "value": "0",
+          "line": 131,
+          "column": 16
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/profile_data_repository.py",
+      "count": 5,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 17,
+          "column": 33
+        },
+        {
+          "value": "2",
+          "line": 22,
+          "column": 26
+        },
+        {
+          "value": "2",
+          "line": 33,
+          "column": 25
+        },
+        {
+          "value": "10000",
+          "line": 33,
+          "column": 28
+        },
+        {
+          "value": "95",
+          "line": 34,
+          "column": 30
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/review_query_repository.py",
+      "count": 2,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 30,
+          "column": 64
+        },
+        {
+          "value": "0",
+          "line": 107,
+          "column": 70
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/review_write_repository.py",
+      "count": 4,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 43,
+          "column": 42
+        },
+        {
+          "value": "0",
+          "line": 98,
+          "column": 115
+        },
+        {
+          "value": "255",
+          "line": 151,
+          "column": 24
+        },
+        {
+          "value": "255",
+          "line": 166,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/route_data_repository.py",
+      "count": 8,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 14,
+          "column": 25
+        },
+        {
+          "value": "2",
+          "line": 92,
+          "column": 21
+        },
+        {
+          "value": "8",
+          "line": 94,
+          "column": 27
+        },
+        {
+          "value": "0",
+          "line": 142,
+          "column": 20
+        },
+        {
+          "value": "1",
+          "line": 149,
+          "column": 62
+        },
+        {
+          "value": "1",
+          "line": 176,
+          "column": 51
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repositories/stamp_data_repository.py",
+      "count": 9,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 86,
+          "column": 53
+        },
+        {
+          "value": "0",
+          "line": 88,
+          "column": 47
+        },
+        {
+          "value": "24",
+          "line": 133,
+          "column": 70
+        },
+        {
+          "value": "1",
+          "line": 139,
+          "column": 40
+        },
+        {
+          "value": "2",
+          "line": 148,
+          "column": 25
+        },
+        {
+          "value": "1",
+          "line": 162,
+          "column": 21
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repository_support_comments.py",
+      "count": 4,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 60,
+          "column": 16
+        },
+        {
+          "value": "0",
+          "line": 79,
+          "column": 58
+        },
+        {
+          "value": "0",
+          "line": 80,
+          "column": 20
+        },
+        {
+          "value": "1",
+          "line": 81,
+          "column": 16
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repository_support_geo.py",
+      "count": 6,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "6_371_000",
+          "line": 16,
+          "column": 27
+        },
+        {
+          "value": "2",
+          "line": 22,
+          "column": 30
+        },
+        {
+          "value": "2",
+          "line": 22,
+          "column": 36
+        },
+        {
+          "value": "2",
+          "line": 23,
+          "column": 91
+        },
+        {
+          "value": "2",
+          "line": 23,
+          "column": 97
+        },
+        {
+          "value": "2",
+          "line": 25,
+          "column": 35
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repository_support_serializers.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 10,
+          "column": 60
+        }
+      ]
+    },
+    {
+      "path": "backend/app/repository_support_time.py",
+      "count": 5,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "20",
+          "line": 27,
+          "column": 33
+        },
+        {
+          "value": "0",
+          "line": 45,
+          "column": 73
+        },
+        {
+          "value": "1",
+          "line": 45,
+          "column": 80
+        },
+        {
+          "value": "0",
+          "line": 52,
+          "column": 21
+        },
+        {
+          "value": "1",
+          "line": 54,
+          "column": 40
+        }
+      ]
+    },
+    {
+      "path": "backend/app/routers/my.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "15",
+          "line": 76,
+          "column": 86
+        }
+      ]
+    },
+    {
+      "path": "backend/app/seed_data.py",
+      "count": 35,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "36.3671",
+          "line": 7,
+          "column": 21
+        },
+        {
+          "value": "127.3886",
+          "line": 8,
+          "column": 22
+        },
+        {
+          "value": "40",
+          "line": 12,
+          "column": 24
+        },
+        {
+          "value": "1",
+          "line": 12,
+          "column": 30
+        },
+        {
+          "value": "20",
+          "line": 12,
+          "column": 34
+        },
+        {
+          "value": "36.3765",
+          "line": 24,
+          "column": 21
+        }
+      ]
+    },
+    {
+      "path": "backend/app/seed.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 19,
+          "column": 63
+        }
+      ]
+    },
+    {
+      "path": "backend/app/services/notification_service.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 60,
+          "column": 28
+        }
+      ]
+    },
+    {
+      "path": "backend/app/services/review_service.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 72,
+          "column": 69
+        }
+      ]
+    },
+    {
+      "path": "backend/app/storage_core.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 49,
+          "column": 45
+        }
+      ]
+    },
+    {
+      "path": "backend/app/storage.py",
+      "count": 1,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 128,
+          "column": 47
+        }
+      ]
+    },
+    {
+      "path": "backend/app/user_routes.py",
+      "count": 11,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "6",
+          "line": 15,
+          "column": 25
+        },
+        {
+          "value": "2",
+          "line": 16,
+          "column": 25
+        },
+        {
+          "value": "2",
+          "line": 22,
+          "column": 37
+        },
+        {
+          "value": "6",
+          "line": 24,
+          "column": 37
+        },
+        {
+          "value": "2",
+          "line": 103,
+          "column": 21
+        },
+        {
+          "value": "8",
+          "line": 105,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "backend/run_appserver.py",
+      "count": 3,
+      "owner": "fastapi-backend",
+      "category": "fastapi-runtime-config-baseline",
+      "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
+      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 13,
+          "column": 11
+        },
+        {
+          "value": "127.0",
+          "line": 19,
+          "column": 39
+        },
+        {
+          "value": "8001",
+          "line": 19,
+          "column": 56
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/index.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "500",
+          "line": 83,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/lib/dates.ts",
+      "count": 6,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 5,
+          "column": 53
+        },
+        {
+          "value": "2",
+          "line": 5,
+          "column": 69
+        },
+        {
+          "value": "2",
+          "line": 5,
+          "column": 86
+        },
+        {
+          "value": "2",
+          "line": 5,
+          "column": 105
+        },
+        {
+          "value": "2",
+          "line": 10,
+          "column": 53
+        },
+        {
+          "value": "2",
+          "line": 10,
+          "column": 69
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/lib/http.ts",
+      "count": 3,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 27,
+          "column": 52
+        },
+        {
+          "value": "302",
+          "line": 87,
+          "column": 39
+        },
+        {
+          "value": "204",
+          "line": 93,
+          "column": 39
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/lib/supabase.ts",
+      "count": 4,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "12",
+          "line": 58,
+          "column": 57
+        },
+        {
+          "value": "24",
+          "line": 58,
+          "column": 72
+        },
+        {
+          "value": "0",
+          "line": 60,
+          "column": 39
+        },
+        {
+          "value": "0",
+          "line": 72,
+          "column": 25
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/base-data-assembler.ts",
+      "count": 2,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 33,
+          "column": 130
+        },
+        {
+          "value": "0",
+          "line": 42,
+          "column": 108
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/base-data-mappers.ts",
+      "count": 22,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 21,
+          "column": 89
+        },
+        {
+          "value": "1",
+          "line": 21,
+          "column": 115
+        },
+        {
+          "value": "0",
+          "line": 28,
+          "column": 27
+        },
+        {
+          "value": "1000",
+          "line": 29,
+          "column": 41
+        },
+        {
+          "value": "60",
+          "line": 29,
+          "column": 48
+        },
+        {
+          "value": "60",
+          "line": 29,
+          "column": 53
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/base-data-repository.ts",
+      "count": 5,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "5",
+          "line": 12,
+          "column": 34
+        },
+        {
+          "value": "60",
+          "line": 12,
+          "column": 38
+        },
+        {
+          "value": "1000",
+          "line": 12,
+          "column": 43
+        },
+        {
+          "value": "0",
+          "line": 17,
+          "column": 14
+        },
+        {
+          "value": "0",
+          "line": 126,
+          "column": 37
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/proxy.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "501",
+          "line": 29,
+          "column": 25
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/route-handlers.ts",
+      "count": 6,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "200",
+          "line": 14,
+          "column": 5
+        },
+        {
+          "value": "200",
+          "line": 45,
+          "column": 5
+        },
+        {
+          "value": "0",
+          "line": 54,
+          "column": 44
+        },
+        {
+          "value": "200",
+          "line": 65,
+          "column": 23
+        },
+        {
+          "value": "200",
+          "line": 72,
+          "column": 5
+        },
+        {
+          "value": "0",
+          "line": 83,
+          "column": 45
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/runtime/route-registry.ts",
+      "count": 15,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 74,
+          "column": 116
+        },
+        {
+          "value": "1",
+          "line": 75,
+          "column": 92
+        },
+        {
+          "value": "1",
+          "line": 76,
+          "column": 93
+        },
+        {
+          "value": "1",
+          "line": 82,
+          "column": 87
+        },
+        {
+          "value": "200",
+          "line": 83,
+          "column": 29
+        },
+        {
+          "value": "1",
+          "line": 86,
+          "column": 102
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/admin-domain/repository.ts",
+      "count": 9,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 20,
+          "column": 66
+        },
+        {
+          "value": "0",
+          "line": 20,
+          "column": 68
+        },
+        {
+          "value": "0",
+          "line": 20,
+          "column": 70
+        },
+        {
+          "value": "1",
+          "line": 21,
+          "column": 48
+        },
+        {
+          "value": "0",
+          "line": 21,
+          "column": 55
+        },
+        {
+          "value": "0",
+          "line": 22,
+          "column": 43
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/admin.ts",
+      "count": 11,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "403",
+          "line": 17,
+          "column": 39
+        },
+        {
+          "value": "0",
+          "line": 27,
+          "column": 73
+        },
+        {
+          "value": "1",
+          "line": 27,
+          "column": 78
+        },
+        {
+          "value": "0",
+          "line": 43,
+          "column": 76
+        },
+        {
+          "value": "200",
+          "line": 54,
+          "column": 25
+        },
+        {
+          "value": "404",
+          "line": 75,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/auth.ts",
+      "count": 10,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "503",
+          "line": 35,
+          "column": 23
+        },
+        {
+          "value": "200",
+          "line": 57,
+          "column": 23
+        },
+        {
+          "value": "200",
+          "line": 61,
+          "column": 23
+        },
+        {
+          "value": "200",
+          "line": 65,
+          "column": 23
+        },
+        {
+          "value": "400",
+          "line": 83,
+          "column": 30
+        },
+        {
+          "value": "200",
+          "line": 110,
+          "column": 25
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/auth/kakao-provider.ts",
+      "count": 2,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 53,
+          "column": 70
+        },
+        {
+          "value": "8",
+          "line": 69,
+          "column": 70
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/auth/naver-provider.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "00",
+          "line": 56,
+          "column": 47
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/auth/session.ts",
+      "count": 16,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "60",
+          "line": 6,
+          "column": 33
+        },
+        {
+          "value": "60",
+          "line": 6,
+          "column": 38
+        },
+        {
+          "value": "24",
+          "line": 6,
+          "column": 43
+        },
+        {
+          "value": "7",
+          "line": 6,
+          "column": 48
+        },
+        {
+          "value": "60",
+          "line": 7,
+          "column": 37
+        },
+        {
+          "value": "10",
+          "line": 7,
+          "column": 42
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/auth/social-user.ts",
+      "count": 12,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 18,
+          "column": 71
+        },
+        {
+          "value": "0",
+          "line": 20,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 26,
+          "column": 117
+        },
+        {
+          "value": "0",
+          "line": 28,
+          "column": 17
+        },
+        {
+          "value": "2",
+          "line": 50,
+          "column": 27
+        },
+        {
+          "value": "400",
+          "line": 52,
+          "column": 20
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/community-domain/mapper.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 29,
+          "column": 36
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/community-domain/repository.ts",
+      "count": 10,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 7,
+          "column": 100
+        },
+        {
+          "value": "0",
+          "line": 9,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 43,
+          "column": 159
+        },
+        {
+          "value": "0",
+          "line": 45,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 51,
+          "column": 138
+        },
+        {
+          "value": "0",
+          "line": 53,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/community-routes.ts",
+      "count": 16,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "401",
+          "line": 27,
+          "column": 39
+        },
+        {
+          "value": "0",
+          "line": 44,
+          "column": 35
+        },
+        {
+          "value": "200",
+          "line": 60,
+          "column": 25
+        },
+        {
+          "value": "401",
+          "line": 66,
+          "column": 27
+        },
+        {
+          "value": "200",
+          "line": 68,
+          "column": 25
+        },
+        {
+          "value": "400",
+          "line": 84,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festivals.ts",
+      "count": 72,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "10",
+          "line": 5,
+          "column": 32
+        },
+        {
+          "value": "60",
+          "line": 5,
+          "column": 37
+        },
+        {
+          "value": "1000",
+          "line": 5,
+          "column": 42
+        },
+        {
+          "value": "504",
+          "line": 8,
+          "column": 93
+        },
+        {
+          "value": "0",
+          "line": 9,
+          "column": 35
+        },
+        {
+          "value": "0",
+          "line": 9,
+          "column": 46
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/my-domain/repository.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 9,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/my.ts",
+      "count": 9,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "10",
+          "line": 9,
+          "column": 36
+        },
+        {
+          "value": "0",
+          "line": 12,
+          "column": 40
+        },
+        {
+          "value": "0",
+          "line": 14,
+          "column": 29
+        },
+        {
+          "value": "401",
+          "line": 26,
+          "column": 27
+        },
+        {
+          "value": "10",
+          "line": 30,
+          "column": 34
+        },
+        {
+          "value": "20",
+          "line": 30,
+          "column": 38
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/notifications.ts",
+      "count": 21,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "401",
+          "line": 6,
+          "column": 37
+        },
+        {
+          "value": "1",
+          "line": 8,
+          "column": 290
+        },
+        {
+          "value": "0",
+          "line": 8,
+          "column": 309
+        },
+        {
+          "value": "0",
+          "line": 11,
+          "column": 462
+        },
+        {
+          "value": "30",
+          "line": 12,
+          "column": 66
+        },
+        {
+          "value": "0",
+          "line": 13,
+          "column": 228
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/review-domain/mapper.ts",
+      "count": 6,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 5,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 7,
+          "column": 16
+        },
+        {
+          "value": "0",
+          "line": 80,
+          "column": 63
+        },
+        {
+          "value": "1",
+          "line": 80,
+          "column": 68
+        },
+        {
+          "value": "1",
+          "line": 89,
+          "column": 51
+        },
+        {
+          "value": "0",
+          "line": 103,
+          "column": 62
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/review-domain/repository.ts",
+      "count": 10,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 7,
+          "column": 94
+        },
+        {
+          "value": "0",
+          "line": 9,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 15,
+          "column": 126
+        },
+        {
+          "value": "0",
+          "line": 17,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 23,
+          "column": 155
+        },
+        {
+          "value": "0",
+          "line": 25,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/review-interactions.ts",
+      "count": 39,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "9",
+          "line": 22,
+          "column": 62
+        },
+        {
+          "value": "9_",
+          "line": 40,
+          "column": 67
+        },
+        {
+          "value": "401",
+          "line": 71,
+          "column": 37
+        },
+        {
+          "value": "400",
+          "line": 85,
+          "column": 25
+        },
+        {
+          "value": "400",
+          "line": 88,
+          "column": 25
+        },
+        {
+          "value": "5242880",
+          "line": 90,
+          "column": 66
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/reviews.ts",
+      "count": 18,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 50,
+          "column": 39
+        },
+        {
+          "value": "10",
+          "line": 62,
+          "column": 36
+        },
+        {
+          "value": "1",
+          "line": 66,
+          "column": 152
+        },
+        {
+          "value": "0",
+          "line": 73,
+          "column": 37
+        },
+        {
+          "value": "0",
+          "line": 97,
+          "column": 39
+        },
+        {
+          "value": "1",
+          "line": 111,
+          "column": 142
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/stamps.ts",
+      "count": 40,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "120",
+          "line": 5,
+          "column": 99
+        },
+        {
+          "value": "0",
+          "line": 5,
+          "column": 149
+        },
+        {
+          "value": "120",
+          "line": 5,
+          "column": 162
+        },
+        {
+          "value": "6371000",
+          "line": 6,
+          "column": 120
+        },
+        {
+          "value": "180",
+          "line": 6,
+          "column": 195
+        },
+        {
+          "value": "180",
+          "line": 6,
+          "column": 269
+        }
+      ]
+    },
+    {
+      "path": "scripts/build-frontend.mjs",
+      "count": 59,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 35,
+          "column": 31
+        },
+        {
+          "value": "0",
+          "line": 39,
+          "column": 35
+        },
+        {
+          "value": "1",
+          "line": 40,
+          "column": 54
+        },
+        {
+          "value": "8000",
+          "line": 59,
+          "column": 88
+        },
+        {
+          "value": "2",
+          "line": 87,
+          "column": 5
+        },
+        {
+          "value": "31536000",
+          "line": 103,
+          "column": 34
+        }
+      ]
+    },
+    {
+      "path": "scripts/build-frontend.ps1",
+      "count": 53,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 31,
+          "column": 39
+        },
+        {
+          "value": "1",
+          "line": 32,
+          "column": 59
+        },
+        {
+          "value": "0",
+          "line": 94,
+          "column": 23
+        },
+        {
+          "value": "31536000",
+          "line": 130,
+          "column": 34
+        },
+        {
+          "value": "31536000",
+          "line": 133,
+          "column": 34
+        },
+        {
+          "value": "2000",
+          "line": 137,
+          "column": 31
+        }
+      ]
+    },
+    {
+      "path": "scripts/create-cloudflare-pages-project.ps1",
+      "count": 4,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "5",
+          "line": 25,
+          "column": 27
+        },
+        {
+          "value": "0",
+          "line": 33,
+          "column": 10
+        },
+        {
+          "value": "409",
+          "line": 37,
+          "column": 25
+        },
+        {
+          "value": "0",
+          "line": 43,
+          "column": 14
+        }
+      ]
+    },
+    {
+      "path": "scripts/daejeon-event-sync/constants.ts",
+      "count": 1,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "504",
+          "line": 1,
+          "column": 82
+        }
+      ]
+    },
+    {
+      "path": "scripts/daejeon-event-sync/fetch.ts",
+      "count": 6,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "504",
+          "line": 11,
+          "column": 15
+        },
+        {
+          "value": "8",
+          "line": 27,
+          "column": 71
+        },
+        {
+          "value": "1",
+          "line": 50,
+          "column": 73
+        },
+        {
+          "value": "1",
+          "line": 52,
+          "column": 31
+        },
+        {
+          "value": "2",
+          "line": 54,
+          "column": 24
+        },
+        {
+          "value": "1",
+          "line": 54,
+          "column": 62
+        }
+      ]
+    },
+    {
+      "path": "scripts/daejeon-event-sync/normalize.ts",
+      "count": 40,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "39",
+          "line": 7,
+          "column": 5
+        },
+        {
+          "value": "39",
+          "line": 12,
+          "column": 50
+        },
+        {
+          "value": "00",
+          "line": 42,
+          "column": 25
+        },
+        {
+          "value": "00",
+          "line": 42,
+          "column": 28
+        },
+        {
+          "value": "09",
+          "line": 42,
+          "column": 31
+        },
+        {
+          "value": "00",
+          "line": 42,
+          "column": 34
+        }
+      ]
+    },
+    {
+      "path": "scripts/daejeon-event-sync/report.ts",
+      "count": 5,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 6,
+          "column": 20
+        },
+        {
+          "value": "0",
+          "line": 7,
+          "column": 46
+        },
+        {
+          "value": "0",
+          "line": 7,
+          "column": 64
+        },
+        {
+          "value": "10",
+          "line": 7,
+          "column": 67
+        },
+        {
+          "value": "0",
+          "line": 7,
+          "column": 87
+        }
+      ]
+    },
+    {
+      "path": "scripts/daejeon-event-sync/upload.ts",
+      "count": 1,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "8",
+          "line": 32,
+          "column": 54
+        }
+      ]
+    },
+    {
+      "path": "scripts/dev.ps1",
+      "count": 35,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "40",
+          "line": 5,
+          "column": 19
+        },
+        {
+          "value": "1.29",
+          "line": 20,
+          "column": 53
+        },
+        {
+          "value": "8.4",
+          "line": 21,
+          "column": 52
+        },
+        {
+          "value": "8001",
+          "line": 29,
+          "column": 49
+        },
+        {
+          "value": "8001",
+          "line": 30,
+          "column": 49
+        },
+        {
+          "value": "1000",
+          "line": 47,
+          "column": 29
+        }
+      ]
+    },
+    {
+      "path": "scripts/generate_seed_places.ps1",
+      "count": 140,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "30",
+          "line": 13,
+          "column": 23
+        },
+        {
+          "value": "1",
+          "line": 13,
+          "column": 29
+        },
+        {
+          "value": "40",
+          "line": 26,
+          "column": 23
+        },
+        {
+          "value": "1",
+          "line": 26,
+          "column": 29
+        },
+        {
+          "value": "30",
+          "line": 26,
+          "column": 33
+        },
+        {
+          "value": "30",
+          "line": 39,
+          "column": 23
+        }
+      ]
+    },
+    {
+      "path": "scripts/generate-sample-place-data.ts",
+      "count": 5,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "3",
+          "line": 39,
+          "column": 66
+        },
+        {
+          "value": "0",
+          "line": 39,
+          "column": 70
+        },
+        {
+          "value": "0",
+          "line": 66,
+          "column": 23
+        },
+        {
+          "value": "0",
+          "line": 71,
+          "column": 28
+        },
+        {
+          "value": "2",
+          "line": 77,
+          "column": 128
+        }
+      ]
+    },
+    {
+      "path": "scripts/install-local-mysql.ps1",
+      "count": 2,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "8.4",
+          "line": 8,
+          "column": 13
+        },
+        {
+          "value": "8.4",
+          "line": 10,
+          "column": 56
+        }
+      ]
+    },
+    {
+      "path": "scripts/install-local-nginx.ps1",
+      "count": 3,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "1.29",
+          "line": 8,
+          "column": 39
+        },
+        {
+          "value": "1.29",
+          "line": 13,
+          "column": 70
+        },
+        {
+          "value": "1.29",
+          "line": 17,
+          "column": 39
+        }
+      ]
+    },
+    {
+      "path": "scripts/mysql-local.ps1",
+      "count": 17,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "8.4",
+          "line": 13,
+          "column": 13
+        },
+        {
+          "value": "3306",
+          "line": 27,
+          "column": 9
+        },
+        {
+          "value": "127.0",
+          "line": 28,
+          "column": 14
+        },
+        {
+          "value": "1000",
+          "line": 45,
+          "column": 29
+        },
+        {
+          "value": "20",
+          "line": 63,
+          "column": 32
+        },
+        {
+          "value": "500",
+          "line": 72,
+          "column": 35
+        }
+      ]
+    },
+    {
+      "path": "scripts/run-protected-smoke-checks.ts",
+      "count": 3,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 43,
+          "column": 47
+        },
+        {
+          "value": "1",
+          "line": 61,
+          "column": 54
+        },
+        {
+          "value": "1",
+          "line": 64,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "scripts/run-public-smoke-checks.ts",
+      "count": 21,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "200",
+          "line": 18,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 18,
+          "column": 49
+        },
+        {
+          "value": "200",
+          "line": 27,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 27,
+          "column": 49
+        },
+        {
+          "value": "200",
+          "line": 33,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 33,
+          "column": 49
+        }
+      ]
+    },
+    {
+      "path": "scripts/run-smoke-checks.ts",
+      "count": 2,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 7,
+          "column": 54
+        },
+        {
+          "value": "1",
+          "line": 10,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "scripts/run-unit-tests.ts",
+      "count": 3,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "8192",
+          "line": 31,
+          "column": 28
+        },
+        {
+          "value": "0",
+          "line": 38,
+          "column": 25
+        },
+        {
+          "value": "1",
+          "line": 39,
+          "column": 35
+        }
+      ]
+    },
+    {
+      "path": "scripts/sample-place/derive.ts",
+      "count": 35,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "70",
+          "line": 2,
+          "column": 3
+        },
+        {
+          "value": "36.3688239",
+          "line": 2,
+          "column": 19
+        },
+        {
+          "value": "127.3879822",
+          "line": 2,
+          "column": 42
+        },
+        {
+          "value": "71",
+          "line": 3,
+          "column": 3
+        },
+        {
+          "value": "36.3601462",
+          "line": 3,
+          "column": 19
+        },
+        {
+          "value": "127.3570634",
+          "line": 3,
+          "column": 42
+        }
+      ]
+    },
+    {
+      "path": "scripts/sample-place/parse.ts",
+      "count": 11,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "39",
+          "line": 12,
+          "column": 5
+        },
+        {
+          "value": "39",
+          "line": 17,
+          "column": 37
+        },
+        {
+          "value": "1",
+          "line": 48,
+          "column": 29
+        },
+        {
+          "value": "1",
+          "line": 48,
+          "column": 102
+        },
+        {
+          "value": "5",
+          "line": 49,
+          "column": 26
+        },
+        {
+          "value": "0",
+          "line": 49,
+          "column": 37
+        }
+      ]
+    },
+    {
+      "path": "scripts/smoke/protected.ts",
+      "count": 6,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "200",
+          "line": 6,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 6,
+          "column": 49
+        },
+        {
+          "value": "200",
+          "line": 15,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 15,
+          "column": 49
+        },
+        {
+          "value": "200",
+          "line": 25,
+          "column": 34
+        },
+        {
+          "value": "200",
+          "line": 25,
+          "column": 49
+        }
+      ]
+    },
+    {
+      "path": "scripts/smoke/shared.ts",
+      "count": 28,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "5.0",
+          "line": 4,
+          "column": 12
+        },
+        {
+          "value": "10.0",
+          "line": 4,
+          "column": 28
+        },
+        {
+          "value": "537.36",
+          "line": 4,
+          "column": 58
+        },
+        {
+          "value": "135.0",
+          "line": 4,
+          "column": 92
+        },
+        {
+          "value": "537.36",
+          "line": 4,
+          "column": 109
+        },
+        {
+          "value": "15000",
+          "line": 8,
+          "column": 65
+        }
+      ]
+    },
+    {
+      "path": "scripts/sync-daejeon-events.ts",
+      "count": 17,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 13,
+          "column": 20
+        },
+        {
+          "value": "1",
+          "line": 13,
+          "column": 53
+        },
+        {
+          "value": "1",
+          "line": 20,
+          "column": 35
+        },
+        {
+          "value": "1",
+          "line": 21,
+          "column": 16
+        },
+        {
+          "value": "1",
+          "line": 25,
+          "column": 33
+        },
+        {
+          "value": "1",
+          "line": 26,
+          "column": 16
+        }
+      ]
+    },
+    {
+      "path": "scripts/upload-sample-place-images.ts",
+      "count": 5,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 13,
+          "column": 20
+        },
+        {
+          "value": "0",
+          "line": 94,
+          "column": 51
+        },
+        {
+          "value": "3",
+          "line": 99,
+          "column": 70
+        },
+        {
+          "value": "0",
+          "line": 99,
+          "column": 74
+        },
+        {
+          "value": "1",
+          "line": 109,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/api/bootstrapClient.ts",
+      "count": 6,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "404",
+          "line": 14,
+          "column": 56
+        },
+        {
+          "value": "501",
+          "line": 14,
+          "column": 80
+        },
+        {
+          "value": "500",
+          "line": 14,
+          "column": 103
+        },
+        {
+          "value": "404",
+          "line": 31,
+          "column": 56
+        },
+        {
+          "value": "501",
+          "line": 31,
+          "column": 80
+        },
+        {
+          "value": "500",
+          "line": 31,
+          "column": 103
+        }
+      ]
+    },
+    {
+      "path": "src/api/core.ts",
+      "count": 13,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "15_000",
+          "line": 12,
+          "column": 28
+        },
+        {
+          "value": "30",
+          "line": 36,
+          "column": 12
+        },
+        {
+          "value": "60",
+          "line": 36,
+          "column": 17
+        },
+        {
+          "value": "1000",
+          "line": 36,
+          "column": 22
+        },
+        {
+          "value": "60",
+          "line": 39,
+          "column": 12
+        },
+        {
+          "value": "1000",
+          "line": 39,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "src/components/comment-thread/CommentComposer.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 25,
+          "column": 30
+        },
+        {
+          "value": "2",
+          "line": 37,
+          "column": 111
+        }
+      ]
+    },
+    {
+      "path": "src/components/comment-thread/CommentThreadItem.tsx",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 37,
+          "column": 30
+        },
+        {
+          "value": "2",
+          "line": 84,
+          "column": 124
+        },
+        {
+          "value": "0",
+          "line": 122,
+          "column": 47
+        }
+      ]
+    },
+    {
+      "path": "src/components/CommentThread.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 30,
+          "column": 26
+        }
+      ]
+    },
+    {
+      "path": "src/components/course/CommunityRouteCard.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 61,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/components/CourseTab.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 62,
+          "column": 39
+        }
+      ]
+    },
+    {
+      "path": "src/components/EventTab.tsx",
+      "count": 6,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "9",
+          "line": 24,
+          "column": 29
+        },
+        {
+          "value": "2",
+          "line": 24,
+          "column": 33
+        },
+        {
+          "value": "2",
+          "line": 25,
+          "column": 18
+        },
+        {
+          "value": "0",
+          "line": 68,
+          "column": 31
+        },
+        {
+          "value": "30",
+          "line": 69,
+          "column": 48
+        },
+        {
+          "value": "0",
+          "line": 86,
+          "column": 81
+        }
+      ]
+    },
+    {
+      "path": "src/components/FeedCommentSheet.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "72",
+          "line": 54,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "src/components/FestivalDetailSheet.tsx",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "9",
+          "line": 18,
+          "column": 29
+        },
+        {
+          "value": "2",
+          "line": 18,
+          "column": 33
+        },
+        {
+          "value": "2",
+          "line": 19,
+          "column": 18
+        }
+      ]
+    },
+    {
+      "path": "src/components/floating-back-button/constants.ts",
+      "count": 5,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "46",
+          "line": 1,
+          "column": 28
+        },
+        {
+          "value": "12",
+          "line": 2,
+          "column": 29
+        },
+        {
+          "value": "120",
+          "line": 3,
+          "column": 39
+        },
+        {
+          "value": "180",
+          "line": 4,
+          "column": 36
+        },
+        {
+          "value": "260",
+          "line": 5,
+          "column": 36
+        }
+      ]
+    },
+    {
+      "path": "src/components/floating-back-button/position.ts",
+      "count": 1,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "640",
+          "line": 66,
+          "column": 49
+        }
+      ]
+    },
+    {
+      "path": "src/components/floating-back-button/useFloatingBackButton.ts",
+      "count": 9,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "-1",
+          "line": 22,
+          "column": 16
+        },
+        {
+          "value": "0",
+          "line": 23,
+          "column": 13
+        },
+        {
+          "value": "0",
+          "line": 24,
+          "column": 13
+        },
+        {
+          "value": "0",
+          "line": 25,
+          "column": 14
+        },
+        {
+          "value": "0",
+          "line": 26,
+          "column": 14
+        },
+        {
+          "value": "-1",
+          "line": 62,
+          "column": 38
+        }
+      ]
+    },
+    {
+      "path": "src/components/GlobalFeedbackButton.tsx",
+      "count": 30,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 5,
+          "column": 19
+        },
+        {
+          "value": "0",
+          "line": 5,
+          "column": 21
+        },
+        {
+          "value": "24",
+          "line": 5,
+          "column": 23
+        },
+        {
+          "value": "24",
+          "line": 5,
+          "column": 26
+        },
+        {
+          "value": "3",
+          "line": 7,
+          "column": 15
+        },
+        {
+          "value": "3",
+          "line": 7,
+          "column": 29
+        }
+      ]
+    },
+    {
+      "path": "src/components/GlobalNotificationCenter.tsx",
+      "count": 48,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 17,
+          "column": 19
+        },
+        {
+          "value": "0",
+          "line": 17,
+          "column": 21
+        },
+        {
+          "value": "24",
+          "line": 17,
+          "column": 23
+        },
+        {
+          "value": "24",
+          "line": 17,
+          "column": 26
+        },
+        {
+          "value": "4",
+          "line": 19,
+          "column": 16
+        },
+        {
+          "value": "4.25",
+          "line": 19,
+          "column": 26
+        }
+      ]
+    },
+    {
+      "path": "src/components/GlobalSettingsMenu.tsx",
+      "count": 128,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 18,
+          "column": 19
+        },
+        {
+          "value": "0",
+          "line": 18,
+          "column": 21
+        },
+        {
+          "value": "24",
+          "line": 18,
+          "column": 23
+        },
+        {
+          "value": "24",
+          "line": 18,
+          "column": 26
+        },
+        {
+          "value": "4",
+          "line": 20,
+          "column": 19
+        },
+        {
+          "value": "1",
+          "line": 20,
+          "column": 26
+        }
+      ]
+    },
+    {
+      "path": "src/components/map-stage/MapStageCategoryStrip.tsx",
+      "count": 4,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "255",
+          "line": 28,
+          "column": 65
+        },
+        {
+          "value": "255",
+          "line": 28,
+          "column": 69
+        },
+        {
+          "value": "255",
+          "line": 28,
+          "column": 73
+        },
+        {
+          "value": "0.94",
+          "line": 28,
+          "column": 77
+        }
+      ]
+    },
+    {
+      "path": "src/components/map-stage/MapStageMapSurface.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "100%",
+          "line": 41,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "src/components/map-stage/MapStageRoutePreviewCard.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 43,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyCommentsTabSection.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 44,
+          "column": 28
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyFeedReviewCard.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "4",
+          "line": 100,
+          "column": 93
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyFeedTabSection.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 42,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyPageOverviewSection.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 44,
+          "column": 26
+        },
+        {
+          "value": "0",
+          "line": 68,
+          "column": 41
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyPageSettingsSection.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "40",
+          "line": 45,
+          "column": 128
+        },
+        {
+          "value": "2",
+          "line": 48,
+          "column": 130
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyPublishedRouteCard.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 30,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyRouteDraftCard.tsx",
+      "count": 4,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 33,
+          "column": 22
+        },
+        {
+          "value": "3",
+          "line": 44,
+          "column": 27
+        },
+        {
+          "value": "2",
+          "line": 56,
+          "column": 68
+        },
+        {
+          "value": "8",
+          "line": 56,
+          "column": 107
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyRoutesTabSection.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 34,
+          "column": 41
+        },
+        {
+          "value": "0",
+          "line": 43,
+          "column": 28
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/myRoutesTabTypes.ts",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 25,
+          "column": 45
+        },
+        {
+          "value": "1",
+          "line": 26,
+          "column": 72
+        },
+        {
+          "value": "24",
+          "line": 29,
+          "column": 57
+        }
+      ]
+    },
+    {
+      "path": "src/components/my-page/MyStampTabSection.tsx",
+      "count": 4,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 23,
+          "column": 37
+        },
+        {
+          "value": "24",
+          "line": 32,
+          "column": 39
+        },
+        {
+          "value": "2",
+          "line": 52,
+          "column": 78
+        },
+        {
+          "value": "0",
+          "line": 57,
+          "column": 29
+        }
+      ]
+    },
+    {
+      "path": "src/components/MyPagePanel.tsx",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 74,
+          "column": 53
+        },
+        {
+          "value": "100",
+          "line": 75,
+          "column": 85
+        },
+        {
+          "value": "0",
+          "line": 76,
+          "column": 9
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/mapSdk.ts",
+      "count": 2,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "36.3504",
+          "line": 1,
+          "column": 43
+        },
+        {
+          "value": "127.3845",
+          "line": 1,
+          "column": 63
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/markerContent.ts",
+      "count": 144,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "95",
+          "line": 6,
+          "column": 45
+        },
+        {
+          "value": "70",
+          "line": 6,
+          "column": 49
+        },
+        {
+          "value": "96",
+          "line": 6,
+          "column": 53
+        },
+        {
+          "value": "0.18",
+          "line": 6,
+          "column": 57
+        },
+        {
+          "value": "1.08",
+          "line": 7,
+          "column": 35
+        },
+        {
+          "value": "1",
+          "line": 7,
+          "column": 51
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/selectionOffset.ts",
+      "count": 19,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 2,
+          "column": 49
+        },
+        {
+          "value": "640",
+          "line": 3,
+          "column": 82
+        },
+        {
+          "value": "0",
+          "line": 4,
+          "column": 20
+        },
+        {
+          "value": "360",
+          "line": 6,
+          "column": 33
+        },
+        {
+          "value": "250",
+          "line": 6,
+          "column": 39
+        },
+        {
+          "value": "280",
+          "line": 8,
+          "column": 31
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverCurrentLocationFocus.ts",
+      "count": 1,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 31,
+          "column": 110
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverCurrentLocationMarker.ts",
+      "count": 3,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "200",
+          "line": 41,
+          "column": 17
+        },
+        {
+          "value": "15",
+          "line": 44,
+          "column": 37
+        },
+        {
+          "value": "15",
+          "line": 44,
+          "column": 41
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverFestivalMarkers.ts",
+      "count": 10,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "15",
+          "line": 33,
+          "column": 44
+        },
+        {
+          "value": "15",
+          "line": 33,
+          "column": 48
+        },
+        {
+          "value": "170",
+          "line": 57,
+          "column": 54
+        },
+        {
+          "value": "110",
+          "line": 57,
+          "column": 60
+        },
+        {
+          "value": "15",
+          "line": 78,
+          "column": 44
+        },
+        {
+          "value": "15",
+          "line": 78,
+          "column": 48
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverMapInstance.ts",
+      "count": 2,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "13",
+          "line": 42,
+          "column": 32
+        },
+        {
+          "value": "11",
+          "line": 43,
+          "column": 20
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverMapInteractions.ts",
+      "count": 1,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 43,
+          "column": 56
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverPlaceMarkers.ts",
+      "count": 8,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "15",
+          "line": 33,
+          "column": 44
+        },
+        {
+          "value": "15",
+          "line": 33,
+          "column": 48
+        },
+        {
+          "value": "15",
+          "line": 74,
+          "column": 44
+        },
+        {
+          "value": "15",
+          "line": 74,
+          "column": 48
+        },
+        {
+          "value": "100",
+          "line": 85,
+          "column": 32
+        },
+        {
+          "value": "160",
+          "line": 97,
+          "column": 32
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverRoutePreviewOverlay.ts",
+      "count": 16,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 53,
+          "column": 62
+        },
+        {
+          "value": "0.82",
+          "line": 62,
+          "column": 22
+        },
+        {
+          "value": "4",
+          "line": 63,
+          "column": 21
+        },
+        {
+          "value": "120",
+          "line": 66,
+          "column": 15
+        },
+        {
+          "value": "165",
+          "line": 75,
+          "column": 19
+        },
+        {
+          "value": "1",
+          "line": 77,
+          "column": 53
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverSelectionSync.ts",
+      "count": 7,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "13",
+          "line": 57,
+          "column": 85
+        },
+        {
+          "value": "15",
+          "line": 58,
+          "column": 75
+        },
+        {
+          "value": "15",
+          "line": 58,
+          "column": 81
+        },
+        {
+          "value": "640",
+          "line": 71,
+          "column": 86
+        },
+        {
+          "value": "260",
+          "line": 72,
+          "column": 71
+        },
+        {
+          "value": "180",
+          "line": 72,
+          "column": 77
+        }
+      ]
+    },
+    {
+      "path": "src/components/naver-map/useNaverViewportSync.ts",
+      "count": 1,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "300",
+          "line": 38,
+          "column": 10
+        }
+      ]
+    },
+    {
+      "path": "src/components/NaverMap.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "100%",
+          "line": 45,
+          "column": 13
+        },
+        {
+          "value": "100%",
+          "line": 92,
+          "column": 49
+        }
+      ]
+    },
+    {
+      "path": "src/components/notifications/NotificationPanel.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 36,
+          "column": 163
+        },
+        {
+          "value": "0",
+          "line": 51,
+          "column": 35
+        }
+      ]
+    },
+    {
+      "path": "src/components/place/PlaceDetailReviewSection.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 36,
+          "column": 39
+        },
+        {
+          "value": "2",
+          "line": 36,
+          "column": 42
+        }
+      ]
+    },
+    {
+      "path": "src/components/place/usePlaceDrawerHandle.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "72",
+          "line": 31,
+          "column": 17
+        },
+        {
+          "value": "-48",
+          "line": 40,
+          "column": 17
+        }
+      ]
+    },
+    {
+      "path": "src/components/review/PlaceReviewPreviewList.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 9,
+          "column": 26
+        }
+      ]
+    },
+    {
+      "path": "src/components/review/ReviewActionIcons.tsx",
+      "count": 69,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 7,
+          "column": 19
+        },
+        {
+          "value": "0",
+          "line": 7,
+          "column": 21
+        },
+        {
+          "value": "24",
+          "line": 7,
+          "column": 23
+        },
+        {
+          "value": "24",
+          "line": 7,
+          "column": 26
+        },
+        {
+          "value": "21s",
+          "line": 9,
+          "column": 16
+        },
+        {
+          "value": "6.716",
+          "line": 9,
+          "column": 20
+        }
+      ]
+    },
+    {
+      "path": "src/components/review/ReviewImageFrame.tsx",
+      "count": 41,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 12,
+          "column": 55
+        },
+        {
+          "value": "0",
+          "line": 12,
+          "column": 66
+        },
+        {
+          "value": "0",
+          "line": 24,
+          "column": 50
+        },
+        {
+          "value": "0",
+          "line": 25,
+          "column": 52
+        },
+        {
+          "value": "100%",
+          "line": 42,
+          "column": 17
+        },
+        {
+          "value": "220px",
+          "line": 43,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/components/ReviewComposer.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "4",
+          "line": 40,
+          "column": 44
+        },
+        {
+          "value": "4",
+          "line": 91,
+          "column": 58
+        }
+      ]
+    },
+    {
+      "path": "src/components/ReviewFormFields.tsx",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "4",
+          "line": 75,
+          "column": 17
+        },
+        {
+          "value": "0",
+          "line": 111,
+          "column": 66
+        }
+      ]
+    },
+    {
+      "path": "src/components/ReviewList.tsx",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 47,
+          "column": 26
+        }
+      ]
+    },
+    {
+      "path": "src/components/RoadmapBannerPreview.tsx",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 27,
+          "column": 31
+        },
+        {
+          "value": "4",
+          "line": 27,
+          "column": 34
+        },
+        {
+          "value": "0",
+          "line": 64,
+          "column": 56
+        }
+      ]
+    },
+    {
+      "path": "src/config.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "8000",
+          "line": 17,
+          "column": 128
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/app-navigation/shellBackNavigation.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 55,
+          "column": 34
+        },
+        {
+          "value": "1",
+          "line": 111,
+          "column": 66
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/app-route-actions/publishRouteAction.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 73,
+          "column": 93
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/app-route/authQueryState.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "8000",
+          "line": 83,
+          "column": 30
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/app-route/mapViewportState.ts",
+      "count": 6,
+      "owner": "frontend-map",
+      "category": "map-coordinate-marker-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
+      "examples": [
+        {
+          "value": "36.3504",
+          "line": 7,
+          "column": 50
+        },
+        {
+          "value": "127.3845",
+          "line": 7,
+          "column": 64
+        },
+        {
+          "value": "13",
+          "line": 7,
+          "column": 80
+        },
+        {
+          "value": "10",
+          "line": 17,
+          "column": 48
+        },
+        {
+          "value": "5",
+          "line": 32,
+          "column": 33
+        },
+        {
+          "value": "5",
+          "line": 33,
+          "column": 33
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/app-tab-loaders/feedReviewLoader.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "10",
+          "line": 24,
+          "column": 51
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppAuthActions.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "2",
+          "line": 32,
+          "column": 48
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppCoordinatorEffects.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "120",
+          "line": 14,
+          "column": 36
+        },
+        {
+          "value": "4000",
+          "line": 15,
+          "column": 33
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppMapActions.ts",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 52,
+          "column": 55
+        },
+        {
+          "value": "0",
+          "line": 81,
+          "column": 66
+        },
+        {
+          "value": "1",
+          "line": 81,
+          "column": 71
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppPagePaginationActions.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "10",
+          "line": 46,
+          "column": 77
+        },
+        {
+          "value": "10",
+          "line": 81,
+          "column": 100
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppReviewCrudActions.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 150,
+          "column": 35
+        },
+        {
+          "value": "1",
+          "line": 150,
+          "column": 66
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppReviewLikeActions.ts",
+      "count": 4,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 30,
+          "column": 58
+        },
+        {
+          "value": "0",
+          "line": 32,
+          "column": 42
+        },
+        {
+          "value": "1",
+          "line": 32,
+          "column": 88
+        },
+        {
+          "value": "-1",
+          "line": 32,
+          "column": 92
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppShellNavigation.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 60,
+          "column": 63
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppShellStageProps.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 25,
+          "column": 74
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAppViewModels.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 78,
+          "column": 56
+        }
+      ]
+    },
+    {
+      "path": "src/hooks/useAutoLoadMore.ts",
+      "count": 3,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "160px",
+          "line": 18,
+          "column": 17
+        },
+        {
+          "value": "0px",
+          "line": 18,
+          "column": 23
+        },
+        {
+          "value": "0.01",
+          "line": 48,
+          "column": 20
+        }
+      ]
+    },
+    {
+      "path": "src/index.css",
+      "count": 1565,
+      "owner": "frontend-ui",
+      "category": "css-layout-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "CSS layout, spacing, radius, color, shadow, or motion values are migrated through UI token work.",
+      "examples": [
+        {
+          "value": "100vw",
+          "line": 3,
+          "column": 16
+        },
+        {
+          "value": "76px",
+          "line": 4,
+          "column": 29
+        },
+        {
+          "value": "255",
+          "line": 6,
+          "column": 46
+        },
+        {
+          "value": "214",
+          "line": 6,
+          "column": 51
+        },
+        {
+          "value": "227",
+          "line": 6,
+          "column": 56
+        },
+        {
+          "value": "0.82",
+          "line": 6,
+          "column": 61
+        }
+      ]
+    },
+    {
+      "path": "src/lib/geolocation.ts",
+      "count": 10,
+      "owner": "frontend-map",
+      "category": "geolocation-threshold-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Distance, radius, accuracy, and timeout values are migrated through geolocation config work.",
+      "examples": [
+        {
+          "value": "36.3504",
+          "line": 9,
+          "column": 36
+        },
+        {
+          "value": "127.3845",
+          "line": 9,
+          "column": 56
+        },
+        {
+          "value": "45_000",
+          "line": 10,
+          "column": 37
+        },
+        {
+          "value": "5_000",
+          "line": 11,
+          "column": 49
+        },
+        {
+          "value": "150",
+          "line": 12,
+          "column": 48
+        },
+        {
+          "value": "0",
+          "line": 18,
+          "column": 60
+        }
+      ]
+    },
+    {
+      "path": "src/lib/imageUpload.ts",
+      "count": 20,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
+      "examples": [
+        {
+          "value": "1600",
+          "line": 1,
+          "column": 30
+        },
+        {
+          "value": "1_000_000",
+          "line": 2,
+          "column": 26
+        },
+        {
+          "value": "0.84",
+          "line": 3,
+          "column": 30
+        },
+        {
+          "value": "0.58",
+          "line": 4,
+          "column": 26
+        },
+        {
+          "value": "0.08",
+          "line": 5,
+          "column": 27
+        },
+        {
+          "value": "960",
+          "line": 6,
+          "column": 36
+        }
+      ]
+    },
+    {
+      "path": "src/lib/reviews.ts",
+      "count": 2,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 4,
+          "column": 54
+        },
+        {
+          "value": "0",
+          "line": 4,
+          "column": 98
+        }
+      ]
+    },
+    {
+      "path": "src/lib/visits.ts",
+      "count": 17,
+      "owner": "frontend-map",
+      "category": "geolocation-threshold-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Distance, radius, accuracy, and timeout values are migrated through geolocation config work.",
+      "examples": [
+        {
+          "value": "6_371_000",
+          "line": 9,
+          "column": 29
+        },
+        {
+          "value": "180",
+          "line": 10,
+          "column": 69
+        },
+        {
+          "value": "180",
+          "line": 11,
+          "column": 72
+        },
+        {
+          "value": "180",
+          "line": 12,
+          "column": 60
+        },
+        {
+          "value": "180",
+          "line": 13,
+          "column": 56
+        },
+        {
+          "value": "2",
+          "line": 16,
+          "column": 30
+        }
+      ]
+    },
+    {
+      "path": "src/store/app-shell-runtime-store.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 35,
+          "column": 24
+        }
+      ]
+    },
+    {
+      "path": "src/store/notification-store/actions.ts",
+      "count": 3,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "3000",
+          "line": 100,
+          "column": 18
+        },
+        {
+          "value": "0",
+          "line": 132,
+          "column": 31
+        },
+        {
+          "value": "0",
+          "line": 139,
+          "column": 22
+        }
+      ]
+    },
+    {
+      "path": "src/store/notification-store/helpers.ts",
+      "count": 1,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 78,
+          "column": 16
+        }
+      ]
+    },
+    {
+      "path": "src/styles/refinements.css",
+      "count": 1177,
+      "owner": "frontend-ui",
+      "category": "css-layout-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "CSS layout, spacing, radius, color, shadow, or motion values are migrated through UI token work.",
+      "examples": [
+        {
+          "value": "2026",
+          "line": 1,
+          "column": 4
+        },
+        {
+          "value": "03",
+          "line": 1,
+          "column": 9
+        },
+        {
+          "value": "18",
+          "line": 1,
+          "column": 12
+        },
+        {
+          "value": "10px",
+          "line": 10,
+          "column": 8
+        },
+        {
+          "value": "100%",
+          "line": 11,
+          "column": 11
+        },
+        {
+          "value": "14px",
+          "line": 12,
+          "column": 12
+        }
+      ]
+    }
+  ]
+}

--- a/test/unit/numeric-literal-audit.test.ts
+++ b/test/unit/numeric-literal-audit.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import {
+  auditNumericLiterals,
+  compareAuditToBaseline,
+  loadNumericLiteralBaseline,
+} from '../../scripts/numeric-literal-audit';
+
+describe('numeric literal config audit', () => {
+  it('keeps production numeric literals classified by config-hardening owner', () => {
+    const baseline = loadNumericLiteralBaseline();
+
+    expect(baseline.version).toBe(1);
+    expect(baseline.files.length).toBeGreaterThan(0);
+    expect(baseline.files.every((file) => file.owner && file.category && file.scopeId && file.reason)).toBe(true);
+    expect(baseline.files.filter((file) => file.category === 'unclassified-production-literal')).toEqual([]);
+  });
+
+  it('fails when production numeric literal counts drift without updating the baseline', () => {
+    const current = auditNumericLiterals();
+    const baseline = loadNumericLiteralBaseline();
+
+    expect(compareAuditToBaseline(current, baseline)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 요약
- Scope-ID: `TSK-002-01-HARDCODED-VALUE-AUDIT`
- Parent Issue: #238
- Child Issue: Closes #239
- 레포 전역 생산 코드의 numeric literal 현황을 baseline으로 고정했습니다.
- 새 numeric literal drift를 `npm run check:numeric-literals`와 unit test에서 감지합니다.

## 변경 사항
- `scripts/numeric-literal-audit.ts`: tracked production file 기준 numeric literal audit와 baseline 비교 CLI 추가
- `scripts/numeric-literal-baseline.json`: PR #237 이후 main SHA 기준 171개 파일 분류 baseline 추가
- `test/unit/numeric-literal-audit.test.ts`: 분류 누락과 baseline drift 회귀 테스트 추가
- `package.json`: `check:numeric-literals` 검증 명령 추가

## 검증
- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- UTF-8 integrity check 통과

## 변경 금지 범위 확인
- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
- FastAPI 파일 변경 없음