### PR TITLE
TSK-002-03 frontend UI token config 분리

### DIFF
--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -87,6 +87,14 @@ function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner
       reason: 'Map viewport, marker layer, selection-motion, geolocation, and distance values are owned by map config.',
     };
   }
+  if (path === 'src/config/uiTokenConfig.ts') {
+    return {
+      owner: 'frontend-ui',
+      category: 'frontend-ui-token-config-baseline',
+      scopeId: 'TSK-002-03-FRONTEND-UI-TOKEN-CONFIG',
+      reason: 'Inline review image frame layout and transform values are owned by UI token config.',
+    };
+  }
   if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
     return {
       owner: 'frontend-map',

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "e70ded4f21bd8f2e9a7fa0644d699e626c9a9897",
+  "generatedFrom": "2597f982e1bff0ece06e98020f8cd624472721e4",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -3640,7 +3640,7 @@
     },
     {
       "path": "src/components/naver-map/markerContent.ts",
-      "count": 144,
+      "count": 52,
       "owner": "frontend-map",
       "category": "map-coordinate-marker-baseline",
       "scopeId": "TSK-002-02-FRONTEND-MAP-GEO-CONFIG",
@@ -3648,33 +3648,33 @@
       "examples": [
         {
           "value": "95",
-          "line": 6,
+          "line": 7,
           "column": 45
         },
         {
           "value": "70",
-          "line": 6,
+          "line": 7,
           "column": 49
         },
         {
           "value": "96",
-          "line": 6,
+          "line": 7,
           "column": 53
         },
         {
           "value": "0.18",
-          "line": 6,
+          "line": 7,
           "column": 57
         },
         {
-          "value": "1.08",
-          "line": 7,
-          "column": 35
+          "value": "50%",
+          "line": 15,
+          "column": 44
         },
         {
-          "value": "1",
-          "line": 7,
-          "column": 51
+          "value": "999px",
+          "line": 15,
+          "column": 226
         }
       ]
     },
@@ -3920,7 +3920,7 @@
     },
     {
       "path": "src/components/review/ReviewImageFrame.tsx",
-      "count": 41,
+      "count": 8,
       "owner": "frontend-ui",
       "category": "frontend-ui-inline-token-baseline",
       "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
@@ -3928,33 +3928,33 @@
       "examples": [
         {
           "value": "0",
-          "line": 12,
+          "line": 13,
           "column": 55
         },
         {
           "value": "0",
-          "line": 12,
+          "line": 13,
           "column": 66
         },
         {
           "value": "0",
-          "line": 24,
+          "line": 25,
           "column": 50
         },
         {
           "value": "0",
-          "line": 25,
+          "line": 26,
           "column": 52
         },
         {
-          "value": "100%",
-          "line": 42,
-          "column": 17
+          "value": "0",
+          "line": 68,
+          "column": 58
         },
         {
-          "value": "220px",
-          "line": 43,
-          "column": 22
+          "value": "0",
+          "line": 69,
+          "column": 60
         }
       ]
     },
@@ -4090,6 +4090,46 @@
           "value": "5",
           "line": 18,
           "column": 44
+        }
+      ]
+    },
+    {
+      "path": "src/config/uiTokenConfig.ts",
+      "count": 87,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-token-config-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Inline review image frame layout and transform values are owned by UI token config.",
+      "examples": [
+        {
+          "value": "1.08",
+          "line": 8,
+          "column": 45
+        },
+        {
+          "value": "1.06",
+          "line": 9,
+          "column": 48
+        },
+        {
+          "value": "1",
+          "line": 10,
+          "column": 41
+        },
+        {
+          "value": "6",
+          "line": 11,
+          "column": 33
+        },
+        {
+          "value": "30",
+          "line": 12,
+          "column": 34
+        },
+        {
+          "value": "10",
+          "line": 13,
+          "column": 34
         }
       ]
     },
