### PR TITLE
Extract frontend runtime limit config

### DIFF
--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -95,6 +95,14 @@ function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner
       reason: 'Inline review image frame layout and transform values are owned by UI token config.',
     };
   }
+  if (path === 'src/config/runtimeLimitConfig.ts') {
+    return {
+      owner: 'frontend-runtime',
+      category: 'frontend-runtime-limit-config-baseline',
+      scopeId: 'TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG',
+      reason: 'API cache TTL, upload compression, autoload, pagination, feedback, and floating-button runtime values are owned by runtime limit config.',
+    };
+  }
   if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
     return {
       owner: 'frontend-map',

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "2597f982e1bff0ece06e98020f8cd624472721e4",
+  "generatedFrom": "1e87b79d113e0376345b5985440f8496982b240b",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -2930,41 +2930,26 @@
     },
     {
       "path": "src/api/core.ts",
-      "count": 13,
+      "count": 3,
       "owner": "frontend-runtime",
       "category": "frontend-runtime-limit-baseline",
       "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
       "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
       "examples": [
         {
-          "value": "15_000",
-          "line": 12,
-          "column": 28
+          "value": "0",
+          "line": 35,
+          "column": 27
         },
         {
-          "value": "30",
-          "line": 36,
-          "column": 12
+          "value": "401",
+          "line": 65,
+          "column": 29
         },
         {
-          "value": "60",
-          "line": 36,
-          "column": 17
-        },
-        {
-          "value": "1000",
-          "line": 36,
-          "column": 22
-        },
-        {
-          "value": "60",
-          "line": 39,
-          "column": 12
-        },
-        {
-          "value": "1000",
-          "line": 39,
-          "column": 17
+          "value": "204",
+          "line": 71,
+          "column": 27
         }
       ]
     },
@@ -3135,41 +3120,6 @@
           "value": "2",
           "line": 19,
           "column": 18
-        }
-      ]
-    },
-    {
-      "path": "src/components/floating-back-button/constants.ts",
-      "count": 5,
-      "owner": "frontend-runtime",
-      "category": "frontend-runtime-limit-baseline",
-      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
-      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
-      "examples": [
-        {
-          "value": "46",
-          "line": 1,
-          "column": 28
-        },
-        {
-          "value": "12",
-          "line": 2,
-          "column": 29
-        },
-        {
-          "value": "120",
-          "line": 3,
-          "column": 39
-        },
-        {
-          "value": "180",
-          "line": 4,
-          "column": 36
-        },
-        {
-          "value": "260",
-          "line": 5,
-          "column": 36
         }
       ]
     },
@@ -4094,6 +4044,46 @@
       ]
     },
     {
+      "path": "src/config/runtimeLimitConfig.ts",
+      "count": 27,
+      "owner": "frontend-runtime",
+      "category": "frontend-runtime-limit-config-baseline",
+      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
+      "reason": "API cache TTL, upload compression, autoload, pagination, feedback, and floating-button runtime values are owned by runtime limit config.",
+      "examples": [
+        {
+          "value": "1000",
+          "line": 2,
+          "column": 30
+        },
+        {
+          "value": "60",
+          "line": 3,
+          "column": 30
+        },
+        {
+          "value": "15",
+          "line": 4,
+          "column": 37
+        },
+        {
+          "value": "30",
+          "line": 7,
+          "column": 66
+        },
+        {
+          "value": "20",
+          "line": 9,
+          "column": 73
+        },
+        {
+          "value": "10",
+          "line": 10,
+          "column": 61
+        }
+      ]
+    },
+    {
       "path": "src/config/uiTokenConfig.ts",
       "count": 87,
       "owner": "frontend-ui",
@@ -4184,21 +4174,6 @@
       ]
     },
     {
-      "path": "src/hooks/app-tab-loaders/feedReviewLoader.ts",
-      "count": 1,
-      "owner": "frontend-ui",
-      "category": "frontend-ui-inline-token-baseline",
-      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
-      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
-      "examples": [
-        {
-          "value": "10",
-          "line": 24,
-          "column": 51
-        }
-      ]
-    },
-    {
       "path": "src/hooks/useAppAuthActions.ts",
       "count": 1,
       "owner": "frontend-ui",
@@ -4210,26 +4185,6 @@
           "value": "2",
           "line": 32,
           "column": 48
-        }
-      ]
-    },
-    {
-      "path": "src/hooks/useAppCoordinatorEffects.ts",
-      "count": 2,
-      "owner": "frontend-ui",
-      "category": "frontend-ui-inline-token-baseline",
-      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
-      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
-      "examples": [
-        {
-          "value": "120",
-          "line": 14,
-          "column": 36
-        },
-        {
-          "value": "4000",
-          "line": 15,
-          "column": 33
         }
       ]
     },
