### PR TITLE
Extract Worker runtime config

### DIFF
--- a/deploy/api-worker-shell/config/runtime.ts
+++ b/deploy/api-worker-shell/config/runtime.ts
@@ -1,0 +1,55 @@
+export class WorkerTimeConfig {
+  static readonly secondMs = 1000;
+  static readonly minuteMs = 60 * WorkerTimeConfig.secondMs;
+  static readonly hourMs = 60 * WorkerTimeConfig.minuteMs;
+  static readonly dayMs = 24 * WorkerTimeConfig.hourMs;
+}
+
+export class WorkerSessionRuntimeConfig {
+  static readonly sessionCookieName = 'jamissue_worker_session';
+  static readonly oauthStateCookieName = 'jamissue_worker_oauth_state';
+  static readonly sessionMaxAgeSeconds = 60 * 60 * 24 * 7;
+  static readonly oauthStateMaxAgeSeconds = 60 * 10;
+}
+
+export class WorkerSupabaseRuntimeConfig {
+  static readonly defaultListLimit = 12;
+  static readonly maxListLimit = 24;
+}
+
+export class WorkerPaginationRuntimeConfig {
+  static readonly reviewFeedPageSize = 10;
+  static readonly reviewFeedMaxPageSize = 20;
+  static readonly myCommentsPageSize = 10;
+  static readonly myCommentsMaxPageSize = 20;
+}
+
+export class WorkerBaseDataRuntimeConfig {
+  static readonly staticBaseCacheTtlMs = 5 * WorkerTimeConfig.minuteMs;
+}
+
+export class WorkerFestivalRuntimeConfig {
+  static readonly cacheTtlMs = 10 * WorkerTimeConfig.minuteMs;
+  static readonly windowMs = 30 * WorkerTimeConfig.dayMs;
+  static readonly dbQueryLimit = 100;
+  static readonly cardDisplayLimit = 10;
+  static readonly bannerQueryLimit = 20;
+  static readonly bannerDisplayLimit = 4;
+  static readonly externalIdTokenLength = 22;
+  static readonly internalSourceKey = 'jamissue-public-event-feed';
+  static readonly internalSourceName = 'Daejeon Official Event Search';
+  static readonly internalSourceUrl = 'https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504';
+}
+
+export class WorkerNotificationRuntimeConfig {
+  static readonly defaultListLimit = 30;
+  static readonly myNotificationsListLimit = 50;
+}
+
+export class WorkerStampRuntimeConfig {
+  static readonly defaultUnlockRadiusMeters = 120;
+  static readonly earthRadiusMeters = 6_371_000;
+  static readonly metersPerKilometer = 1000;
+  static readonly radiansPerDegree = Math.PI / 180;
+  static readonly travelSessionGapMs = WorkerTimeConfig.dayMs;
+}

--- a/deploy/api-worker-shell/lib/supabase.ts
+++ b/deploy/api-worker-shell/lib/supabase.ts
@@ -1,4 +1,5 @@
 import type { SupabaseCacheState, SupabaseRequestOptions, WorkerEnv } from '../types';