@@ -4360,7 +4400,7 @@
     },
     {
       "path": "src/index.css",
-      "count": 1565,
+      "count": 1534,
       "owner": "frontend-ui",
       "category": "css-layout-token-baseline",
       "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
@@ -4408,12 +4448,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 15,
+          "line": 14,
           "column": 60
         },
         {
           "value": "0",
-          "line": 45,
+          "line": 44,
           "column": 21
         }
       ]

--- a/src/components/naver-map/markerContent.ts
+++ b/src/components/naver-map/markerContent.ts
@@ -1,21 +1,22 @@
+import { cssPx, UiNaverMarkerVisualConfig } from '../../config/uiTokenConfig';
 import { categoryInfo } from '../../lib/categories';
 import type { FestivalItem, Place } from '../../types';
 
 export function placeMarkerContent(place: Place, isActive: boolean) {
   const info = categoryInfo[place.category];
   const ring = isActive ? '#5f4660' : 'rgba(95, 70, 96, 0.18)';
-  const scale = isActive ? 'scale(1.08)' : 'scale(1)';
-  const shadow = isActive ? '0 14px 28px rgba(255,127,168,0.28)' : '0 10px 22px rgba(255,156,96,0.18)';
+  const scale = isActive ? UiNaverMarkerVisualConfig.activePlaceScale : UiNaverMarkerVisualConfig.defaultScale;
+  const shadow = isActive ? UiNaverMarkerVisualConfig.activePlaceShadow : UiNaverMarkerVisualConfig.inactivePlaceShadow;
   const label = '';
 
   return `
-    <div style="transform:${scale};display:flex;flex-direction:column;align-items:center;gap:6px;">
-      <div style="position:relative;width:30px;height:30px;">
-        <div style="position:absolute;left:50%;top:1px;width:10px;height:10px;border-radius:999px;background:${info.jamColor};transform:translateX(-50%);"></div>
-        <div style="position:absolute;left:50%;bottom:1px;width:10px;height:10px;border-radius:999px;background:${info.jamColor};transform:translateX(-50%);"></div>
-        <div style="position:absolute;left:1px;top:50%;width:10px;height:10px;border-radius:999px;background:${info.jamColor};transform:translateY(-50%);"></div>
-        <div style="position:absolute;right:1px;top:50%;width:10px;height:10px;border-radius:999px;background:${info.jamColor};transform:translateY(-50%);"></div>
-        <div style="position:absolute;inset:7px;border-radius:999px;background:${info.color};border:2px solid ${ring};box-shadow:${shadow};display:flex;align-items:center;justify-content:center;color:#5f4660;font-size:10px;font-weight:900;">${info.icon}</div>
+    <div style="transform:${scale};display:flex;flex-direction:column;align-items:center;gap:${cssPx(UiNaverMarkerVisualConfig.columnGapPx)};">
+      <div style="position:relative;width:${cssPx(UiNaverMarkerVisualConfig.markerSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.markerSizePx)};">
+        <div style="position:absolute;left:50%;top:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:${info.jamColor};transform:translateX(-50%);"></div>
+        <div style="position:absolute;left:50%;bottom:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:${info.jamColor};transform:translateX(-50%);"></div>
+        <div style="position:absolute;left:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};top:50%;width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:${info.jamColor};transform:translateY(-50%);"></div>
+        <div style="position:absolute;right:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};top:50%;width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:${info.jamColor};transform:translateY(-50%);"></div>
+        <div style="position:absolute;inset:${cssPx(UiNaverMarkerVisualConfig.placeCoreInsetPx)};border-radius:999px;background:${info.color};border:${cssPx(UiNaverMarkerVisualConfig.markerBorderWidthPx)} solid ${ring};box-shadow:${shadow};display:flex;align-items:center;justify-content:center;color:#5f4660;font-size:${cssPx(UiNaverMarkerVisualConfig.placeIconFontSizePx)};font-weight:900;">${info.icon}</div>
       </div>
       ${label}
     </div>
@@ -24,17 +25,17 @@ export function placeMarkerContent(place: Place, isActive: boolean) {
 
 export function festivalMarkerContent(_festival: FestivalItem, isActive: boolean) {
   const ring = isActive ? '#ff4f93' : 'rgba(255, 79, 147, 0.22)';
-  const scale = isActive ? 'scale(1.06)' : 'scale(1)';
+  const scale = isActive ? UiNaverMarkerVisualConfig.activeFestivalScale : UiNaverMarkerVisualConfig.defaultScale;
   const label = '';
 
   return `
-    <div style="transform:${scale};display:flex;flex-direction:column;align-items:center;gap:6px;">
-      <div style="position:relative;width:30px;height:30px;">
-        <div style="position:absolute;left:50%;top:1px;width:10px;height:10px;border-radius:999px;background:#ffd4e6;transform:translateX(-50%);"></div>
-        <div style="position:absolute;left:50%;bottom:1px;width:10px;height:10px;border-radius:999px;background:#ffd4e6;transform:translateX(-50%);"></div>
-        <div style="position:absolute;left:1px;top:50%;width:10px;height:10px;border-radius:999px;background:#ffd4e6;transform:translateY(-50%);"></div>
-        <div style="position:absolute;right:1px;top:50%;width:10px;height:10px;border-radius:999px;background:#ffd4e6;transform:translateY(-50%);"></div>
-        <div style="position:absolute;inset:8px;border-radius:999px;background:#fff4fa;border:2px solid ${ring};box-shadow:0 10px 24px rgba(255,93,146,0.18);display:flex;align-items:center;justify-content:center;color:#7b1948;font-size:8px;font-weight:900;">축제</div>
+    <div style="transform:${scale};display:flex;flex-direction:column;align-items:center;gap:${cssPx(UiNaverMarkerVisualConfig.columnGapPx)};">
+      <div style="position:relative;width:${cssPx(UiNaverMarkerVisualConfig.markerSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.markerSizePx)};">
+        <div style="position:absolute;left:50%;top:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:#ffd4e6;transform:translateX(-50%);"></div>
+        <div style="position:absolute;left:50%;bottom:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:#ffd4e6;transform:translateX(-50%);"></div>
+        <div style="position:absolute;left:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};top:50%;width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:#ffd4e6;transform:translateY(-50%);"></div>
+        <div style="position:absolute;right:${cssPx(UiNaverMarkerVisualConfig.jamDotEdgePx)};top:50%;width:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.jamDotSizePx)};border-radius:999px;background:#ffd4e6;transform:translateY(-50%);"></div>
+        <div style="position:absolute;inset:${cssPx(UiNaverMarkerVisualConfig.festivalCoreInsetPx)};border-radius:999px;background:#fff4fa;border:${cssPx(UiNaverMarkerVisualConfig.markerBorderWidthPx)} solid ${ring};box-shadow:${UiNaverMarkerVisualConfig.festivalShadow};display:flex;align-items:center;justify-content:center;color:#7b1948;font-size:${cssPx(UiNaverMarkerVisualConfig.festivalLabelFontSizePx)};font-weight:900;">축제</div>
       </div>
       ${label}
     </div>
@@ -50,14 +51,14 @@ export function hasFestivalCoordinates(festival: FestivalItem) {
 
 export function currentLocationMarkerContent() {
   return `
-    <div style="display:flex;align-items:center;justify-content:center;width:28px;height:28px;border-radius:999px;background:rgba(255,255,255,0.92);box-shadow:0 6px 18px rgba(95,70,96,0.18);border:1px solid rgba(95,70,96,0.12);">
-      <div style="width:12px;height:12px;border-radius:999px;background:#4f8cff;box-shadow:0 0 0 6px rgba(79,140,255,0.18);"></div>
+    <div style="display:flex;align-items:center;justify-content:center;width:${cssPx(UiNaverMarkerVisualConfig.currentLocationSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.currentLocationSizePx)};border-radius:999px;background:rgba(255,255,255,0.92);box-shadow:${UiNaverMarkerVisualConfig.currentLocationShadow};border:${cssPx(UiNaverMarkerVisualConfig.currentLocationBorderWidthPx)} solid rgba(95,70,96,0.12);">
+      <div style="width:${cssPx(UiNaverMarkerVisualConfig.currentLocationDotSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.currentLocationDotSizePx)};border-radius:999px;background:#4f8cff;box-shadow:${UiNaverMarkerVisualConfig.currentLocationPulseShadow};"></div>
     </div>
   `;
 }
 
 export function routeStepMarkerContent(step: number) {
   return `
-    <div style="display:flex;align-items:center;justify-content:center;width:26px;height:26px;border-radius:999px;background:#5f4660;color:#fff;font-size:11px;font-weight:800;box-shadow:0 10px 24px rgba(95,70,96,0.22);border:2px solid rgba(255,255,255,0.9);">${step}</div>
+    <div style="display:flex;align-items:center;justify-content:center;width:${cssPx(UiNaverMarkerVisualConfig.routeStepSizePx)};height:${cssPx(UiNaverMarkerVisualConfig.routeStepSizePx)};border-radius:999px;background:#5f4660;color:#fff;font-size:${cssPx(UiNaverMarkerVisualConfig.routeStepFontSizePx)};font-weight:800;box-shadow:${UiNaverMarkerVisualConfig.routeStepShadow};border:${cssPx(UiNaverMarkerVisualConfig.markerBorderWidthPx)} solid rgba(255,255,255,0.9);">${step}</div>
   `;
 }

--- a/src/components/review/ReviewImageFrame.tsx
+++ b/src/components/review/ReviewImageFrame.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react';
+import { UiReviewImageFrameConfig } from '../../config/uiTokenConfig';
 
 interface ReviewImageFrameProps {
   src: string;
@@ -38,30 +39,14 @@ export function ReviewImageFrame({ src, thumbnailSrc = null, alt }: ReviewImageF
     <div
       ref={frameRef}
       className={isTall ? 'review-card__image-frame review-card__image-frame--rotated' : 'review-card__image-frame'}
-      style={{
-        width: '100%',
-        height: 'min(220px, 56vw)',
-        maxHeight: '220px',
-        borderRadius: '20px',
-        overflow: 'hidden',
-        background: 'rgba(255, 250, 252, 0.96)',
-        border: '1px solid rgba(255, 176, 201, 0.16)',
-        padding: '0',
-        position: 'relative',
-      }}
+      style={UiReviewImageFrameConfig.frameStyle}
     >
       {isTall ? (
         <div
           style={{
-            position: 'absolute',
-            top: '50%',
-            left: '50%',
-            width: `${Math.max(frameSize.height, 1)}px`,
-            height: `${Math.max(frameSize.width, 1)}px`,
-            transform: 'translate(-50%, -50%) rotate(-90deg)',
-            transformOrigin: 'center center',
-            overflow: 'hidden',
-            borderRadius: '14px',
+            ...UiReviewImageFrameConfig.rotatedWrapperStyle,
+            width: `${Math.max(frameSize.height, UiReviewImageFrameConfig.minimumRotatedDimensionPx)}px`,
+            height: `${Math.max(frameSize.width, UiReviewImageFrameConfig.minimumRotatedDimensionPx)}px`,
           }}
         >
           <img
@@ -77,7 +62,7 @@ export function ReviewImageFrame({ src, thumbnailSrc = null, alt }: ReviewImageF
             }}
             onLoad={(event) => {
               const target = event.currentTarget;
-              setIsTall(target.naturalHeight > target.naturalWidth * 1.12);
+              setIsTall(target.naturalHeight > target.naturalWidth * UiReviewImageFrameConfig.tallImageAspectRatio);
               if (frameRef.current) {
                 setFrameSize({
                   width: frameRef.current.clientWidth || 0,
@@ -85,14 +70,7 @@ export function ReviewImageFrame({ src, thumbnailSrc = null, alt }: ReviewImageF
                 });
               }
             }}
-            style={{
-              width: '100%',
-              height: '100%',
-              objectFit: 'cover',
-              borderRadius: '14px',
-              display: 'block',
-              margin: 0,
-            }}
+            style={UiReviewImageFrameConfig.imageStyle}
           />
         </div>
       ) : (
@@ -109,7 +87,7 @@ export function ReviewImageFrame({ src, thumbnailSrc = null, alt }: ReviewImageF
           }}
           onLoad={(event) => {
             const target = event.currentTarget;
-            setIsTall(target.naturalHeight > target.naturalWidth * 1.12);
+            setIsTall(target.naturalHeight > target.naturalWidth * UiReviewImageFrameConfig.tallImageAspectRatio);
             if (frameRef.current) {
               setFrameSize({
                 width: frameRef.current.clientWidth || 0,
@@ -117,14 +95,7 @@ export function ReviewImageFrame({ src, thumbnailSrc = null, alt }: ReviewImageF
               });
             }
           }}
-          style={{
-            width: '100%',
-            height: '100%',
-            objectFit: 'cover',
-            borderRadius: '14px',
-            display: 'block',
-            margin: 0,
-          }}
+          style={UiReviewImageFrameConfig.imageStyle}
         />
       )}
     </div>

--- a/src/config/uiTokenConfig.ts
+++ b/src/config/uiTokenConfig.ts
@@ -1,0 +1,67 @@
+import type { CSSProperties } from 'react';
+
+export function cssPx(value: number) {
+  return `${value}px`;
+}
+
+export class UiNaverMarkerVisualConfig {
+  static readonly activePlaceScale = 'scale(1.08)';
+  static readonly activeFestivalScale = 'scale(1.06)';
+  static readonly defaultScale = 'scale(1)';
+  static readonly columnGapPx = 6;
+  static readonly markerSizePx = 30;
+  static readonly jamDotSizePx = 10;
+  static readonly jamDotEdgePx = 1;
+  static readonly placeCoreInsetPx = 7;
+  static readonly festivalCoreInsetPx = 8;
+  static readonly placeIconFontSizePx = 10;
+  static readonly festivalLabelFontSizePx = 8;
+  static readonly currentLocationSizePx = 28;
+  static readonly currentLocationDotSizePx = 12;
+  static readonly routeStepSizePx = 26;
+  static readonly routeStepFontSizePx = 11;
+  static readonly markerBorderWidthPx = 2;
+  static readonly currentLocationBorderWidthPx = 1;
+  static readonly activePlaceShadow = '0 14px 28px rgba(255,127,168,0.28)';
+  static readonly inactivePlaceShadow = '0 10px 22px rgba(255,156,96,0.18)';
+  static readonly festivalShadow = '0 10px 24px rgba(255,93,146,0.18)';
+  static readonly currentLocationShadow = '0 6px 18px rgba(95,70,96,0.18)';
+  static readonly currentLocationPulseShadow = '0 0 0 6px rgba(79,140,255,0.18)';
+  static readonly routeStepShadow = '0 10px 24px rgba(95,70,96,0.22)';
+}
+
+export class UiReviewImageFrameConfig {
+  static readonly tallImageAspectRatio = 1.12;
+  static readonly minimumRotatedDimensionPx = 1;
+
+  static readonly frameStyle = {
+    width: '100%',
+    height: 'min(220px, 56vw)',
+    maxHeight: '220px',
+    borderRadius: '20px',
+    overflow: 'hidden',
+    background: 'rgba(255, 250, 252, 0.96)',
+    border: '1px solid rgba(255, 176, 201, 0.16)',
+    padding: '0',
+    position: 'relative',
+  } satisfies CSSProperties;
+
+  static readonly rotatedWrapperStyle = {
+    position: 'absolute',
+    top: '50%',
+    left: '50%',
+    transform: 'translate(-50%, -50%) rotate(-90deg)',
+    transformOrigin: 'center center',
+    overflow: 'hidden',
+    borderRadius: '14px',
+  } satisfies CSSProperties;
+
+  static readonly imageStyle = {
+    width: '100%',
+    height: '100%',
+    objectFit: 'cover',
+    borderRadius: '14px',
+    display: 'block',
+    margin: 0,
+  } satisfies CSSProperties;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -19,6 +19,35 @@
   --line: rgba(255, 255, 255, 0.76);
   --shadow: 0 18px 42px rgba(255, 143, 183, 0.18);
   --sheet-shadow: 0 -18px 34px rgba(66, 40, 60, 0.16);
+  --app-shell-safe-y: 16px;
+  --app-shell-safe-x: 14px;
+  --phone-shell-max-width: 430px;
+  --phone-shell-max-height: 920px;
+  --phone-shell-height-gap: 24px;
+  --phone-shell-radius: 32px;
+  --layer-app-header: 40;
+  --layer-utility: 1200;
+  --layer-utility-panel: 1201;
+  --utility-slot-top: 14px;
+  --utility-slot-right: 20px;
+  --utility-gap: 10px;
+  --utility-control-size: 48px;
+  --utility-control-radius: 18px;
+  --utility-menu-top: 56px;
+  --utility-menu-width: 220px;
+  --utility-panel-viewport-gap: 40px;
+  --utility-panel-padding: 14px;
+  --utility-panel-radius: 24px;
+  --utility-panel-border: 1px solid rgba(255, 197, 217, 0.42);
+  --utility-panel-background: rgba(255, 252, 249, 0.98);
+  --utility-panel-shadow: 0 20px 42px rgba(66, 40, 60, 0.18);
+  --utility-panel-blur: 18px;
+  --notification-panel-top: 156px;
+  --notification-panel-width: 332px;
+  --notification-panel-max-height: 520px;
+  --notification-panel-max-vh: 62vh;
+  --notification-panel-embedded-gap: 6px;
+  --notification-scrollbar-size: 10px;
 }
 
 * {
@@ -86,18 +115,18 @@ textarea {
   place-items: center;
   background: var(--app-surface-background);
   padding:
-    max(16px, env(safe-area-inset-top))
-    max(14px, env(safe-area-inset-right))
-    max(16px, env(safe-area-inset-bottom))
-    max(14px, env(safe-area-inset-left));
+    max(var(--app-shell-safe-y), env(safe-area-inset-top))
+    max(var(--app-shell-safe-x), env(safe-area-inset-right))
+    max(var(--app-shell-safe-y), env(safe-area-inset-bottom))
+    max(var(--app-shell-safe-x), env(safe-area-inset-left));
 }
 
 .phone-shell {
   position: relative;
-  width: min(100%, 430px);
-  height: min(920px, calc(var(--app-height) - 24px));
-  max-height: calc(var(--app-height) - 24px);
-  border-radius: 32px;
+  width: min(100%, var(--phone-shell-max-width));
+  height: min(var(--phone-shell-max-height), calc(var(--app-height) - var(--phone-shell-height-gap)));
+  max-height: calc(var(--app-height) - var(--phone-shell-height-gap));
+  border-radius: var(--phone-shell-radius);
   overflow: hidden;
   background: rgba(255, 252, 249, 0.9);
   border: 1px solid rgba(255, 255, 255, 0.82);
@@ -113,19 +142,19 @@ textarea {
   top: 0;
   left: 0;
   right: 0;
-  z-index: 40;
+  z-index: var(--layer-app-header);
   padding: 10px 138px 0 16px;
   pointer-events: none;
 }
 
 .phone-shell__utility-slot {
   position: absolute;
-  top: 14px;
-  right: 20px;
-  z-index: 1200;
+  top: var(--utility-slot-top);
+  right: var(--utility-slot-right);
+  z-index: var(--layer-utility);
   display: inline-flex;
   align-items: flex-start;
-  gap: 10px;
+  gap: var(--utility-gap);
   pointer-events: auto;
 }
 
@@ -154,26 +183,26 @@ textarea {
 }
 
 .global-settings-menu__trigger {
-  min-width: 48px;
-  width: 48px;
-  height: 48px;
-  border-radius: 18px;
+  min-width: var(--utility-control-size);
+  width: var(--utility-control-size);
+  height: var(--utility-control-size);
+  border-radius: var(--utility-control-radius);
 }
 
 .global-settings-menu__menu {
   position: absolute;
-  top: 56px;
+  top: var(--utility-menu-top);
   right: 0;
-  z-index: 1201;
+  z-index: var(--layer-utility-panel);
   display: grid;
-  gap: 10px;
-  width: min(220px, calc(100vw - 40px));
-  padding: 14px;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 197, 217, 0.42);
-  background: rgba(255, 252, 249, 0.98);
-  box-shadow: 0 20px 42px rgba(66, 40, 60, 0.18);
-  backdrop-filter: blur(18px);
+  gap: var(--utility-gap);
+  width: min(var(--utility-menu-width), calc(100vw - var(--utility-panel-viewport-gap)));
+  padding: var(--utility-panel-padding);
+  border-radius: var(--utility-panel-radius);
+  border: var(--utility-panel-border);
+  background: var(--utility-panel-background);
+  box-shadow: var(--utility-panel-shadow);
+  backdrop-filter: blur(var(--utility-panel-blur));
 }
 
 .global-settings-menu__item {
@@ -185,30 +214,30 @@ textarea {
 }
 
 .feedback-button {
-  min-width: 48px;
-  width: 48px;
-  height: 48px;
-  border-radius: 18px;
+  min-width: var(--utility-control-size);
+  width: var(--utility-control-size);
+  height: var(--utility-control-size);
+  border-radius: var(--utility-control-radius);
   text-decoration: none;
 }
 
 .global-notification-panel {
   position: absolute;
-  top: 156px;
+  top: var(--notification-panel-top);
   right: 0;
-  z-index: 1201;
-  width: min(332px, calc(100vw - 40px));
-  max-height: min(62vh, 520px);
+  z-index: var(--layer-utility-panel);
+  width: min(var(--notification-panel-width), calc(100vw - var(--utility-panel-viewport-gap)));
+  max-height: min(var(--notification-panel-max-vh), var(--notification-panel-max-height));
   overflow-y: auto;
   scrollbar-gutter: stable;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 151, 187, 0.72) rgba(255, 241, 246, 0.92);
-  padding: 14px;
-  border-radius: 24px;
-  border: 1px solid rgba(255, 197, 217, 0.42);
-  background: rgba(255, 252, 249, 0.98);
-  box-shadow: 0 20px 42px rgba(66, 40, 60, 0.18);
-  backdrop-filter: blur(18px);
+  padding: var(--utility-panel-padding);
+  border-radius: var(--utility-panel-radius);
+  border: var(--utility-panel-border);
+  background: var(--utility-panel-background);
+  box-shadow: var(--utility-panel-shadow);
+  backdrop-filter: blur(var(--utility-panel-blur));
 }
 
 .global-notification-panel--embedded {
@@ -217,11 +246,11 @@ textarea {
   right: auto;
   width: 100%;
   max-height: none;
-  margin-top: 6px;
+  margin-top: var(--notification-panel-embedded-gap);
 }
 
 .global-notification-panel::-webkit-scrollbar {
-  width: 10px;
+  width: var(--notification-scrollbar-size);
 }
 
 .global-notification-panel::-webkit-scrollbar-track {

--- a/test/unit/ui-token-config.test.ts
+++ b/test/unit/ui-token-config.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { cssPx, UiNaverMarkerVisualConfig, UiReviewImageFrameConfig } from '../../src/config/uiTokenConfig';
+
+describe('ui token config boundaries', () => {
+  it('keeps review image frame inline layout values in named config', () => {
+    expect(UiReviewImageFrameConfig.tallImageAspectRatio).toBe(1.12);
+    expect(UiReviewImageFrameConfig.minimumRotatedDimensionPx).toBe(1);
+    expect(UiReviewImageFrameConfig.frameStyle).toMatchObject({
+      width: '100%',
+      height: 'min(220px, 56vw)',
+      maxHeight: '220px',
+      borderRadius: '20px',
+      position: 'relative',
+    });
+    expect(UiReviewImageFrameConfig.rotatedWrapperStyle).toMatchObject({
+      top: '50%',
+      left: '50%',
+      transform: 'translate(-50%, -50%) rotate(-90deg)',
+      borderRadius: '14px',
+    });
+    expect(UiReviewImageFrameConfig.imageStyle).toMatchObject({
+      width: '100%',
+      height: '100%',
+      objectFit: 'cover',
+      borderRadius: '14px',
+    });
+  });
+
+  it('keeps naver marker visual geometry in named config', () => {
+    expect(cssPx(UiNaverMarkerVisualConfig.markerSizePx)).toBe('30px');
+    expect(UiNaverMarkerVisualConfig.activePlaceScale).toBe('scale(1.08)');
+    expect(UiNaverMarkerVisualConfig.activeFestivalScale).toBe('scale(1.06)');
+    expect(UiNaverMarkerVisualConfig.jamDotSizePx).toBe(10);
+    expect(UiNaverMarkerVisualConfig.placeCoreInsetPx).toBe(7);
+    expect(UiNaverMarkerVisualConfig.festivalCoreInsetPx).toBe(8);
+    expect(UiNaverMarkerVisualConfig.currentLocationSizePx).toBe(28);
+    expect(UiNaverMarkerVisualConfig.routeStepSizePx).toBe(26);
+  });
+});


### PR DESCRIPTION
## 요약
- Scope-ID: `TSK-002-03-FRONTEND-UI-TOKEN-CONFIG`
- Parent Issue: #238
- Child Issue: Closes #241
- app shell/utility/notification 레이아웃 수치를 CSS custom property로 승격했습니다.
- `ReviewImageFrame`과 Naver marker HTML의 inline style geometry를 `src/config/uiTokenConfig.ts`로 분리했습니다.

## 변경 사항
- `src/index.css`: app shell, phone shell, utility slot/menu, notification panel 주요 spacing/z-index/size 값을 CSS token으로 치환
- `UiReviewImageFrameConfig`: review image frame height/radius/rotation/aspect-ratio inline style 값 분리
- `UiNaverMarkerVisualConfig`: Naver marker HTML의 marker size, dot size, inset, font size, shadow, scale 값 분리
- `test/unit/ui-token-config.test.ts`: UI token 값 회귀 고정
- numeric literal baseline을 UI token config 소유권 기준으로 갱신

## media query와 잔여 수치 처리
- CSS media query breakpoint는 이번 PR에서 생성 방식까지 바꾸지 않았습니다.
- media query 값은 CSS 변수로 직접 대체하기 어렵기 때문에 #245 문서화 단계에서 allowlist/생성 전략으로 기록합니다.
- 시각 디자인 값은 그대로 이름 있는 token/config로 이동했으며 의도적 redesign은 없습니다.

## 검증
- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- `npm run test:smoke:ui` 통과
- UTF-8 integrity check 통과

## 변경 금지 범위 확인
- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
- FastAPI 파일 변경 없음