### PR TITLE
TSK-002-02 지도 좌표 마커 config 분리

### DIFF
--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -79,6 +79,14 @@ function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner
       reason: 'CSS layout, spacing, radius, color, shadow, or motion values are migrated through UI token work.',
     };
   }
+  if (path === 'src/config/mapConfig.ts') {
+    return {
+      owner: 'frontend-map',
+      category: 'map-geo-config-baseline',
+      scopeId: 'TSK-002-02-FRONTEND-MAP-GEO-CONFIG',
+      reason: 'Map viewport, marker layer, selection-motion, geolocation, and distance values are owned by map config.',
+    };
+  }
   if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
     return {
       owner: 'frontend-map',

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "ee6cf17cbe5dc2ac189d1486b2ae31ed7754c750",
+  "generatedFrom": "e70ded4f21bd8f2e9a7fa0644d699e626c9a9897",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -3639,26 +3639,6 @@
       ]
     },
     {
-      "path": "src/components/naver-map/mapSdk.ts",
-      "count": 2,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "36.3504",
-          "line": 1,
-          "column": 43
-        },
-        {
-          "value": "127.3845",
-          "line": 1,
-          "column": 63
-        }
-      ]
-    },
-    {
       "path": "src/components/naver-map/markerContent.ts",
       "count": 144,
       "owner": "frontend-map",
@@ -3700,7 +3680,7 @@
     },
     {
       "path": "src/components/naver-map/selectionOffset.ts",
-      "count": 19,
+      "count": 2,
       "owner": "frontend-map",
       "category": "map-coordinate-marker-baseline",
       "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
@@ -3708,33 +3688,13 @@
       "examples": [
         {
           "value": "0",
-          "line": 2,
+          "line": 10,
           "column": 49
         },
         {
-          "value": "640",
-          "line": 3,
-          "column": 82
-        },
-        {
           "value": "0",
-          "line": 4,
+          "line": 12,
           "column": 20
-        },
-        {
-          "value": "360",
-          "line": 6,
-          "column": 33
-        },
-        {
-          "value": "250",
-          "line": 6,
-          "column": 39
-        },
-        {
-          "value": "280",
-          "line": 8,
-          "column": 31
         }
       ]
     },
@@ -3754,91 +3714,6 @@
       ]
     },
     {
-      "path": "src/components/naver-map/useNaverCurrentLocationMarker.ts",
-      "count": 3,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "200",
-          "line": 41,
-          "column": 17
-        },
-        {
-          "value": "15",
-          "line": 44,
-          "column": 37
-        },
-        {
-          "value": "15",
-          "line": 44,
-          "column": 41
-        }
-      ]
-    },
-    {
-      "path": "src/components/naver-map/useNaverFestivalMarkers.ts",
-      "count": 10,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "15",
-          "line": 33,
-          "column": 44
-        },
-        {
-          "value": "15",
-          "line": 33,
-          "column": 48
-        },
-        {
-          "value": "170",
-          "line": 57,
-          "column": 54
-        },
-        {
-          "value": "110",
-          "line": 57,
-          "column": 60
-        },
-        {
-          "value": "15",
-          "line": 78,
-          "column": 44
-        },
-        {
-          "value": "15",
-          "line": 78,
-          "column": 48
-        }
-      ]
-    },
-    {
-      "path": "src/components/naver-map/useNaverMapInstance.ts",
-      "count": 2,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "13",
-          "line": 42,
-          "column": 32
-        },
-        {
-          "value": "11",
-          "line": 43,
-          "column": 20
-        }
-      ]
-    },
-    {
       "path": "src/components/naver-map/useNaverMapInteractions.ts",
       "count": 1,
       "owner": "frontend-map",
@@ -3854,7 +3729,7 @@
       ]
     },
     {
-      "path": "src/components/naver-map/useNaverPlaceMarkers.ts",
+      "path": "src/components/naver-map/useNaverRoutePreviewOverlay.ts",
       "count": 8,
       "owner": "frontend-map",
       "category": "map-coordinate-marker-baseline",
@@ -3862,119 +3737,39 @@
       "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
       "examples": [
         {
-          "value": "15",
-          "line": 33,
-          "column": 44
-        },
-        {
-          "value": "15",
-          "line": 33,
-          "column": 48
-        },
-        {
-          "value": "15",
-          "line": 74,
-          "column": 44
-        },
-        {
-          "value": "15",
-          "line": 74,
-          "column": 48
-        },
-        {
-          "value": "100",
-          "line": 85,
-          "column": 32
-        },
-        {
-          "value": "160",
-          "line": 97,
-          "column": 32
-        }
-      ]
-    },
-    {
-      "path": "src/components/naver-map/useNaverRoutePreviewOverlay.ts",
-      "count": 16,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
           "value": "0",
-          "line": 53,
+          "line": 54,
           "column": 62
         },
         {
           "value": "0.82",
-          "line": 62,
+          "line": 63,
           "column": 22
         },
         {
           "value": "4",
-          "line": 63,
+          "line": 64,
           "column": 21
         },
         {
-          "value": "120",
-          "line": 66,
-          "column": 15
+          "value": "1",
+          "line": 78,
+          "column": 53
         },
         {
-          "value": "165",
-          "line": 75,
-          "column": 19
+          "value": "2",
+          "line": 84,
+          "column": 38
         },
         {
           "value": "1",
-          "line": 77,
-          "column": 53
+          "line": 88,
+          "column": 46
         }
       ]
     },
     {
       "path": "src/components/naver-map/useNaverSelectionSync.ts",
-      "count": 7,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "13",
-          "line": 57,
-          "column": 85
-        },
-        {
-          "value": "15",
-          "line": 58,
-          "column": 75
-        },
-        {
-          "value": "15",
-          "line": 58,
-          "column": 81
-        },
-        {
-          "value": "640",
-          "line": 71,
-          "column": 86
-        },
-        {
-          "value": "260",
-          "line": 72,
-          "column": 71
-        },
-        {
-          "value": "180",
-          "line": 72,
-          "column": 77
-        }
-      ]
-    },
-    {
-      "path": "src/components/naver-map/useNaverViewportSync.ts",
       "count": 1,
       "owner": "frontend-map",
       "category": "map-coordinate-marker-baseline",
@@ -3982,9 +3777,9 @@
       "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
       "examples": [
         {
-          "value": "300",
-          "line": 38,
-          "column": 10
+          "value": "0",
+          "line": 80,
+          "column": 23
         }
       ]
     },