+import { WorkerSupabaseRuntimeConfig } from '../config/runtime';
 
 export function getSupabaseKey(env: WorkerEnv) {
   return env.APP_SUPABASE_SERVICE_ROLE_KEY || env.APP_SUPABASE_ANON_KEY || '';
@@ -55,7 +56,11 @@ export function encodeFilterValue(value: unknown) {
   return encodeURIComponent(String(value));
 }
 
-export function parseListLimit(url: URL, defaultLimit = 12, maxLimit = 24) {
+export function parseListLimit(
+  url: URL,
+  defaultLimit = WorkerSupabaseRuntimeConfig.defaultListLimit,
+  maxLimit = WorkerSupabaseRuntimeConfig.maxListLimit,
+) {
   const raw = Number(url.searchParams.get('limit') ?? defaultLimit);
   if (!Number.isFinite(raw) || raw <= 0) {
     return defaultLimit;

--- a/deploy/api-worker-shell/runtime/base-data-mappers.ts
+++ b/deploy/api-worker-shell/runtime/base-data-mappers.ts
@@ -1,4 +1,5 @@
 import { formatDate, formatDateTime, toSeoulDateKey } from '../lib/dates';
+import { WorkerTimeConfig } from '../config/runtime';
 import type {
   SupabaseCoursePlaceRow,
   SupabaseCourseRow,
@@ -26,7 +27,7 @@ function buildSessionDurationLabel(session: any) {
   const startedAt = new Date(session.started_at);
   const endedAt = new Date(session.ended_at);
   const diffMs = Math.max(0, endedAt.getTime() - startedAt.getTime());
-  const diffDays = Math.floor(diffMs / (1000 * 60 * 60 * 24));
+  const diffDays = Math.floor(diffMs / WorkerTimeConfig.dayMs);
   if (diffDays <= 0) {
     return `당일 코스 · 스탬프 ${session.stamp_count ?? 0}개`;
   }

--- a/deploy/api-worker-shell/runtime/base-data-repository.ts
+++ b/deploy/api-worker-shell/runtime/base-data-repository.ts
@@ -1,4 +1,5 @@
 import { buildInFilter, encodeFilterValue, rememberPending, supabaseRequest } from '../lib/supabase';
+import { WorkerBaseDataRuntimeConfig } from '../config/runtime';
 import type {
   SupabaseCacheState,
   SupabaseCoursePlaceRow,
@@ -9,7 +10,7 @@ import type {
   WorkerStaticBaseRows,
 } from '../types';
 
-const STATIC_BASE_CACHE_TTL_MS = 5 * 60 * 1000;
+const STATIC_BASE_CACHE_TTL_MS = WorkerBaseDataRuntimeConfig.staticBaseCacheTtlMs;
 
 let staticBaseCache: SupabaseCacheState<WorkerStaticBaseRows> & {
   expiresAt: number;

--- a/deploy/api-worker-shell/services/auth/session.ts
+++ b/deploy/api-worker-shell/services/auth/session.ts
@@ -1,10 +1,11 @@
 import { jsonResponse } from '../../lib/http';
 import type { WorkerEnv, WorkerSessionUser } from '../../types';
+import { WorkerSessionRuntimeConfig } from '../../config/runtime';
 
-const SESSION_COOKIE_NAME = 'jamissue_worker_session';
-const OAUTH_STATE_COOKIE_NAME = 'jamissue_worker_oauth_state';
-const SESSION_MAX_AGE_SECONDS = 60 * 60 * 24 * 7;
-const OAUTH_STATE_MAX_AGE_SECONDS = 60 * 10;
+const SESSION_COOKIE_NAME = WorkerSessionRuntimeConfig.sessionCookieName;
+const OAUTH_STATE_COOKIE_NAME = WorkerSessionRuntimeConfig.oauthStateCookieName;
+const SESSION_MAX_AGE_SECONDS = WorkerSessionRuntimeConfig.sessionMaxAgeSeconds;
+const OAUTH_STATE_MAX_AGE_SECONDS = WorkerSessionRuntimeConfig.oauthStateMaxAgeSeconds;
 
 const textEncoder = new TextEncoder();
 

--- a/deploy/api-worker-shell/services/festivals.ts
+++ b/deploy/api-worker-shell/services/festivals.ts
@@ -1,16 +1,17 @@
 import { formatDate, toSeoulDateKey } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
 import { encodeFilterValue, rememberPending, supabaseRequest } from '../lib/supabase';
+import { WorkerFestivalRuntimeConfig } from '../config/runtime';
 const textEncoder = new TextEncoder();
-const FESTIVALS_CACHE_TTL_MS = 10 * 60 * 1000;
-const INTERNAL_FESTIVAL_SOURCE_KEY = 'jamissue-public-event-feed';
-const INTERNAL_FESTIVAL_SOURCE_NAME = 'Daejeon Official Event Search';
-const INTERNAL_FESTIVAL_SOURCE_URL = 'https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504';
+const FESTIVALS_CACHE_TTL_MS = WorkerFestivalRuntimeConfig.cacheTtlMs;
+const INTERNAL_FESTIVAL_SOURCE_KEY = WorkerFestivalRuntimeConfig.internalSourceKey;
+const INTERNAL_FESTIVAL_SOURCE_NAME = WorkerFestivalRuntimeConfig.internalSourceName;
+const INTERNAL_FESTIVAL_SOURCE_URL = WorkerFestivalRuntimeConfig.internalSourceUrl;
 let festivalsCache = { expiresAt: 0, syncAt: 0, value: null, pending: null };
 function base64UrlEncode(bytes) { let binary = ''; for (const byte of bytes) {
     binary += String.fromCharCode(byte);
 } return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, ''); }
-function createFestivalExternalId(title, startDate, venueName, roadAddress) { const seed = `${title}|${startDate.toISOString()}|${venueName || ''}|${roadAddress || ''}`; const bytes = textEncoder.encode(seed); return `festival-${base64UrlEncode(bytes).slice(0, 22)}`; }
+function createFestivalExternalId(title, startDate, venueName, roadAddress) { const seed = `${title}|${startDate.toISOString()}|${venueName || ''}|${roadAddress || ''}`; const bytes = textEncoder.encode(seed); return `festival-${base64UrlEncode(bytes).slice(0, WorkerFestivalRuntimeConfig.externalIdTokenLength)}`; }
 function isFestivalOngoingInSeoul(startsAt, endsAt, nowValue = Date.now()) { if (!startsAt || !endsAt) {
     return false;
 } const startDateKey = toSeoulDateKey(startsAt); const endDateKey = toSeoulDateKey(endsAt); const nowDateKey = toSeoulDateKey(nowValue); return startDateKey <= nowDateKey && endDateKey >= nowDateKey; }
@@ -138,7 +139,7 @@ function parseFestivalDate(value, endOfDay = false) { if (!value) {
 } if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(text)) {
     parsed.setUTCHours(23, 59, 59, 0);
 } return parsed; }
-function getFestivalWindowEnd(now) { return new Date(now + 30 * 24 * 60 * 60 * 1000); }
+function getFestivalWindowEnd(now) { return new Date(now + WorkerFestivalRuntimeConfig.windowMs); }
 function getTargetFestivalCityKeyword(env) { const cityKeyword = String(env.APP_PUBLIC_EVENT_CITY_KEYWORD || '대전').trim(); return cityKeyword || '대전'; }
 function getTargetFestivalAreaKeywords(cityKeyword) { const normalized = String(cityKeyword || '').trim(); const keywords = new Set(normalized ? [normalized] : []); if (normalized.includes('대전')) {
     ['대전광역시', '동구', '중구', '서구', '유성구', '대덕구'].forEach((keyword) => keywords.add(keyword));
@@ -170,13 +171,13 @@ async function upsertImportedFestivalItems(env: any, items: any[], options: any 
 } const staleIds = (existingRows || []).filter((row) => !seenExternalIds.has(String(row.external_id))).map((row) => row.public_event_id); if (staleIds.length > 0) {
     await supabaseRequest(env, `public_event?public_event_id=in.(${staleIds.join(',')})`, { method: 'DELETE', });
 } await supabaseRequest(env, `public_data_source?source_id=eq.${encodeFilterValue(sourceId)}`, { method: 'PATCH', body: JSON.stringify({ name: sourceName, source_url: requestUrl, last_imported_at: importedAt, updated_at: nowIso, }), }); return normalizedItems; }
-async function loadFestivalRowsFromDb(env, nowIso, windowEndIso, limit = 100) { const rows = await supabaseRequest(env, `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`); const cityKeyword = getTargetFestivalCityKeyword(env); return groupFestivalRowsBySeries((rows || []).filter((row) => isFestivalRowInTargetArea(row, cityKeyword))); }
+async function loadFestivalRowsFromDb(env, nowIso, windowEndIso, limit = WorkerFestivalRuntimeConfig.dbQueryLimit) { const rows = await supabaseRequest(env, `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`); const cityKeyword = getTargetFestivalCityKeyword(env); return groupFestivalRowsBySeries((rows || []).filter((row) => isFestivalRowInTargetArea(row, cityKeyword))); }
 function buildFestivalCard(row, now) { return { id: String(row.public_event_id), title: row.title, venueName: row.venue_name ?? null, startDate: row.starts_at ? toSeoulDateKey(row.starts_at) : '', endDate: row.ends_at ? toSeoulDateKey(row.ends_at) : '', homepageUrl: row.source_page_url ?? null, roadAddress: row.road_address ?? row.address ?? null, latitude: parseFestivalCoordinate(row.latitude), longitude: parseFestivalCoordinate(row.longitude), isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now), }; }
 function buildBannerItem(row, now, emptyDateLabel = '') { return { id: String(row.public_event_id), title: row.title, venueName: row.venue_name ?? null, district: row.district ?? '', startDate: row.starts_at, endDate: row.ends_at, dateLabel: row.starts_at && row.ends_at ? `${formatDate(row.starts_at)} - ${formatDate(row.ends_at)}` : emptyDateLabel, summary: row.summary ?? '', sourcePageUrl: row.source_page_url ?? null, linkedPlaceName: null, isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now), }; }
 export async function handleFestivals(request, env) { const now = Date.now(); if (festivalsCache.value && festivalsCache.expiresAt > now) {
     return jsonResponse(200, festivalsCache.value, env, request);
-} const festivals = await rememberPending(festivalsCache, async () => { const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const rows = await loadFestivalRowsFromDb(env, nowIso, windowEndIso, 100); const windowEndTime = getFestivalWindowEnd(now).getTime(); const value = rows.filter((row) => { const startTime = new Date(row.starts_at).getTime(); const endTime = new Date(row.ends_at).getTime(); return Number.isFinite(startTime) && Number.isFinite(endTime) && endTime >= now && startTime <= windowEndTime; }).slice(0, 10).map((row) => buildFestivalCard(row, now)); festivalsCache = { ...festivalsCache, value, expiresAt: Date.now() + FESTIVALS_CACHE_TTL_MS, pending: null, }; return value; }); return jsonResponse(200, festivals, env, request); }
-export async function handleBannerEvents(request, env) { const now = Date.now(); const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const [eventRows, sourceRows] = await Promise.all([loadFestivalRowsFromDb(env, nowIso, windowEndIso, 20), supabaseRequest(env, `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`),]); const source = sourceRows[0] ?? null; const items = eventRows.length > 0 ? eventRows.slice(0, 4).map((row) => buildBannerItem(row, now)) : []; return jsonResponse(200, { sourceReady: items.length > 0 || Boolean(source?.last_imported_at), sourceName: source?.name ?? null, importedAt: source?.last_imported_at ?? null, items, }, env, request); }
+} const festivals = await rememberPending(festivalsCache, async () => { const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const rows = await loadFestivalRowsFromDb(env, nowIso, windowEndIso, WorkerFestivalRuntimeConfig.dbQueryLimit); const windowEndTime = getFestivalWindowEnd(now).getTime(); const value = rows.filter((row) => { const startTime = new Date(row.starts_at).getTime(); const endTime = new Date(row.ends_at).getTime(); return Number.isFinite(startTime) && Number.isFinite(endTime) && endTime >= now && startTime <= windowEndTime; }).slice(0, WorkerFestivalRuntimeConfig.cardDisplayLimit).map((row) => buildFestivalCard(row, now)); festivalsCache = { ...festivalsCache, value, expiresAt: Date.now() + FESTIVALS_CACHE_TTL_MS, pending: null, }; return value; }); return jsonResponse(200, festivals, env, request); }
+export async function handleBannerEvents(request, env) { const now = Date.now(); const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const [eventRows, sourceRows] = await Promise.all([loadFestivalRowsFromDb(env, nowIso, windowEndIso, WorkerFestivalRuntimeConfig.bannerQueryLimit), supabaseRequest(env, `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`),]); const source = sourceRows[0] ?? null; const items = eventRows.length > 0 ? eventRows.slice(0, WorkerFestivalRuntimeConfig.bannerDisplayLimit).map((row) => buildBannerItem(row, now)) : []; return jsonResponse(200, { sourceReady: items.length > 0 || Boolean(source?.last_imported_at), sourceName: source?.name ?? null, importedAt: source?.last_imported_at ?? null, items, }, env, request); }
 export async function handleFestivalImport(request, env) { const configuredToken = readFestivalImportToken(env); if (!configuredToken) {
     return jsonResponse(503, { detail: 'APP_EVENT_IMPORT_TOKEN is empty.' }, env, request);
 } const bearerToken = readBearerToken(request); if (!bearerToken || bearerToken !== configuredToken) {

--- a/deploy/api-worker-shell/services/my.ts
+++ b/deploy/api-worker-shell/services/my.ts
@@ -1,12 +1,13 @@
 import { jsonResponse } from '../lib/http';
 import { parseListLimit } from '../lib/supabase';
+import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
 import { mapMyComments } from './my-domain/mapper';
 import { loadFeedsForCommentRows, loadMyCommentRows, loadMySummaryCommentRows } from './my-domain/repository';
 
 export function createMyService({ communityRouteService, loadBaseData, loadStaticBaseRows, loadUserNotifications }: any) {
   async function loadMyCommentPageData(env: any, userId: string, options: any = {}) {
-    const { cursor = null, limit = 10 } = options;
+    const { cursor = null, limit = WorkerPaginationRuntimeConfig.myCommentsPageSize } = options;
     const commentRows = await loadMyCommentRows(env, userId, cursor, limit);
     const nextCursor = commentRows.length > limit ? String(commentRows[limit].created_at) : null;
     const pageRows = commentRows.slice(0, limit);
@@ -27,7 +28,7 @@ export function createMyService({ communityRouteService, loadBaseData, loadStati
     }
     const payload = await loadMyCommentPageData(env, sessionUser.id, {
       cursor: url.searchParams.get('cursor') ?? null,
-      limit: parseListLimit(url, 10, 20),
+      limit: parseListLimit(url, WorkerPaginationRuntimeConfig.myCommentsPageSize, WorkerPaginationRuntimeConfig.myCommentsMaxPageSize),
     });
     return jsonResponse(200, payload, env, request);
   }

--- a/deploy/api-worker-shell/services/notifications.ts
+++ b/deploy/api-worker-shell/services/notifications.ts
@@ -1,6 +1,7 @@
 import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
 import { buildInFilter, encodeFilterValue, getSupabaseKey, supabaseRequest } from '../lib/supabase';
+import { WorkerNotificationRuntimeConfig } from '../config/runtime';
 import { getSigningSecret, readSessionUser, sha256Base64Url } from './auth';
 async function requireSessionUser(request, env) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
     return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
@@ -9,7 +10,7 @@ async function readNotificationRow(env, notificationId) { const rows = await sup
 export async function createUserNotification(env, { userId, actorUserId = null, type, title, body = '', reviewId = null, commentId = null, routeId = null, metadata = {} }) { if (!userId) {
     return null;
 } const nowIso = new Date().toISOString(); const rows = await supabaseRequest(env, 'user_notification?select=notification_id', { method: 'POST', body: JSON.stringify({ user_id: userId, actor_user_id: actorUserId, type, title, body, review_id: reviewId ? Number(reviewId) : null, comment_id: commentId ? Number(commentId) : null, route_id: routeId ? Number(routeId) : null, metadata, is_read: false, created_at: nowIso, updated_at: nowIso, }), }); return rows?.[0] ?? null; }
-export async function loadUserNotifications(env, userId, limit = 30) { const rows = await supabaseRequest(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc&limit=${limit}`); const actorIdsFilter = buildInFilter((rows || []).map((row) => row.actor_user_id).filter(Boolean)); const actorRows = actorIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${actorIdsFilter}`) : []; const actorNameById = new Map((actorRows || []).map((row) => [row.user_id, row.nickname])); return (rows || []).map((row) => ({ id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName: row.actor_user_id ? actorNameById.get(row.actor_user_id) ?? null : null, })); }
+export async function loadUserNotifications(env, userId, limit = WorkerNotificationRuntimeConfig.defaultListLimit) { const rows = await supabaseRequest(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc&limit=${limit}`); const actorIdsFilter = buildInFilter((rows || []).map((row) => row.actor_user_id).filter(Boolean)); const actorRows = actorIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${actorIdsFilter}`) : []; const actorNameById = new Map((actorRows || []).map((row) => [row.user_id, row.nickname])); return (rows || []).map((row) => ({ id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName: row.actor_user_id ? actorNameById.get(row.actor_user_id) ?? null : null, })); }
 export async function countUnreadNotifications(env, userId) { const rows = await supabaseRequest(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`); return rows?.length ?? 0; }
 export async function loadNotificationById(env, notificationId) { const row = await readNotificationRow(env, notificationId); if (!row) {
     return null;
@@ -28,7 +29,7 @@ async function sendRealtimeBroadcast(env, topic, event, payload) { if (!env.APP_
 export async function publishNotificationEvent(env, userId, event, payload) { const topic = await buildNotificationRealtimeTopic(env, userId); await sendRealtimeBroadcast(env, topic, event, payload); }
 export async function handleMyNotifications(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
-} const notifications = await loadUserNotifications(env, sessionResult.sessionUser.id, 50); return jsonResponse(200, notifications, env, request); }
+} const notifications = await loadUserNotifications(env, sessionResult.sessionUser.id, WorkerNotificationRuntimeConfig.myNotificationsListLimit); return jsonResponse(200, notifications, env, request); }
 export async function handleNotificationRealtimeChannel(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const topic = await buildNotificationRealtimeTopic(env, sessionResult.sessionUser.id); return jsonResponse(200, { topic }, env, request); }

--- a/deploy/api-worker-shell/services/reviews.ts
+++ b/deploy/api-worker-shell/services/reviews.ts
@@ -1,5 +1,6 @@
 import { jsonResponse } from '../lib/http';
 import { buildInFilter, encodeFilterValue, parseListLimit, supabaseRequest } from '../lib/supabase';
+import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
 import { createReviewMapper } from './review-domain/mapper';
 
@@ -59,7 +60,7 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
   }
 
   async function loadReviewPageData(env: any, sessionUserId: string | null = null, options: any = {}) {
-    const { cursor = null, limit = 10 } = options;
+    const { cursor = null, limit = WorkerPaginationRuntimeConfig.reviewFeedPageSize } = options;
     const { placeRows } = await loadStaticBaseRows(env);
     const places = placeRows.map(mapPlace);
     const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
@@ -161,7 +162,7 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     const sessionUser = await readSessionUser(request, env);
     const payload = await loadReviewPageData(env, sessionUser?.id ?? null, {
       cursor: url.searchParams.get('cursor') ?? null,
-      limit: parseListLimit(url, 10, 20),
+      limit: parseListLimit(url, WorkerPaginationRuntimeConfig.reviewFeedPageSize, WorkerPaginationRuntimeConfig.reviewFeedMaxPageSize),
     });
     return jsonResponse(200, payload, env, request);
   }

--- a/deploy/api-worker-shell/services/stamps.ts
+++ b/deploy/api-worker-shell/services/stamps.ts
@@ -1,13 +1,14 @@
 import { toSeoulDateKey } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
 import { encodeFilterValue, supabaseRequest } from '../lib/supabase';
+import { WorkerStampRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
-function getStampUnlockRadius(env) { const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? '120'); return Number.isFinite(parsed) && parsed > 0 ? parsed : 120; }
-function calculateDistanceMeters(startLatitude, startLongitude, endLatitude, endLongitude) { const earthRadiusMeters = 6371000; const latitudeDelta = ((endLatitude - startLatitude) * Math.PI) / 180; const longitudeDelta = ((endLongitude - startLongitude) * Math.PI) / 180; const startLatitudeRadians = (startLatitude * Math.PI) / 180; const endLatitudeRadians = (endLatitude * Math.PI) / 180; const haversine = Math.sin(latitudeDelta / 2) ** 2 + Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2; return earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine))); }
+function getStampUnlockRadius(env) { const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters); return Number.isFinite(parsed) && parsed > 0 ? parsed : WorkerStampRuntimeConfig.defaultUnlockRadiusMeters; }
+function calculateDistanceMeters(startLatitude, startLongitude, endLatitude, endLongitude) { const latitudeDelta = (endLatitude - startLatitude) * WorkerStampRuntimeConfig.radiansPerDegree; const longitudeDelta = (endLongitude - startLongitude) * WorkerStampRuntimeConfig.radiansPerDegree; const startLatitudeRadians = startLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const endLatitudeRadians = endLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const haversine = Math.sin(latitudeDelta / 2) ** 2 + Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2; return WorkerStampRuntimeConfig.earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine))); }
 function formatDistanceMeters(distanceMeters) { if (!Number.isFinite(distanceMeters)) {
     return '알 수 없음';
-} if (distanceMeters >= 1000) {
-    return `${(distanceMeters / 1000).toFixed(1)}km`;
+} if (distanceMeters >= WorkerStampRuntimeConfig.metersPerKilometer) {
+    return `${(distanceMeters / WorkerStampRuntimeConfig.metersPerKilometer).toFixed(1)}km`;
 } return `${Math.round(distanceMeters)}m`; }
 function buildNearPlaceMessage(placeName, distanceMeters, unlockRadius) { return `${placeName}까지 ${formatDistanceMeters(distanceMeters)} 남아있어요. 반경 ${unlockRadius}m 안에 들어오면 열려요.`; }
 async function requireSessionUser(request, env) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
@@ -32,7 +33,7 @@ export function createStampService({ loadBaseData }) { async function handleTogg
     return jsonResponse(200, { collectedPlaceIds: nextBaseData.collectedPlaceIds, logs: nextBaseData.stampLogs, travelSessions: nextBaseData.travelSessions, }, env, request);
 } const nowIso = new Date().toISOString(); const placeStampRows = await supabaseRequest(env, `user_stamp?select=stamp_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&position_id=eq.${encodeFilterValue(place.positionId)}`); const visitOrdinal = (placeStampRows?.length ?? 0) + 1; const lastStampRows = await supabaseRequest(env, `user_stamp?select=stamp_id,travel_session_id,created_at&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&order=created_at.desc&limit=1`); const lastStampRow = lastStampRows?.[0] ?? null; let travelSessionId = null; if (lastStampRow) {
     const gapMs = new Date(nowIso).getTime() - new Date(lastStampRow.created_at).getTime();
-    if (gapMs <= 1000 * 60 * 60 * 24) {
+    if (gapMs <= WorkerStampRuntimeConfig.travelSessionGapMs) {
         if (lastStampRow.travel_session_id) {
             travelSessionId = Number(lastStampRow.travel_session_id);
             const sessionRows = await supabaseRequest(env, `travel_session?select=stamp_count&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&limit=1`);

--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -103,6 +103,14 @@ function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner
       reason: 'API cache TTL, upload compression, autoload, pagination, feedback, and floating-button runtime values are owned by runtime limit config.',
     };
   }
+  if (path === 'deploy/api-worker-shell/config/runtime.ts') {
+    return {
+      owner: 'worker-backend',
+      category: 'worker-runtime-config-baseline',
+      scopeId: 'TSK-002-05-WORKER-RUNTIME-CONFIG',
+      reason: 'Worker session, cache, pagination, festival, notification, and stamp runtime values are owned by Worker runtime config.',
+    };
+  }
   if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
     return {
       owner: 'frontend-map',

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "1e87b79d113e0376345b5985440f8496982b240b",
+  "generatedFrom": "a20928a7ed64dd88fd91c3b6b9eb85781c1c15be",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -1124,6 +1124,46 @@
       ]
     },
     {
+      "path": "deploy/api-worker-shell/config/runtime.ts",
+      "count": 31,
+      "owner": "worker-backend",
+      "category": "worker-runtime-config-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker session, cache, pagination, festival, notification, and stamp runtime values are owned by Worker runtime config.",
+      "examples": [
+        {
+          "value": "1000",
+          "line": 2,
+          "column": 30
+        },
+        {
+          "value": "60",
+          "line": 3,
+          "column": 30
+        },
+        {
+          "value": "60",
+          "line": 4,
+          "column": 28
+        },
+        {
+          "value": "24",
+          "line": 5,
+          "column": 27
+        },
+        {
+          "value": "60",
+          "line": 11,
+          "column": 42
+        },
+        {
+          "value": "60",
+          "line": 11,
+          "column": 47
+        }
+      ]
+    },
+    {
       "path": "deploy/api-worker-shell/index.ts",
       "count": 1,
       "owner": "worker-backend",
@@ -1205,30 +1245,20 @@
     },
     {
       "path": "deploy/api-worker-shell/lib/supabase.ts",
-      "count": 4,
+      "count": 2,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "12",
-          "line": 58,
-          "column": 57
-        },
-        {
-          "value": "24",
-          "line": 58,
-          "column": 72
-        },
-        {
           "value": "0",
-          "line": 60,
+          "line": 65,
           "column": 39
         },
         {
           "value": "0",
-          "line": 72,
+          "line": 77,
           "column": 25
         }
       ]
@@ -1255,7 +1285,7 @@
     },
     {
       "path": "deploy/api-worker-shell/runtime/base-data-mappers.ts",
-      "count": 22,
+      "count": 18,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -1263,67 +1293,52 @@
       "examples": [
         {
           "value": "0",
-          "line": 21,
+          "line": 22,
           "column": 89
         },
         {
           "value": "1",
-          "line": 21,
+          "line": 22,
           "column": 115
         },
         {
           "value": "0",
-          "line": 28,
+          "line": 29,
           "column": 27
         },
         {
-          "value": "1000",
-          "line": 29,
-          "column": 41
+          "value": "0",
+          "line": 31,
+          "column": 19
         },
         {
-          "value": "60",
-          "line": 29,
-          "column": 48
+          "value": "0",
+          "line": 32,
+          "column": 50
         },
         {
-          "value": "60",
-          "line": 29,
-          "column": 53
+          "value": "1",
+          "line": 34,
+          "column": 37
         }
       ]
     },
     {
       "path": "deploy/api-worker-shell/runtime/base-data-repository.ts",
-      "count": 5,
+      "count": 2,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "5",
-          "line": 12,
-          "column": 34
-        },
-        {
-          "value": "60",
-          "line": 12,
-          "column": 38
-        },
-        {
-          "value": "1000",
-          "line": 12,
-          "column": 43
-        },
-        {
           "value": "0",
-          "line": 17,
+          "line": 18,
           "column": 14
         },
         {
           "value": "0",
-          "line": 126,
+          "line": 127,
           "column": 37
         }
       ]
@@ -1580,41 +1595,41 @@
     },
     {
       "path": "deploy/api-worker-shell/services/auth/session.ts",
-      "count": 16,
+      "count": 10,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "60",
-          "line": 6,
-          "column": 33
+          "value": "1000",
+          "line": 43,
+          "column": 34
         },
         {
-          "value": "60",
-          "line": 6,
-          "column": 38
+          "value": "4",
+          "line": 56,
+          "column": 39
         },
         {
-          "value": "24",
-          "line": 6,
-          "column": 43
+          "value": "4",
+          "line": 56,
+          "column": 60
         },
         {
-          "value": "7",
-          "line": 6,
-          "column": 48
+          "value": "4",
+          "line": 56,
+          "column": 65
         },
         {
-          "value": "60",
-          "line": 7,
-          "column": 37
+          "value": "4",
+          "line": 56,
+          "column": 71
         },
         {
-          "value": "10",
-          "line": 7,
-          "column": 42
+          "value": "0",
+          "line": 58,
+          "column": 70
         }
       ]
     },
@@ -1755,41 +1770,41 @@
     },
     {
       "path": "deploy/api-worker-shell/services/festivals.ts",
-      "count": 72,
+      "count": 57,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "10",
-          "line": 5,
-          "column": 32
-        },
-        {
-          "value": "60",
-          "line": 5,
-          "column": 37
-        },
-        {
-          "value": "1000",
-          "line": 5,
-          "column": 42
-        },
-        {
-          "value": "504",
-          "line": 8,
-          "column": 93
-        },
-        {
           "value": "0",
-          "line": 9,
+          "line": 10,
           "column": 35
         },
         {
           "value": "0",
-          "line": 9,
+          "line": 10,
           "column": 46
+        },
+        {
+          "value": "0",
+          "line": 14,
+          "column": 259
+        },
+        {
+          "value": "2",
+          "line": 18,
+          "column": 170
+        },
+        {
+          "value": "00",
+          "line": 20,
+          "column": 70
+        },
+        {
+          "value": "00",
+          "line": 20,
+          "column": 73
         }
       ]
     },
@@ -1810,47 +1825,47 @@
     },
     {
       "path": "deploy/api-worker-shell/services/my.ts",
-      "count": 9,
+      "count": 6,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "10",
-          "line": 9,
-          "column": 36
-        },
-        {
           "value": "0",
-          "line": 12,
+          "line": 13,
           "column": 40
         },
         {
           "value": "0",
-          "line": 14,
+          "line": 15,
           "column": 29
         },
         {
           "value": "401",
-          "line": 26,
+          "line": 27,
           "column": 27
         },
         {
-          "value": "10",
-          "line": 30,
-          "column": 34
+          "value": "200",
+          "line": 33,
+          "column": 25
         },
         {
-          "value": "20",
-          "line": 30,
-          "column": 38
+          "value": "401",
+          "line": 39,
+          "column": 27
+        },
+        {
+          "value": "200",
+          "line": 54,
+          "column": 7
         }
       ]
     },
     {
       "path": "deploy/api-worker-shell/services/notifications.ts",
-      "count": 21,
+      "count": 19,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -1858,33 +1873,33 @@
       "examples": [
         {
           "value": "401",
-          "line": 6,
+          "line": 7,
           "column": 37
         },
         {
           "value": "1",
-          "line": 8,
+          "line": 9,
           "column": 290
         },
         {
           "value": "0",
-          "line": 8,
+          "line": 9,
           "column": 309
         },
         {
           "value": "0",
-          "line": 11,
+          "line": 12,
           "column": 462
         },
         {
-          "value": "30",
-          "line": 12,
-          "column": 66
+          "value": "0",
+          "line": 14,
+          "column": 228
         },
         {
-          "value": "0",
-          "line": 13,
-          "column": 228
+          "value": "1",
+          "line": 18,
+          "column": 137
         }
       ]
     },
@@ -2010,7 +2025,7 @@
     },
     {
       "path": "deploy/api-worker-shell/services/reviews.ts",
-      "count": 18,
+      "count": 15,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -2018,73 +2033,73 @@
       "examples": [
         {
           "value": "0",
-          "line": 50,
+          "line": 51,
           "column": 39
         },
         {
-          "value": "10",
-          "line": 62,
-          "column": 36
-        },
-        {
           "value": "1",
-          "line": 66,
+          "line": 67,
           "column": 152
         },
         {
           "value": "0",
-          "line": 73,
+          "line": 74,
           "column": 37
         },
         {
           "value": "0",
-          "line": 97,
+          "line": 98,
           "column": 39
         },
         {
           "value": "1",
-          "line": 111,
+          "line": 112,
           "column": 142
+        },
+        {
+          "value": "0",
+          "line": 114,
+          "column": 36
         }
       ]
     },
     {
       "path": "deploy/api-worker-shell/services/stamps.ts",
-      "count": 40,
+      "count": 27,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "120",
-          "line": 5,
-          "column": 99
-        },
-        {
           "value": "0",
-          "line": 5,
-          "column": 149
-        },
-        {
-          "value": "120",
-          "line": 5,
-          "column": 162
-        },
-        {
-          "value": "6371000",
           "line": 6,
-          "column": 120
+          "column": 194
         },
         {
-          "value": "180",
-          "line": 6,
-          "column": 195
+          "value": "2",
+          "line": 7,
+          "column": 506
         },
         {
-          "value": "180",
-          "line": 6,
-          "column": 269
+          "value": "2",
+          "line": 7,
+          "column": 512
+        },
+        {
+          "value": "2",
+          "line": 7,
+          "column": 606
+        },
+        {
+          "value": "2",
+          "line": 7,
+          "column": 612
+        },
+        {
+          "value": "2",
+          "line": 7,
+          "column": 668
         }
       ]
     },

--- a/test/unit/worker-runtime-config.test.ts
+++ b/test/unit/worker-runtime-config.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  WorkerBaseDataRuntimeConfig,
+  WorkerFestivalRuntimeConfig,
+  WorkerNotificationRuntimeConfig,
+  WorkerPaginationRuntimeConfig,
+  WorkerSessionRuntimeConfig,
+  WorkerStampRuntimeConfig,
+  WorkerSupabaseRuntimeConfig,
+  WorkerTimeConfig,
+} from '../../deploy/api-worker-shell/config/runtime';
+
+describe('Worker runtime config', () => {
+  it('preserves shared time units', () => {
+    expect(WorkerTimeConfig.secondMs).toBe(1000);
+    expect(WorkerTimeConfig.minuteMs).toBe(60 * 1000);
+    expect(WorkerTimeConfig.hourMs).toBe(60 * 60 * 1000);
+    expect(WorkerTimeConfig.dayMs).toBe(24 * 60 * 60 * 1000);
+  });
+
+  it('preserves auth session cookie settings', () => {
+    expect(WorkerSessionRuntimeConfig.sessionCookieName).toBe('jamissue_worker_session');
+    expect(WorkerSessionRuntimeConfig.oauthStateCookieName).toBe('jamissue_worker_oauth_state');
+    expect(WorkerSessionRuntimeConfig.sessionMaxAgeSeconds).toBe(60 * 60 * 24 * 7);
+    expect(WorkerSessionRuntimeConfig.oauthStateMaxAgeSeconds).toBe(60 * 10);
+  });
+
+  it('preserves list pagination limits', () => {
+    expect(WorkerSupabaseRuntimeConfig.defaultListLimit).toBe(12);
+    expect(WorkerSupabaseRuntimeConfig.maxListLimit).toBe(24);
+    expect(WorkerPaginationRuntimeConfig.reviewFeedPageSize).toBe(10);
+    expect(WorkerPaginationRuntimeConfig.reviewFeedMaxPageSize).toBe(20);
+    expect(WorkerPaginationRuntimeConfig.myCommentsPageSize).toBe(10);
+    expect(WorkerPaginationRuntimeConfig.myCommentsMaxPageSize).toBe(20);
+  });
+
+  it('preserves base data cache settings', () => {
+    expect(WorkerBaseDataRuntimeConfig.staticBaseCacheTtlMs).toBe(5 * 60 * 1000);
+  });
+
+  it('preserves festival runtime settings', () => {
+    expect(WorkerFestivalRuntimeConfig.cacheTtlMs).toBe(10 * 60 * 1000);
+    expect(WorkerFestivalRuntimeConfig.windowMs).toBe(30 * 24 * 60 * 60 * 1000);
+    expect(WorkerFestivalRuntimeConfig.dbQueryLimit).toBe(100);
+    expect(WorkerFestivalRuntimeConfig.cardDisplayLimit).toBe(10);
+    expect(WorkerFestivalRuntimeConfig.bannerQueryLimit).toBe(20);
+    expect(WorkerFestivalRuntimeConfig.bannerDisplayLimit).toBe(4);
+    expect(WorkerFestivalRuntimeConfig.externalIdTokenLength).toBe(22);
+    expect(WorkerFestivalRuntimeConfig.internalSourceKey).toBe('jamissue-public-event-feed');
+    expect(WorkerFestivalRuntimeConfig.internalSourceName).toBe('Daejeon Official Event Search');
+    expect(WorkerFestivalRuntimeConfig.internalSourceUrl).toBe('https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504');
+  });
+
+  it('preserves notification runtime limits', () => {
+    expect(WorkerNotificationRuntimeConfig.defaultListLimit).toBe(30);
+    expect(WorkerNotificationRuntimeConfig.myNotificationsListLimit).toBe(50);
+  });
+
+  it('preserves stamp runtime limits and geometry constants', () => {
+    expect(WorkerStampRuntimeConfig.defaultUnlockRadiusMeters).toBe(120);
+    expect(WorkerStampRuntimeConfig.earthRadiusMeters).toBe(6_371_000);
+    expect(WorkerStampRuntimeConfig.metersPerKilometer).toBe(1000);
+    expect(WorkerStampRuntimeConfig.radiansPerDegree).toBe(Math.PI / 180);
+    expect(WorkerStampRuntimeConfig.travelSessionGapMs).toBe(24 * 60 * 60 * 1000);
+  });
+});


### PR DESCRIPTION
## 요약

- Scope-ID: `TSK-002-05-WORKER-RUNTIME-CONFIG`
- Parent Issue: #238
- Child Issue: Closes #243
- Branch: `worker-runtime-config`

Worker 운영 런타임 수치를 소유권 있는 config class로 분리했습니다. session cookie age, Supabase list limit, static base cache TTL, festival window/cache/display limit, notification limit, stamp radius/distance/session gap 값을 `deploy/api-worker-shell/config/runtime.ts`로 옮겼습니다.

## 변경 내용

- `WorkerSessionRuntimeConfig`: session/OAuth cookie name과 max-age를 관리합니다.
- `WorkerSupabaseRuntimeConfig`: 기본 list limit과 max list limit을 관리합니다.
- `WorkerPaginationRuntimeConfig`: review feed와 my comments page size/max size를 관리합니다.
- `WorkerBaseDataRuntimeConfig`: static base data cache TTL을 관리합니다.
- `WorkerFestivalRuntimeConfig`: festival cache TTL, 조회 window, query/display limit, source metadata를 관리합니다.
- `WorkerNotificationRuntimeConfig`: notification 기본 조회 limit과 my notifications limit을 관리합니다.
- `WorkerStampRuntimeConfig`: stamp unlock radius, distance 계산 상수, travel-session gap을 관리합니다.
- numeric literal audit 분류에 Worker runtime config 소유권을 추가하고 baseline을 갱신했습니다.

## 검증

- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- `git diff --check` 통과
- `.\\.tools\\python313\\python.exe .tmp\\check_utf8_integrity.py --staged` 통과

## 비목표

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