@@ -4255,26 +4210,6 @@
           "value": "1",
           "line": 81,
           "column": 71
-        }
-      ]
-    },
-    {
-      "path": "src/hooks/useAppPagePaginationActions.ts",
-      "count": 2,
-      "owner": "frontend-ui",
-      "category": "frontend-ui-inline-token-baseline",
-      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
-      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
-      "examples": [
-        {
-          "value": "10",
-          "line": 46,
-          "column": 77
-        },
-        {
-          "value": "10",
-          "line": 81,
-          "column": 100
         }
       ]
     },
@@ -4374,31 +4309,6 @@
       ]
     },
     {
-      "path": "src/hooks/useAutoLoadMore.ts",
-      "count": 3,
-      "owner": "frontend-runtime",
-      "category": "frontend-runtime-limit-baseline",
-      "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
-      "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
-      "examples": [
-        {
-          "value": "160px",
-          "line": 18,
-          "column": 17
-        },
-        {
-          "value": "0px",
-          "line": 18,
-          "column": 23
-        },
-        {
-          "value": "0.01",
-          "line": 48,
-          "column": 20
-        }
-      ]
-    },
-    {
       "path": "src/index.css",
       "count": 1534,
       "owner": "frontend-ui",
@@ -4460,41 +4370,41 @@
     },
     {
       "path": "src/lib/imageUpload.ts",
-      "count": 20,
+      "count": 9,
       "owner": "frontend-runtime",
       "category": "frontend-runtime-limit-baseline",
       "scopeId": "TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG",
       "reason": "Upload limits, cache TTLs, autoload margins, and interaction delays are migrated through runtime config work.",
       "examples": [
         {
-          "value": "1600",
-          "line": 1,
-          "column": 30
+          "value": "-1",
+          "line": 10,
+          "column": 20
         },
         {
-          "value": "1_000_000",
-          "line": 2,
+          "value": "0",
+          "line": 13,
+          "column": 28
+        },
+        {
+          "value": "1",
+          "line": 31,
           "column": 26
         },
         {
-          "value": "0.84",
-          "line": 3,
-          "column": 30
-        },
-        {
-          "value": "0.58",
-          "line": 4,
+          "value": "1",
+          "line": 32,
           "column": 26
         },
         {
-          "value": "0.08",
-          "line": 5,
+          "value": "1",
+          "line": 33,
           "column": 27
         },
         {
-          "value": "960",
-          "line": 6,
-          "column": 36
+          "value": "0",
+          "line": 41,
+          "column": 28
         }
       ]
     },

--- a/src/api/core.ts
+++ b/src/api/core.ts
@@ -1,4 +1,5 @@
 import { getClientConfig } from '../config';
+import { ApiCacheConfig } from '../config/runtimeLimitConfig';
 
 export class ApiError extends Error {
   status: number;
@@ -9,7 +10,6 @@ export class ApiError extends Error {
   }
 }
 
-const DEFAULT_GET_TTL_MS = 15_000;
 const WORKER_FALLBACK_BASE_URL = '';
 
 const responseCache = new Map<string, { expiresAt: number; value: unknown }>();
