### PR TITLE
TSK-002-02 marker selection O(1) 회귀 테스트 보강

### DIFF
--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -64,7 +64,7 @@ export function useNaverFestivalMarkers({
       mapsApi.Event.addListener(marker, 'click', () => onSelectFestival(festival.id));
       festivalMarkersRef.current.set(festival.id, marker);
     });
-  }, [festivals, mapRef, mapsApi, onSelectFestival, selectedFestivalId, status]);
+  }, [festivals, mapRef, mapsApi, onSelectFestival, status]);
 
   const prevSelectedFestivalIdRef = useRef<string | null>(selectedFestivalId);
   const prevFestivalsRef = useRef<FestivalItem[]>(festivals);

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -60,7 +60,7 @@ export function useNaverPlaceMarkers({
       mapsApi.Event.addListener(marker, 'click', () => onSelectPlace(place.id));
       placeMarkersRef.current.set(place.id, marker);
     });
-  }, [mapRef, mapsApi, onSelectPlace, places, selectedPlaceId, status]);
+  }, [mapRef, mapsApi, onSelectPlace, places, status]);
 
   const prevSelectedPlaceIdRef = useRef<string | null>(selectedPlaceId);
   const prevPlacesRef = useRef<Place[]>(places);

--- a/test/unit/naver-marker-selection.test.tsx
+++ b/test/unit/naver-marker-selection.test.tsx
@@ -1,0 +1,153 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { NaverMarkerConfig } from '../../src/config/mapConfig';
+import { useNaverFestivalMarkers } from '../../src/components/naver-map/useNaverFestivalMarkers';
+import { useNaverPlaceMarkers } from '../../src/components/naver-map/useNaverPlaceMarkers';
+import type { FestivalItem, Place } from '../../src/types';
+
+type MarkerRecord = {
+  options: Record<string, unknown>;
+  setIcon: ReturnType<typeof vi.fn>;
+  setMap: ReturnType<typeof vi.fn>;
+  setPosition: ReturnType<typeof vi.fn>;
+  setZIndex: ReturnType<typeof vi.fn>;
+};
+
+function createMapsApi(markerRecords: MarkerRecord[]) {
+  class Point {
+    constructor(
+      readonly x: number,
+      readonly y: number,
+    ) {}
+  }
+
+  class LatLng {
+    constructor(
+      readonly latitude: number,
+      readonly longitude: number,
+    ) {}
+  }
+
+  class Marker {
+    readonly options: Record<string, unknown>;
+    readonly setIcon = vi.fn();
+    readonly setMap = vi.fn();
+    readonly setPosition = vi.fn();
+    readonly setZIndex = vi.fn();
+
+    constructor(options: Record<string, unknown>) {
+      this.options = options;
+      markerRecords.push(this);
+    }
+  }
+
+  return {
+    Point,
+    LatLng,
+    Marker,
+    Event: {
+      addListener: vi.fn(),
+    },
+  } as unknown as typeof window.naver.maps;
+}
+
+function clearMarkerSpies(markerRecords: MarkerRecord[]) {
+  markerRecords.forEach((marker) => {
+    marker.setIcon.mockClear();
+    marker.setMap.mockClear();
+    marker.setPosition.mockClear();
+    marker.setZIndex.mockClear();
+  });
+}
+
+const places = [
+  { id: 'place-1', latitude: 36.1, longitude: 127.1, category: 'cafe' },
+  { id: 'place-2', latitude: 36.2, longitude: 127.2, category: 'restaurant' },
+  { id: 'place-3', latitude: 36.3, longitude: 127.3, category: 'culture' },
+] as Place[];
+
+const festivals = [
+  { id: 'festival-1', latitude: 36.4, longitude: 127.4 },
+  { id: 'festival-2', latitude: 36.5, longitude: 127.5 },
+  { id: 'festival-3', latitude: 36.6, longitude: 127.6 },
+] as FestivalItem[];
+
+describe('naver marker selection updates', () => {
+  it('updates only previous and next place marker state when selection changes', () => {
+    const markerRecords: MarkerRecord[] = [];
+    const mapsApi = createMapsApi(markerRecords);
+    const mapRef = { current: {} };
+    const onSelectPlace = vi.fn();
+
+    function Harness({ selectedPlaceId }: { selectedPlaceId: string | null }) {
+      useNaverPlaceMarkers({
+        status: 'ready',
+        mapsApi,
+        mapRef,
+        places,
+        selectedPlaceId,
+        onSelectPlace,
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Harness selectedPlaceId={null} />);
+
+    expect(markerRecords).toHaveLength(places.length);
+    clearMarkerSpies(markerRecords);
+
+    rerender(<Harness selectedPlaceId="place-2" />);
+    rerender(<Harness selectedPlaceId="place-3" />);
+
+    expect(markerRecords[0].setIcon).not.toHaveBeenCalled();
+    expect(markerRecords[0].setZIndex).not.toHaveBeenCalled();
+    expect(markerRecords[0].setPosition).not.toHaveBeenCalled();
+
+    expect(markerRecords[1].setIcon).toHaveBeenCalledTimes(2);
+    expect(markerRecords[1].setZIndex).toHaveBeenLastCalledWith(NaverMarkerConfig.zIndex.placeDefault);
+    expect(markerRecords[1].setPosition).not.toHaveBeenCalled();
+
+    expect(markerRecords[2].setIcon).toHaveBeenCalledTimes(1);
+    expect(markerRecords[2].setZIndex).toHaveBeenLastCalledWith(NaverMarkerConfig.zIndex.placeActive);
+    expect(markerRecords[2].setPosition).not.toHaveBeenCalled();
+  });
+
+  it('updates only previous and next festival marker state when selection changes', () => {
+    const markerRecords: MarkerRecord[] = [];
+    const mapsApi = createMapsApi(markerRecords);
+    const mapRef = { current: {} };
+    const onSelectFestival = vi.fn();
+
+    function Harness({ selectedFestivalId }: { selectedFestivalId: string | null }) {
+      useNaverFestivalMarkers({
+        status: 'ready',
+        mapsApi,
+        mapRef,
+        festivals,
+        selectedFestivalId,
+        onSelectFestival,
+      });
+      return null;
+    }
+
+    const { rerender } = render(<Harness selectedFestivalId={null} />);
+
+    expect(markerRecords).toHaveLength(festivals.length);
+    clearMarkerSpies(markerRecords);
+
+    rerender(<Harness selectedFestivalId="festival-2" />);
+    rerender(<Harness selectedFestivalId="festival-3" />);
+
+    expect(markerRecords[0].setIcon).not.toHaveBeenCalled();
+    expect(markerRecords[0].setZIndex).not.toHaveBeenCalled();
+    expect(markerRecords[0].setPosition).not.toHaveBeenCalled();
+
+    expect(markerRecords[1].setIcon).toHaveBeenCalledTimes(2);
+    expect(markerRecords[1].setZIndex).toHaveBeenLastCalledWith(NaverMarkerConfig.zIndex.festivalDefault);
+    expect(markerRecords[1].setPosition).not.toHaveBeenCalled();
+
+    expect(markerRecords[2].setIcon).toHaveBeenCalledTimes(1);
+    expect(markerRecords[2].setZIndex).toHaveBeenLastCalledWith(NaverMarkerConfig.zIndex.festivalActive);
+    expect(markerRecords[2].setPosition).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 요약
- Scope-ID: `TSK-002-02-FRONTEND-MAP-GEO-CONFIG`
- Parent Issue: #238
- Child Issue: Refs #240
- PR #247에서 config 분리는 완료했지만, #240 체크리스트의 “PR #237 O(1) marker selection 동작 유지 테스트” 근거를 별도 보강합니다.
- selection id 변경만으로 place/festival marker 생성/position loop가 다시 돌지 않고, previous/next marker의 icon/z-index만 갱신되도록 고정했습니다.

## 변경 사항
- `useNaverPlaceMarkers`, `useNaverFestivalMarkers`의 marker 생성/position effect에서 selected id dependency 제거
- `test/unit/naver-marker-selection.test.tsx` 추가
- place/festival selection 변경 시 비활성 marker는 `setIcon`, `setZIndex`, `setPosition`이 호출되지 않음을 검증

## 검증
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run check:numeric-literals` 통과
- `npm run build` 통과
- UTF-8 integrity check 통과

## 변경 금지 범위 확인
- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
- FastAPI 파일 변경 없음