@@ -4259,6 +4054,46 @@
       ]
     },
     {
+      "path": "src/config/mapConfig.ts",
+      "count": 53,
+      "owner": "frontend-map",
+      "category": "map-geo-config-baseline",
+      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
+      "reason": "Map viewport, marker layer, selection-motion, geolocation, and distance values are owned by map config.",
+      "examples": [
+        {
+          "value": "36.3504",
+          "line": 14,
+          "column": 62
+        },
+        {
+          "value": "127.3845",
+          "line": 14,
+          "column": 82
+        },
+        {
+          "value": "13",
+          "line": 15,
+          "column": 33
+        },
+        {
+          "value": "11",
+          "line": 16,
+          "column": 29
+        },
+        {
+          "value": "15",
+          "line": 17,
+          "column": 39
+        },
+        {
+          "value": "5",
+          "line": 18,
+          "column": 44
+        }
+      ]
+    },
+    {
       "path": "src/hooks/app-navigation/shellBackNavigation.ts",
       "count": 2,
       "owner": "frontend-ui",
@@ -4305,46 +4140,6 @@
           "value": "8000",
           "line": 83,
           "column": 30
-        }
-      ]
-    },
-    {
-      "path": "src/hooks/app-route/mapViewportState.ts",
-      "count": 6,
-      "owner": "frontend-map",
-      "category": "map-coordinate-marker-baseline",
-      "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
-      "reason": "Map center, zoom, marker, overlay, or selection-motion values are migrated through map config work.",
-      "examples": [
-        {
-          "value": "36.3504",
-          "line": 7,
-          "column": 50
-        },
-        {
-          "value": "127.3845",
-          "line": 7,
-          "column": 64
-        },
-        {
-          "value": "13",
-          "line": 7,
-          "column": 80
-        },
-        {
-          "value": "10",
-          "line": 17,
-          "column": 48
-        },
-        {
-          "value": "5",
-          "line": 32,
-          "column": 33
-        },
-        {
-          "value": "5",
-          "line": 33,
-          "column": 33
         }
       ]
     },
@@ -4605,41 +4400,21 @@
     },
     {
       "path": "src/lib/geolocation.ts",
-      "count": 10,
+      "count": 2,
       "owner": "frontend-map",
       "category": "geolocation-threshold-baseline",
       "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
       "reason": "Distance, radius, accuracy, and timeout values are migrated through geolocation config work.",
       "examples": [
         {
-          "value": "36.3504",
-          "line": 9,
-          "column": 36
-        },
-        {
-          "value": "127.3845",
-          "line": 9,
-          "column": 56
-        },
-        {
-          "value": "45_000",
-          "line": 10,
-          "column": 37
-        },
-        {
-          "value": "5_000",
-          "line": 11,
-          "column": 49
-        },
-        {
-          "value": "150",
-          "line": 12,
-          "column": 48
+          "value": "0",
+          "line": 15,
+          "column": 60
         },
         {
           "value": "0",
-          "line": 18,
-          "column": 60
+          "line": 45,
+          "column": 21
         }
       ]
     },
@@ -4705,41 +4480,41 @@
     },
     {
       "path": "src/lib/visits.ts",
-      "count": 17,
+      "count": 8,
       "owner": "frontend-map",
       "category": "geolocation-threshold-baseline",
       "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
       "reason": "Distance, radius, accuracy, and timeout values are migrated through geolocation config work.",
       "examples": [
         {
-          "value": "6_371_000",
-          "line": 9,
-          "column": 29
-        },
-        {
-          "value": "180",
-          "line": 10,
-          "column": 69
-        },
-        {
-          "value": "180",
-          "line": 11,
-          "column": 72
-        },
-        {
-          "value": "180",
-          "line": 12,
-          "column": 60
-        },
-        {
-          "value": "180",
-          "line": 13,
-          "column": 56
+          "value": "2",
+          "line": 16,
+          "column": 30
         },
         {
           "value": "2",
           "line": 16,
-          "column": 30
+          "column": 36
+        },
+        {
+          "value": "2",
+          "line": 17,
+          "column": 95
+        },
+        {
+          "value": "2",
+          "line": 17,
+          "column": 101
+        },
+        {
+          "value": "2",
+          "line": 49,
+          "column": 13
+        },
+        {
+          "value": "2",
+          "line": 50,
+          "column": 11
         }
       ]
     },