@@ -29,22 +29,6 @@ function clonePayload<T>(value: T): T {
 function buildCacheKey(path: string, init?: RequestInit) {
   const method = (init?.method ?? 'GET').toUpperCase();
   return method + ':' + path;
-}
-
-function getTtlForPath(path: string) {
-  if (path.startsWith('/api/festivals') || path.startsWith('/api/banner/events')) {
-    return 30 * 60 * 1000;
-  }
-  if (path.startsWith('/api/courses/curated')) {
-    return 60 * 1000;
-  }
-  if (path.startsWith('/api/map-bootstrap') || path.startsWith('/api/community-routes')) {
-    return 20 * 1000;
-  }
-  if (path.startsWith('/api/reviews') || path.startsWith('/api/my/summary')) {
-    return 10 * 1000;
-  }
-  return DEFAULT_GET_TTL_MS;
 }
 
 export function invalidateApiCache(prefixes: string[] = []) {
@@ -144,7 +128,7 @@ export async function fetchJson<T>(path: string, init?: RequestInit): Promise<T>
     const payload = await requestPromise;
     if (canCache) {
       responseCache.set(cacheKey, {
-        expiresAt: now + getTtlForPath(path),
+        expiresAt: now + ApiCacheConfig.getTtlForPath(path),
         value: clonePayload(payload),
       });
     }

--- a/src/components/floating-back-button/constants.ts
+++ b/src/components/floating-back-button/constants.ts
@@ -1,5 +1,7 @@
-export const BUTTON_SIZE = 46;
-export const EDGE_PADDING = 12;
-export const DESKTOP_BOTTOM_PADDING = 120;
-export const MOBILE_SHEET_OFFSET = 180;
-export const TOUCH_DRAG_DELAY_MS = 260;
+import { FloatingBackButtonRuntimeConfig } from '../../config/runtimeLimitConfig';
+
+export const BUTTON_SIZE = FloatingBackButtonRuntimeConfig.buttonSizePx;
+export const EDGE_PADDING = FloatingBackButtonRuntimeConfig.edgePaddingPx;
+export const DESKTOP_BOTTOM_PADDING = FloatingBackButtonRuntimeConfig.desktopBottomPaddingPx;
+export const MOBILE_SHEET_OFFSET = FloatingBackButtonRuntimeConfig.mobileSheetOffsetPx;
+export const TOUCH_DRAG_DELAY_MS = FloatingBackButtonRuntimeConfig.touchDragDelayMs;

--- a/src/config/runtimeLimitConfig.ts
+++ b/src/config/runtimeLimitConfig.ts
@@ -1,0 +1,64 @@
+export class ApiCacheConfig {
+  static readonly secondMs = 1000;
+  static readonly minuteMs = 60 * ApiCacheConfig.secondMs;
+  static readonly defaultGetTtlMs = 15 * ApiCacheConfig.secondMs;
+
+  static readonly endpointTtlRules = [
+    { prefixes: ['/api/festivals', '/api/banner/events'], ttlMs: 30 * ApiCacheConfig.minuteMs },
+    { prefixes: ['/api/courses/curated'], ttlMs: ApiCacheConfig.minuteMs },
+    { prefixes: ['/api/map-bootstrap', '/api/community-routes'], ttlMs: 20 * ApiCacheConfig.secondMs },
+    { prefixes: ['/api/reviews', '/api/my/summary'], ttlMs: 10 * ApiCacheConfig.secondMs },
+  ] as const;
+
+  static getTtlForPath(path: string) {
+    return ApiCacheConfig.endpointTtlRules.find((rule) =>
+      rule.prefixes.some((prefix) => path.startsWith(prefix)),
+    )?.ttlMs ?? ApiCacheConfig.defaultGetTtlMs;
+  }
+}
+
+export class ImageUploadConfig {
+  static readonly shrinkScale = 0.75;
+  static readonly jpegMimeType = 'image/jpeg';
+  static readonly jpegExtension = 'jpg';
+
+  static readonly main = {
+    maxDimension: 1600,
+    maxBytes: 1_000_000,
+    minDimensionAfterResize: 960,
+  };
+
+  static readonly thumbnail = {
+    maxDimension: 480,
+    maxBytes: 120_000,
+    minDimensionAfterResize: 320,
+  };
+
+  static readonly jpegQuality = {
+    initial: 0.84,
+    min: 0.58,
+    step: 0.08,
+  };
+}
+
+export class AutoLoadMoreConfig {
+  static readonly defaultRootMargin = '160px 0px';
+  static readonly threshold = 0.01;
+}
+
+export class FeedbackRuntimeConfig {
+  static readonly stampUnlockRadiusMeters = 120;
+  static readonly noticeDismissDelayMs = 4000;
+}
+
+export class PaginationRuntimeConfig {
+  static readonly pageSize = 10;
+}
+
+export class FloatingBackButtonRuntimeConfig {
+  static readonly buttonSizePx = 46;
+  static readonly edgePaddingPx = 12;
+  static readonly desktopBottomPaddingPx = 120;
+  static readonly mobileSheetOffsetPx = 180;
+  static readonly touchDragDelayMs = 260;
+}

--- a/src/hooks/app-tab-loaders/feedReviewLoader.ts
+++ b/src/hooks/app-tab-loaders/feedReviewLoader.ts
@@ -1,5 +1,6 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getReviewFeedPage } from '../../api/reviewsClient';
+import { PaginationRuntimeConfig } from '../../config/runtimeLimitConfig';
 import { toReviewSummaryList } from '../../lib/reviews';
 import type { Review } from '../../types';
 
@@ -21,7 +22,7 @@ export function createFeedReviewLoader({
       return;
     }
 
-    const page = await getReviewFeedPage({ limit: 10 });
+    const page = await getReviewFeedPage({ limit: PaginationRuntimeConfig.pageSize });
     setReviews(toReviewSummaryList(page.items));
     setFeedNextCursor(page.nextCursor);
     setFeedHasMore(Boolean(page.nextCursor));

--- a/src/hooks/useAppCoordinatorEffects.ts
+++ b/src/hooks/useAppCoordinatorEffects.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { FeedbackRuntimeConfig } from '../config/runtimeLimitConfig';
 import { getInitialNotice } from './useAppRouteState';
 import { useAppFeedbackEffects } from './useAppFeedbackEffects';
 import { useAppBootstrapLifecycle } from './useAppBootstrapLifecycle';
@@ -10,9 +11,6 @@ import type {
   ShellRuntimeState,
 } from './useAppShellCoordinator.types';
 import type { useAppCoordinatorServices } from './useAppCoordinatorServices';
-
-const STAMP_UNLOCK_RADIUS_METERS = 120;
-const NOTICE_DISMISS_DELAY_MS = 4000;
 
 type CoordinatorEffectsArgs = {
   routeState: RouteState;
@@ -77,8 +75,8 @@ export function useAppCoordinatorEffects({
     todayStamp: viewModels.todayStamp,
     notice,
     mapLocationMessage,
-    stampUnlockRadiusMeters: STAMP_UNLOCK_RADIUS_METERS,
-    noticeDismissDelayMs: NOTICE_DISMISS_DELAY_MS,
+    stampUnlockRadiusMeters: FeedbackRuntimeConfig.stampUnlockRadiusMeters,
+    noticeDismissDelayMs: FeedbackRuntimeConfig.noticeDismissDelayMs,
   });
 
   useAppBootstrapLifecycle({

--- a/src/hooks/useAppPagePaginationActions.ts
+++ b/src/hooks/useAppPagePaginationActions.ts
@@ -1,6 +1,7 @@
 import { useCallback, type Dispatch, type SetStateAction } from 'react';
 import { getMyCommentsPage } from '../api/myClient';
 import { getReviewFeedPage } from '../api/reviewsClient';
+import { PaginationRuntimeConfig } from '../config/runtimeLimitConfig';
 import { toReviewSummaryList } from '../lib/reviews';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import type { MyPageResponse, Review, SessionUser } from '../types';
@@ -43,7 +44,7 @@ export function useAppPagePaginationActions({
 
     setFeedLoadingMore(true);
     try {
-      const page = await getReviewFeedPage({ cursor: feedNextCursor, limit: 10 });
+      const page = await getReviewFeedPage({ cursor: feedNextCursor, limit: PaginationRuntimeConfig.pageSize });
       setReviews((current) => {
         const existingIds = new Set(current.map((review) => review.id));
         const nextItems = toReviewSummaryList(page.items).filter((review) => !existingIds.has(review.id));
@@ -78,7 +79,10 @@ export function useAppPagePaginationActions({
     setMyCommentsLoadingMore(true);
     setMyCommentsLoadedOnce(true);
     try {
-      const page = await getMyCommentsPage({ cursor: initial ? null : myCommentsNextCursor, limit: 10 });
+      const page = await getMyCommentsPage({
+        cursor: initial ? null : myCommentsNextCursor,
+        limit: PaginationRuntimeConfig.pageSize,
+      });
       setMyPage((current) => {
         if (!current) {
           return current;

--- a/src/hooks/useAutoLoadMore.ts
+++ b/src/hooks/useAutoLoadMore.ts
@@ -1,5 +1,6 @@
 import type { RefObject } from 'react';
 import { useEffect, useRef } from 'react';
+import { AutoLoadMoreConfig } from '../config/runtimeLimitConfig';
 import { useEventCallback } from './useEventCallback';
 
 interface UseAutoLoadMoreOptions {
@@ -15,7 +16,7 @@ export function useAutoLoadMore({
   loading,
   onLoadMore,
   rootRef,
-  rootMargin = '160px 0px',
+  rootMargin = AutoLoadMoreConfig.defaultRootMargin,
 }: UseAutoLoadMoreOptions) {
   const sentinelRef = useRef<HTMLDivElement | null>(null);
   const stableOnLoadMore = useEventCallback(onLoadMore);
@@ -45,7 +46,7 @@ export function useAutoLoadMore({
       {
         root: rootRef.current,
         rootMargin,
-        threshold: 0.01,
+        threshold: AutoLoadMoreConfig.threshold,
       },
     );
 

--- a/src/lib/imageUpload.ts
+++ b/src/lib/imageUpload.ts
@@ -1,13 +1,4 @@
-const MAX_UPLOAD_DIMENSION = 1600;
-const MAX_UPLOAD_BYTES = 1_000_000;
-const INITIAL_JPEG_QUALITY = 0.84;
-const MIN_JPEG_QUALITY = 0.58;
-const JPEG_QUALITY_STEP = 0.08;
-const MIN_DIMENSION_AFTER_RESIZE = 960;
-
-const THUMBNAIL_DIMENSION = 480;
-const THUMBNAIL_MAX_BYTES = 120_000;
-const THUMBNAIL_MIN_DIMENSION_AFTER_RESIZE = 320;
+import { ImageUploadConfig } from '../config/runtimeLimitConfig';
 
 export interface PreparedReviewImageUpload {
   file: File;
@@ -53,15 +44,15 @@ function drawResizedCanvas(image: HTMLImageElement, maxDimension: number) {
 
 async function canvasToBlob(canvas: HTMLCanvasElement, quality?: number) {
   return await new Promise<Blob | null>((resolve) => {
-    canvas.toBlob((blob) => resolve(blob), 'image/jpeg', quality);
+    canvas.toBlob((blob) => resolve(blob), ImageUploadConfig.jpegMimeType, quality);
   });
 }
 
 async function compressCanvas(canvas: HTMLCanvasElement, maxBytes: number) {
-  let quality = INITIAL_JPEG_QUALITY;
+  let quality = ImageUploadConfig.jpegQuality.initial;
   let blob: Blob | null = null;
 
-  while (quality >= MIN_JPEG_QUALITY) {
+  while (quality >= ImageUploadConfig.jpegQuality.min) {
     blob = await canvasToBlob(canvas, quality);
     if (!blob) {
       return null;
@@ -69,7 +60,7 @@ async function compressCanvas(canvas: HTMLCanvasElement, maxBytes: number) {
     if (blob.size <= maxBytes) {
       return blob;
     }
-    quality -= JPEG_QUALITY_STEP;
+    quality -= ImageUploadConfig.jpegQuality.step;
   }
 
   return blob;
@@ -77,8 +68,8 @@ async function compressCanvas(canvas: HTMLCanvasElement, maxBytes: number) {
 
 function shrinkCanvas(canvas: HTMLCanvasElement, minDimension: number) {
   const resizedCanvas = document.createElement('canvas');
-  resizedCanvas.width = Math.max(minDimension, Math.round(canvas.width * 0.75));
-  resizedCanvas.height = Math.max(minDimension, Math.round(canvas.height * 0.75));
+  resizedCanvas.width = Math.max(minDimension, Math.round(canvas.width * ImageUploadConfig.shrinkScale));
+  resizedCanvas.height = Math.max(minDimension, Math.round(canvas.height * ImageUploadConfig.shrinkScale));
   const context = resizedCanvas.getContext('2d');
   if (!context) {
     return null;
@@ -106,8 +97,8 @@ async function buildOptimizedFile(file: File, options: { maxDimension: number; m
     }
   }
 
-  return new File([compressedBlob], replaceExtension(file.name, 'jpg'), {
-    type: 'image/jpeg',
+  return new File([compressedBlob], replaceExtension(file.name, ImageUploadConfig.jpegExtension), {
+    type: ImageUploadConfig.jpegMimeType,
     lastModified: Date.now(),
   });
 }
@@ -123,14 +114,14 @@ export async function prepareReviewImageUpload(file: File): Promise<PreparedRevi
   try {
     const [optimizedFile, optimizedThumbnail] = await Promise.all([
       buildOptimizedFile(file, {
-        maxDimension: MAX_UPLOAD_DIMENSION,
-        maxBytes: MAX_UPLOAD_BYTES,
-        minDimension: MIN_DIMENSION_AFTER_RESIZE,
+        maxDimension: ImageUploadConfig.main.maxDimension,
+        maxBytes: ImageUploadConfig.main.maxBytes,
+        minDimension: ImageUploadConfig.main.minDimensionAfterResize,
       }),
       buildOptimizedFile(file, {
-        maxDimension: THUMBNAIL_DIMENSION,
-        maxBytes: THUMBNAIL_MAX_BYTES,
-        minDimension: THUMBNAIL_MIN_DIMENSION_AFTER_RESIZE,
+        maxDimension: ImageUploadConfig.thumbnail.maxDimension,
+        maxBytes: ImageUploadConfig.thumbnail.maxBytes,
+        minDimension: ImageUploadConfig.thumbnail.minDimensionAfterResize,
       }),
     ]);
 

--- a/test/unit/runtime-limit-config.test.ts
+++ b/test/unit/runtime-limit-config.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  ApiCacheConfig,
+  AutoLoadMoreConfig,
+  FeedbackRuntimeConfig,
+  FloatingBackButtonRuntimeConfig,
+  ImageUploadConfig,
+  PaginationRuntimeConfig,
+} from '../../src/config/runtimeLimitConfig';
+
+describe('runtime limit config', () => {
+  it('preserves API cache TTL rules by endpoint prefix', () => {
+    expect(ApiCacheConfig.getTtlForPath('/api/festivals')).toBe(30 * 60 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/banner/events/current')).toBe(30 * 60 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/courses/curated')).toBe(60 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/map-bootstrap')).toBe(20 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/community-routes')).toBe(20 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/reviews')).toBe(10 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/my/summary')).toBe(10 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/places')).toBe(15 * 1000);
+  });
+
+  it('preserves review image upload compression limits', () => {
+    expect(ImageUploadConfig.main).toEqual({
+      maxDimension: 1600,
+      maxBytes: 1_000_000,
+      minDimensionAfterResize: 960,
+    });
+    expect(ImageUploadConfig.thumbnail).toEqual({
+      maxDimension: 480,
+      maxBytes: 120_000,
+      minDimensionAfterResize: 320,
+    });
+    expect(ImageUploadConfig.jpegQuality).toEqual({
+      initial: 0.84,
+      min: 0.58,
+      step: 0.08,
+    });
+    expect(ImageUploadConfig.shrinkScale).toBe(0.75);
+    expect(ImageUploadConfig.jpegMimeType).toBe('image/jpeg');
+    expect(ImageUploadConfig.jpegExtension).toBe('jpg');
+  });
+
+  it('preserves frontend interaction and pagination limits', () => {
+    expect(AutoLoadMoreConfig.defaultRootMargin).toBe('160px 0px');
+    expect(AutoLoadMoreConfig.threshold).toBe(0.01);
+    expect(FeedbackRuntimeConfig.stampUnlockRadiusMeters).toBe(120);
+    expect(FeedbackRuntimeConfig.noticeDismissDelayMs).toBe(4000);
+    expect(PaginationRuntimeConfig.pageSize).toBe(10);
+  });
+
+  it('preserves floating back button runtime geometry', () => {
+    expect(FloatingBackButtonRuntimeConfig.buttonSizePx).toBe(46);
+    expect(FloatingBackButtonRuntimeConfig.edgePaddingPx).toBe(12);
+    expect(FloatingBackButtonRuntimeConfig.desktopBottomPaddingPx).toBe(120);
+    expect(FloatingBackButtonRuntimeConfig.mobileSheetOffsetPx).toBe(180);
+    expect(FloatingBackButtonRuntimeConfig.touchDragDelayMs).toBe(260);
+  });
+});


### PR DESCRIPTION
## 요약

- Scope-ID: `TSK-002-04-FRONTEND-RUNTIME-LIMIT-CONFIG`
- Parent Issue: #238
- Child Issue: Closes #242
- Branch: `frontend-runtime-limit-config`

Frontend runtime limit 값을 소유권 있는 config class로 분리했습니다. API 캐시 TTL, 이미지 업로드 압축 한계, 자동 로딩 observer 값, 피드백 반경/알림 지연, 페이지네이션 크기, floating back button 위치/지연 값을 `src/config/runtimeLimitConfig.ts`로 옮겼습니다.

## 변경 내용

- `ApiCacheConfig`: endpoint별 GET cache TTL과 기본 TTL을 관리합니다.
- `ImageUploadConfig`: 리뷰 이미지/썸네일 크기, byte limit, JPEG 품질 ladder, MIME/확장자를 관리합니다.
- `AutoLoadMoreConfig`: root margin과 observer threshold를 관리합니다.
- `FeedbackRuntimeConfig`: stamp unlock radius와 notice dismiss delay를 관리합니다.
- `PaginationRuntimeConfig`: feed/my comments page size를 관리합니다.
- `FloatingBackButtonRuntimeConfig`: 버튼 크기, edge padding, sheet offset, drag delay를 관리합니다.
- numeric literal audit 분류에 `runtimeLimitConfig.ts` 소유권을 추가하고 baseline을 갱신했습니다.

## 검증

- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- `git diff --check` 통과
- `.\\.tools\\python313\\python.exe .tmp\\check_utf8_integrity.py --staged` 통과

## 비목표

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