--- a/src/components/naver-map/mapSdk.ts
+++ b/src/components/naver-map/mapSdk.ts
@@ -1,4 +1,6 @@
-export const DAEJEON_CENTER = { latitude: 36.3504, longitude: 127.3845 };
+import { MapViewportConfig } from '../../config/mapConfig';
+
+export const DAEJEON_CENTER = MapViewportConfig.daejeonCenter;
 
 declare global {
   interface Window {

--- a/src/components/naver-map/selectionOffset.ts
+++ b/src/components/naver-map/selectionOffset.ts
@@ -1,21 +1,20 @@
-export function getSelectionVerticalOffset(mapElement: HTMLDivElement | null, targetType: 'place' | 'festival') {
+import { SelectionMotionConfig } from '../../config/mapConfig';
+import type { SelectionTargetType } from '../../config/mapConfig';
+
+function getViewportSizeBucket() {
+  const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= SelectionMotionConfig.mobileBreakpointPx;
+  return isMobileViewport ? 'mobile' : 'desktop';
+}
+
+export function getSelectionVerticalOffset(mapElement: HTMLDivElement | null, targetType: SelectionTargetType) {
   const mapHeight = mapElement?.clientHeight ?? 0;
-  const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 640;
+  const viewportSize = getViewportSizeBucket();
   if (mapHeight <= 0) {
-    if (targetType === 'place') {
-      return isMobileViewport ? 360 : 250;
-    }
-    return isMobileViewport ? 280 : 190;
+    return SelectionMotionConfig.fallbackOffsetPx[targetType][viewportSize];
   }
 
-  const ratio = targetType === 'place'
-    ? (isMobileViewport ? 0.56 : 0.38)
-    : (isMobileViewport ? 0.42 : 0.29);
-  const minOffset = targetType === 'place'
-    ? (isMobileViewport ? 340 : 240)
-    : (isMobileViewport ? 260 : 170);
-  const maxOffset = targetType === 'place'
-    ? (isMobileViewport ? 430 : 310)
-    : (isMobileViewport ? 330 : 230);
+  const ratio = SelectionMotionConfig.offsetRatio[targetType][viewportSize];
+  const minOffset = SelectionMotionConfig.minOffsetPx[targetType][viewportSize];
+  const maxOffset = SelectionMotionConfig.maxOffsetPx[targetType][viewportSize];
   return Math.min(maxOffset, Math.max(minOffset, Math.round(mapHeight * ratio)));
 }

--- a/src/components/naver-map/useNaverCurrentLocationMarker.ts
+++ b/src/components/naver-map/useNaverCurrentLocationMarker.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
+import { NaverMarkerConfig } from '../../config/mapConfig';
 import { currentLocationMarkerContent } from './markerContent';
 
 type MapsApi = typeof window.naver.maps;
@@ -38,10 +39,10 @@ export function useNaverCurrentLocationMarker({
         map: mapRef.current,
         position,
         title: '',
-        zIndex: 200,
+        zIndex: NaverMarkerConfig.zIndex.currentLocation,
         icon: {
           content: currentLocationMarkerContent(),
-          anchor: new mapsApi.Point(15, 15),
+          anchor: new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y),
         },
       });
       return;

--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
+import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { FestivalItem } from '../../types';
 import { festivalMarkerContent, hasFestivalCoordinates } from './markerContent';
 
@@ -30,7 +31,7 @@ export function useNaverFestivalMarkers({
     }
 
     const nextIds = new Set(festivals.filter(hasFestivalCoordinates).map((festival) => festival.id));
-    const markerAnchor = new mapsApi.Point(15, 15);
+    const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     for (const [festivalId, marker] of festivalMarkersRef.current.entries()) {
       if (!nextIds.has(festivalId)) {
@@ -54,7 +55,7 @@ export function useNaverFestivalMarkers({
         map: mapRef.current,
         position,
         title: '',
-        zIndex: festival.id === selectedFestivalId ? 170 : 110,
+        zIndex: festival.id === selectedFestivalId ? NaverMarkerConfig.zIndex.festivalActive : NaverMarkerConfig.zIndex.festivalDefault,
         icon: {
           content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
           anchor: markerAnchor,
@@ -75,7 +76,7 @@ export function useNaverFestivalMarkers({
 
     const isFestivalsSame = festivals === prevFestivalsRef.current;
     const prevSelectedId = prevSelectedFestivalIdRef.current;
-    const markerAnchor = new mapsApi.Point(15, 15);
+    const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     if (isFestivalsSame && prevSelectedId !== selectedFestivalId) {
       if (prevSelectedId) {
@@ -86,7 +87,7 @@ export function useNaverFestivalMarkers({
             content: festivalMarkerContent(prevFestival, false),
             anchor: markerAnchor,
           });
-          prevMarker.setZIndex(110);
+          prevMarker.setZIndex(NaverMarkerConfig.zIndex.festivalDefault);
         }
       }
 
@@ -98,7 +99,7 @@ export function useNaverFestivalMarkers({
             content: festivalMarkerContent(nextFestival, true),
             anchor: markerAnchor,
           });
-          nextMarker.setZIndex(170);
+          nextMarker.setZIndex(NaverMarkerConfig.zIndex.festivalActive);
         }
       }
     } else {
@@ -111,7 +112,9 @@ export function useNaverFestivalMarkers({
           content: festivalMarkerContent(festival, festival.id === selectedFestivalId),
           anchor: markerAnchor,
         });
-        marker.setZIndex(festival.id === selectedFestivalId ? 170 : 110);
+        marker.setZIndex(
+          festival.id === selectedFestivalId ? NaverMarkerConfig.zIndex.festivalActive : NaverMarkerConfig.zIndex.festivalDefault,
+        );
       });
     }
 

--- a/src/components/naver-map/useNaverMapInstance.ts
+++ b/src/components/naver-map/useNaverMapInstance.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { MapViewportConfig } from '../../config/mapConfig';
 import { DAEJEON_CENTER, loadNaverMaps } from './mapSdk';
 
 type MapInstanceArgs = {
@@ -39,8 +40,8 @@ export function useNaverMapInstance({
 
         mapRef.current = new maps.Map(mapElementRef.current, {
           center: new maps.LatLng(initialCenter?.lat ?? DAEJEON_CENTER.latitude, initialCenter?.lng ?? DAEJEON_CENTER.longitude),
-          zoom: initialZoom ?? 13,
-          minZoom: 11,
+          zoom: initialZoom ?? MapViewportConfig.defaultZoom,
+          minZoom: MapViewportConfig.minZoom,
           scaleControl: false,
           logoControl: false,
           mapDataControl: false,

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
+import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { Place } from '../../types';
 import { placeMarkerContent } from './markerContent';
 
@@ -30,7 +31,7 @@ export function useNaverPlaceMarkers({
     }
 
     const nextIds = new Set(places.map((place) => place.id));
-    const markerAnchor = new mapsApi.Point(15, 15);
+    const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     for (const [placeId, marker] of placeMarkersRef.current.entries()) {
       if (!nextIds.has(placeId)) {
@@ -71,7 +72,7 @@ export function useNaverPlaceMarkers({
 
     const isPlacesSame = places === prevPlacesRef.current;
     const prevSelectedId = prevSelectedPlaceIdRef.current;
-    const markerAnchor = new mapsApi.Point(15, 15);
+    const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     if (isPlacesSame && prevSelectedId !== selectedPlaceId) {
       if (prevSelectedId) {
@@ -82,7 +83,7 @@ export function useNaverPlaceMarkers({
             content: placeMarkerContent(prevPlace, false),
             anchor: markerAnchor,
           });
-          prevMarker.setZIndex(100);
+          prevMarker.setZIndex(NaverMarkerConfig.zIndex.placeDefault);
         }
       }
 
@@ -94,7 +95,7 @@ export function useNaverPlaceMarkers({
             content: placeMarkerContent(nextPlace, true),
             anchor: markerAnchor,
           });
-          nextMarker.setZIndex(160);
+          nextMarker.setZIndex(NaverMarkerConfig.zIndex.placeActive);
         }
       }
     } else {
@@ -107,7 +108,7 @@ export function useNaverPlaceMarkers({
           content: placeMarkerContent(place, place.id === selectedPlaceId),
           anchor: markerAnchor,
         });
-        marker.setZIndex(place.id === selectedPlaceId ? 160 : 100);
+        marker.setZIndex(place.id === selectedPlaceId ? NaverMarkerConfig.zIndex.placeActive : NaverMarkerConfig.zIndex.placeDefault);
       });
     }
 

--- a/src/components/naver-map/useNaverRoutePreviewOverlay.ts
+++ b/src/components/naver-map/useNaverRoutePreviewOverlay.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { Place } from '../../types';
 import { routeStepMarkerContent } from './markerContent';
 
@@ -63,7 +64,7 @@ export function useNaverRoutePreviewOverlay({
       strokeWeight: 4,
       strokeLineCap: 'round',
       strokeLineJoin: 'round',
-      zIndex: 120,
+      zIndex: NaverMarkerConfig.zIndex.routeLine,
     });
 
     routeStepMarkersRef.current = routePreviewPlaces.map(
@@ -72,10 +73,10 @@ export function useNaverRoutePreviewOverlay({
           map: mapRef.current,
           position: new mapsApi.LatLng(place.latitude, place.longitude),
           title: '',
-          zIndex: 165,
+          zIndex: NaverMarkerConfig.zIndex.routeStep,
           icon: {
             content: routeStepMarkerContent(index + 1),
-            anchor: new mapsApi.Point(13, 13),
+            anchor: new mapsApi.Point(NaverMarkerConfig.anchor.routeStep.x, NaverMarkerConfig.anchor.routeStep.y),
           },
         }),
     );
@@ -83,7 +84,7 @@ export function useNaverRoutePreviewOverlay({
     if (routePreviewPlaces.length >= 2 && !selectedPlaceId && !selectedFestivalId) {
       const bounds = new mapsApi.LatLngBounds();
       routePreviewPlaces.forEach((place) => bounds.extend(new mapsApi.LatLng(place.latitude, place.longitude)));
-      mapRef.current.fitBounds?.(bounds, { top: 72, right: 40, bottom: 120, left: 40 });
+      mapRef.current.fitBounds?.(bounds, NaverMarkerConfig.routeBoundsPadding);
     } else if (routePreviewPlaces.length === 1 && !selectedPlaceId && !selectedFestivalId) {
       mapRef.current.panTo?.(new mapsApi.LatLng(routePreviewPlaces[0].latitude, routePreviewPlaces[0].longitude));
     }

--- a/src/components/naver-map/useNaverSelectionSync.ts
+++ b/src/components/naver-map/useNaverSelectionSync.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { MapViewportConfig, SelectionMotionConfig } from '../../config/mapConfig';
 import type { FestivalItem, Place } from '../../types';
 import { hasFestivalCoordinates } from './markerContent';
 import { getSelectionVerticalOffset } from './selectionOffset';
@@ -54,8 +55,10 @@ export function useNaverSelectionSync({
 
     const map = mapRef.current;
     const targetLatLng = new mapsApi.LatLng(target.latitude, target.longitude);
-    const currentZoom = typeof map.getZoom === 'function' ? Number(map.getZoom()) : 13;
-    const nextZoom = Number.isFinite(currentZoom) ? Math.max(currentZoom, 15) : 15;
+    const currentZoom = typeof map.getZoom === 'function' ? Number(map.getZoom()) : MapViewportConfig.defaultZoom;
+    const nextZoom = Number.isFinite(currentZoom)
+      ? Math.max(currentZoom, MapViewportConfig.selectedZoomFloor)
+      : MapViewportConfig.selectedZoomFloor;
 
     if (typeof map.setZoom === 'function' && currentZoom < nextZoom) {
       map.setZoom(nextZoom, false);
@@ -68,8 +71,10 @@ export function useNaverSelectionSync({
     }
 
     if (typeof map.panBy === 'function') {
-      const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= 640;
-      const panDelayMs = isMobileViewport && targetType === 'place' ? 260 : 180;
+      const isMobileViewport = typeof window !== 'undefined' && window.innerWidth <= SelectionMotionConfig.mobileBreakpointPx;
+      const panDelayMs = isMobileViewport && targetType === 'place'
+        ? SelectionMotionConfig.panDelayMs.mobilePlace
+        : SelectionMotionConfig.panDelayMs.default;
       window.setTimeout(() => {
         if (mapRef.current === map) {
           map.panBy?.(0, -getSelectionVerticalOffset(mapElementRef.current, targetType));

--- a/src/components/naver-map/useNaverViewportSync.ts
+++ b/src/components/naver-map/useNaverViewportSync.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from 'react';
+import { SelectionMotionConfig } from '../../config/mapConfig';
 
 type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
 
@@ -35,7 +36,7 @@ export function useNaverViewportSync({
       viewportDebounceTimerRef.current = setTimeout(() => {
         onViewportChangeRef.current?.(center.lat(), center.lng(), zoom);
         viewportDebounceTimerRef.current = null;
-      }, 300);
+      }, SelectionMotionConfig.viewportIdleDebounceMs);
     });
 
     idleListenerRef.current = idleListener;

--- a/src/config/mapConfig.ts
+++ b/src/config/mapConfig.ts
@@ -1,0 +1,118 @@
+export type GeoCoordinate = Readonly<{
+  latitude: number;
+  longitude: number;
+}>;
+
+export type MapPointConfig = Readonly<{
+  x: number;
+  y: number;
+}>;
+
+export type SelectionTargetType = 'place' | 'festival';
+
+export class MapViewportConfig {
+  static readonly daejeonCenter: GeoCoordinate = { latitude: 36.3504, longitude: 127.3845 };
+  static readonly defaultZoom = 13;
+  static readonly minZoom = 11;
+  static readonly selectedZoomFloor = 15;
+  static readonly urlCoordinatePrecision = 5;
+  static readonly urlZoomRadix = 10;
+}
+
+export class NaverMarkerConfig {
+  static readonly anchor = {
+    default: { x: 15, y: 15 },
+    routeStep: { x: 13, y: 13 },
+  } satisfies Record<string, MapPointConfig>;
+
+  static readonly zIndex = {
+    placeDefault: 100,
+    placeActive: 160,
+    festivalDefault: 110,
+    festivalActive: 170,
+    routeLine: 120,
+    routeStep: 165,
+    currentLocation: 200,
+  };
+
+  static readonly routeBoundsPadding = {
+    top: 72,
+    right: 40,
+    bottom: 120,
+    left: 40,
+  };
+}
+
+export class SelectionMotionConfig {
+  static readonly mobileBreakpointPx = 640;
+  static readonly panDelayMs = {
+    mobilePlace: 260,
+    default: 180,
+  };
+  static readonly viewportIdleDebounceMs = 300;
+
+  static readonly fallbackOffsetPx = {
+    place: {
+      mobile: 360,
+      desktop: 250,
+    },
+    festival: {
+      mobile: 280,
+      desktop: 190,
+    },
+  };
+
+  static readonly offsetRatio = {
+    place: {
+      mobile: 0.56,
+      desktop: 0.38,
+    },
+    festival: {
+      mobile: 0.42,
+      desktop: 0.29,
+    },
+  };
+
+  static readonly minOffsetPx = {
+    place: {
+      mobile: 340,
+      desktop: 240,
+    },
+    festival: {
+      mobile: 260,
+      desktop: 170,
+    },
+  };
+
+  static readonly maxOffsetPx = {
+    place: {
+      mobile: 430,
+      desktop: 310,
+    },
+    festival: {
+      mobile: 330,
+      desktop: 230,
+    },
+  };
+}
+
+export class GeolocationConfig {
+  static readonly validAreaCenter = MapViewportConfig.daejeonCenter;
+  static readonly validRadiusMeters = 45_000;
+  static readonly maxAcceptableAccuracyMeters = 5_000;
+  static readonly earlySuccessAccuracyMeters = 150;
+  static readonly settleTimeoutMs = 8_000;
+  static readonly watchOptions: PositionOptions = {
+    enableHighAccuracy: true,
+    timeout: 10_000,
+    maximumAge: 0,
+  };
+}
+
+export class GeoDistanceConfig {
+  static readonly earthRadiusMeters = 6_371_000;
+  static readonly degreesPerHalfCircle = 180;
+  static readonly haversineMultiplier = 2;
+  static readonly kilometerThresholdMeters = 1000;
+  static readonly kilometerFractionDigits = 1;
+}

--- a/src/hooks/app-route/mapViewportState.ts
+++ b/src/hooks/app-route/mapViewportState.ts
@@ -1,10 +1,16 @@
+import { MapViewportConfig } from '../../config/mapConfig';
+
 export interface MapViewport {
   lat: number;
   lng: number;
   zoom: number;
 }
 
-const DEFAULT_MAP_VIEWPORT: MapViewport = { lat: 36.3504, lng: 127.3845, zoom: 13 };
+const DEFAULT_MAP_VIEWPORT: MapViewport = {
+  lat: MapViewportConfig.daejeonCenter.latitude,
+  lng: MapViewportConfig.daejeonCenter.longitude,
+  zoom: MapViewportConfig.defaultZoom,
+};
 
 export function getInitialMapViewport(): MapViewport {
   if (typeof window === 'undefined') {
@@ -14,7 +20,7 @@ export function getInitialMapViewport(): MapViewport {
   const params = new URLSearchParams(window.location.search);
   const lat = parseFloat(params.get('lat') ?? '');
   const lng = parseFloat(params.get('lng') ?? '');
-  const zoom = parseInt(params.get('z') ?? '', 10);
+  const zoom = parseInt(params.get('z') ?? '', MapViewportConfig.urlZoomRadix);
 
   return {
     lat: Number.isFinite(lat) ? lat : DEFAULT_MAP_VIEWPORT.lat,
@@ -29,8 +35,8 @@ export function updateMapViewportInUrl(lat: number, lng: number, zoom: number) {
   }
 
   const params = new URLSearchParams(window.location.search);
-  params.set('lat', lat.toFixed(5));
-  params.set('lng', lng.toFixed(5));
+  params.set('lat', lat.toFixed(MapViewportConfig.urlCoordinatePrecision));
+  params.set('lng', lng.toFixed(MapViewportConfig.urlCoordinatePrecision));
   params.set('z', String(zoom));
   const nextUrl = `${window.location.pathname}?${params.toString()}`;
   window.history.replaceState(window.history.state, '', nextUrl);

--- a/src/lib/geolocation.ts
+++ b/src/lib/geolocation.ts
@@ -1,15 +1,11 @@
-﻿import { calculateDistanceMeters, formatDistanceMeters } from './visits';
+import { GeolocationConfig } from '../config/mapConfig';
+import { calculateDistanceMeters, formatDistanceMeters } from './visits';
 
 export interface CurrentDeviceLocation {
   latitude: number;
   longitude: number;
   accuracyMeters: number;
 }
-
-const DAEJEON_CENTER = { latitude: 36.3504, longitude: 127.3845 };
-const DAEJEON_VALID_RADIUS_METERS = 45_000;
-const MAX_ACCEPTABLE_LOCATION_ACCURACY_METERS = 5_000;
-const EARLY_SUCCESS_LOCATION_ACCURACY_METERS = 150;
 
 function validateCurrentDevicePosition(position: GeolocationPosition): CurrentDeviceLocation {
   const nextPosition = {
@@ -19,17 +15,17 @@ function validateCurrentDevicePosition(position: GeolocationPosition): CurrentDe
   };
 
   const distanceFromDaejeon = calculateDistanceMeters(
-    DAEJEON_CENTER.latitude,
-    DAEJEON_CENTER.longitude,
+    GeolocationConfig.validAreaCenter.latitude,
+    GeolocationConfig.validAreaCenter.longitude,
     nextPosition.latitude,
     nextPosition.longitude,
   );
 
-  if (distanceFromDaejeon > DAEJEON_VALID_RADIUS_METERS) {
+  if (distanceFromDaejeon > GeolocationConfig.validRadiusMeters) {
     throw new Error('현재 위치가 대전 반경 밖으로 잡혔어요. 위치 서비스나 Wi-Fi를 켠 뒤 다시 확인해 주세요.');
   }
 
-  if (nextPosition.accuracyMeters > MAX_ACCEPTABLE_LOCATION_ACCURACY_METERS) {
+  if (nextPosition.accuracyMeters > GeolocationConfig.maxAcceptableAccuracyMeters) {
     throw new Error(`현재 위치 정확도가 약 ${formatDistanceMeters(nextPosition.accuracyMeters)}로 너무 넓어요. 위치를 다시 확인해 주세요.`);
   }
 
@@ -88,7 +84,7 @@ export function getCurrentDevicePosition() {
           bestPosition = position;
         }
 
-        if (position.coords.accuracy <= EARLY_SUCCESS_LOCATION_ACCURACY_METERS) {
+        if (position.coords.accuracy <= GeolocationConfig.earlySuccessAccuracyMeters) {
           finishWithBestPosition(watchId);
         }
       },
@@ -107,15 +103,11 @@ export function getCurrentDevicePosition() {
         }
         finishWithError(watchId, new Error('현재 위치를 확인하지 못했어요.'));
       },
-      {
-        enableHighAccuracy: true,
-        timeout: 10_000,
-        maximumAge: 0,
-      },
+      GeolocationConfig.watchOptions,
     );
 
     timeoutId = window.setTimeout(() => {
       finishWithBestPosition(watchId);
-    }, 8_000);
+    }, GeolocationConfig.settleTimeoutMs);
   });
 }

--- a/src/lib/visits.ts
+++ b/src/lib/visits.ts
@@ -1,3 +1,4 @@
+import { GeoDistanceConfig } from '../config/mapConfig';
 import type { StampLog } from '../types';
 
 export function calculateDistanceMeters(
@@ -6,25 +7,24 @@ export function calculateDistanceMeters(
   endLatitude: number,
   endLongitude: number,
 ) {
-  const earthRadiusMeters = 6_371_000;
-  const latitudeDelta = ((endLatitude - startLatitude) * Math.PI) / 180;
-  const longitudeDelta = ((endLongitude - startLongitude) * Math.PI) / 180;
-  const startLatitudeRadians = (startLatitude * Math.PI) / 180;
-  const endLatitudeRadians = (endLatitude * Math.PI) / 180;
+  const latitudeDelta = ((endLatitude - startLatitude) * Math.PI) / GeoDistanceConfig.degreesPerHalfCircle;
+  const longitudeDelta = ((endLongitude - startLongitude) * Math.PI) / GeoDistanceConfig.degreesPerHalfCircle;
+  const startLatitudeRadians = (startLatitude * Math.PI) / GeoDistanceConfig.degreesPerHalfCircle;
+  const endLatitudeRadians = (endLatitude * Math.PI) / GeoDistanceConfig.degreesPerHalfCircle;
 
   const haversine =
     Math.sin(latitudeDelta / 2) ** 2 +
     Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2;
 
-  return earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine)));
+  return GeoDistanceConfig.earthRadiusMeters * (GeoDistanceConfig.haversineMultiplier * Math.asin(Math.sqrt(haversine)));
 }
 
 export function formatDistanceMeters(distanceMeters: number) {
-  if (distanceMeters < 1000) {
+  if (distanceMeters < GeoDistanceConfig.kilometerThresholdMeters) {
     return `${Math.round(distanceMeters)}m`;
   }
 
-  return `${(distanceMeters / 1000).toFixed(1)}km`;
+  return `${(distanceMeters / GeoDistanceConfig.kilometerThresholdMeters).toFixed(GeoDistanceConfig.kilometerFractionDigits)}km`;
 }
 
 export function getTodayStampLog(stampLogs: StampLog[], placeId: string) {

--- a/test/unit/map-config.test.ts
+++ b/test/unit/map-config.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  GeoDistanceConfig,
+  GeolocationConfig,
+  MapViewportConfig,
+  NaverMarkerConfig,
+  SelectionMotionConfig,
+} from '../../src/config/mapConfig';
+import { getSelectionVerticalOffset } from '../../src/components/naver-map/selectionOffset';
+import { getInitialMapViewport, updateMapViewportInUrl } from '../../src/hooks/app-route/mapViewportState';
+
+const originalUrl = window.location.href;
+const originalInnerWidth = window.innerWidth;
+
+afterEach(() => {
+  window.history.replaceState({}, '', originalUrl);
+  setViewportWidth(originalInnerWidth);
+});
+
+function setViewportWidth(width: number) {
+  Object.defineProperty(window, 'innerWidth', {
+    value: width,
+    configurable: true,
+  });
+}
+
+describe('map config boundaries', () => {
+  it('keeps the default Daejeon viewport and URL precision stable', () => {
+    window.history.replaceState({}, '', '/?lat=36.111119&lng=127.222229&z=15');
+
+    expect(getInitialMapViewport()).toEqual({ lat: 36.111119, lng: 127.222229, zoom: 15 });
+
+    updateMapViewportInUrl(36.111119, 127.222229, MapViewportConfig.defaultZoom);
+
+    expect(window.location.search).toContain('lat=36.11112');
+    expect(window.location.search).toContain('lng=127.22223');
+    expect(window.location.search).toContain(`z=${MapViewportConfig.defaultZoom}`);
+  });
+
+  it('keeps marker layer and anchor semantics in named config', () => {
+    expect(MapViewportConfig.daejeonCenter).toEqual({ latitude: 36.3504, longitude: 127.3845 });
+    expect(MapViewportConfig.defaultZoom).toBe(13);
+    expect(MapViewportConfig.minZoom).toBe(11);
+    expect(MapViewportConfig.selectedZoomFloor).toBe(15);
+    expect(MapViewportConfig.urlCoordinatePrecision).toBe(5);
+
+    expect(NaverMarkerConfig.anchor.default).toEqual({ x: 15, y: 15 });
+    expect(NaverMarkerConfig.anchor.routeStep).toEqual({ x: 13, y: 13 });
+    expect(NaverMarkerConfig.zIndex).toMatchObject({
+      placeDefault: 100,
+      placeActive: 160,
+      festivalDefault: 110,
+      festivalActive: 170,
+      routeLine: 120,
+      routeStep: 165,
+      currentLocation: 200,
+    });
+    expect(NaverMarkerConfig.routeBoundsPadding).toEqual({ top: 72, right: 40, bottom: 120, left: 40 });
+  });
+
+  it('keeps selection offset behavior while moving numbers into config', () => {
+    setViewportWidth(390);
+    expect(getSelectionVerticalOffset(null, 'place')).toBe(SelectionMotionConfig.fallbackOffsetPx.place.mobile);
+    expect(getSelectionVerticalOffset(null, 'festival')).toBe(SelectionMotionConfig.fallbackOffsetPx.festival.mobile);
+
+    const mapElement = document.createElement('div');
+    Object.defineProperty(mapElement, 'clientHeight', {
+      value: 700,
+      configurable: true,
+    });
+
+    expect(getSelectionVerticalOffset(mapElement, 'place')).toBe(392);
+    expect(getSelectionVerticalOffset(mapElement, 'festival')).toBe(294);
+  });
+
+  it('keeps geolocation and distance thresholds in named config', () => {
+    expect(GeolocationConfig.validAreaCenter).toBe(MapViewportConfig.daejeonCenter);
+    expect(GeolocationConfig.validRadiusMeters).toBe(45_000);
+    expect(GeolocationConfig.maxAcceptableAccuracyMeters).toBe(5_000);
+    expect(GeolocationConfig.earlySuccessAccuracyMeters).toBe(150);
+    expect(GeolocationConfig.settleTimeoutMs).toBe(8_000);
+    expect(GeolocationConfig.watchOptions).toEqual({
+      enableHighAccuracy: true,
+      timeout: 10_000,
+      maximumAge: 0,
+    });
+
+    expect(GeoDistanceConfig.earthRadiusMeters).toBe(6_371_000);
+    expect(GeoDistanceConfig.kilometerThresholdMeters).toBe(1000);
+    expect(GeoDistanceConfig.kilometerFractionDigits).toBe(1);
+  });
+});


### PR DESCRIPTION
## 요약
- Scope-ID: `TSK-002-02-FRONTEND-MAP-GEO-CONFIG`
- Parent Issue: #238
- Child Issue: Closes #240
- 지도 viewport, Naver marker anchor/z-index, selection pan/offset, geolocation, distance formatting 수치를 `src/config/mapConfig.ts`의 owner config class로 이동했습니다.
- PR #237의 marker selection O(1) 업데이트 구조는 유지하고, 기존 값은 회귀 테스트로 고정했습니다.

## 변경 사항
- `MapViewportConfig`: 대전 중심 좌표, 기본/min/selection zoom, URL precision/radix
- `NaverMarkerConfig`: marker anchor, place/festival/route/current-location z-index, route bounds padding
- `SelectionMotionConfig`: mobile breakpoint, pan delay, viewport debounce, drawer offset ratio/min/max/fallback
- `GeolocationConfig`: 대전 유효 반경, 정확도 threshold, watch/settle timeout
- `GeoDistanceConfig`: haversine 계산과 m/km formatting 기준
- `test/unit/map-config.test.ts`: config 값과 기존 URL/selection/geolocation 의미 회귀 고정
- numeric literal baseline을 새 config 소유권 기준으로 갱신

## 검증
- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- UTF-8 integrity check 통과

## 변경 금지 범위 확인
- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
- FastAPI 파일 변경 없음
- UI 시각 재설계 없음