### PR TITLE
Centralize FastAPI runtime config

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -27,6 +27,12 @@ from .config_database import (
     uses_supabase_pooler,
 )
 from .config_paths import resolve_repo_relative_path, split_csv_set, split_csv_values
+from .runtime_config import (
+    FastApiAuthRuntimeConfig,
+    FastApiPublicDataRuntimeConfig,
+    FastApiStampRuntimeConfig,
+    FastApiUploadRuntimeConfig,
+)
 
 
 class Settings(BaseSettings):
@@ -37,11 +43,11 @@ class Settings(BaseSettings):
     port: int = 8001
     cors_origins: str = "http://localhost:8000,http://127.0.0.1:8000"
     frontend_url: str = "http://localhost:8000"
-    session_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
+    session_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(FastApiAuthRuntimeConfig.default_secret_token_urlsafe_bytes))
     session_https: bool = False
-    jwt_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(32))
+    jwt_secret: str = Field(default_factory=lambda: secrets.token_urlsafe(FastApiAuthRuntimeConfig.default_secret_token_urlsafe_bytes))
     jwt_algorithm: str = "HS256"
-    jwt_access_token_minutes: int = 60 * 24 * 14
+    jwt_access_token_minutes: int = FastApiAuthRuntimeConfig.default_jwt_access_token_minutes
     admin_user_ids: str = ""
     database_url: str = "mysql+pymysql://jamissue:jamissue@127.0.0.1:3306/jamissue?charset=utf8mb4"
     seed_demo_data: bool = False
@@ -49,19 +55,19 @@ class Settings(BaseSettings):
     auto_import_public_data: bool = True
     public_data_path: str = "data/public_bundle.json"
     public_data_source_url: str = ""
-    public_data_request_timeout_seconds: float = 3.0
+    public_data_request_timeout_seconds: float = FastApiPublicDataRuntimeConfig.request_timeout_seconds
     public_event_path: str = "data/public_events.json"
     public_event_source_url: str = ""
-    public_event_request_timeout_seconds: float = 3.0
+    public_event_request_timeout_seconds: float = FastApiPublicDataRuntimeConfig.request_timeout_seconds
     public_event_service_key: str = ""
     public_event_city_keyword: str = "대전"
-    public_event_refresh_minutes: int = 360
-    public_event_limit: int = 6
+    public_event_refresh_minutes: int = FastApiPublicDataRuntimeConfig.event_refresh_minutes
+    public_event_limit: int = FastApiPublicDataRuntimeConfig.event_limit
     storage_backend: Literal["local", "supabase"] = "local"
     upload_dir: str = "storage/uploads"
     upload_base_url: str = "/uploads"
-    max_upload_size_bytes: int = 5 * 1024 * 1024
-    stamp_unlock_radius_meters: int = 120
+    max_upload_size_bytes: int = FastApiUploadRuntimeConfig.max_upload_size_bytes
+    stamp_unlock_radius_meters: int = FastApiStampRuntimeConfig.default_unlock_radius_meters
     supabase_url: str = ""
     supabase_anon_key: str = ""
     supabase_service_role_key: str = ""

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -12,6 +12,7 @@ from .routers.auth import router as auth_router
 from .routers.content import router as content_router
 from .routers.my import router as my_router
 from .routers.reviews import router as reviews_router
+from .runtime_config import FastApiAuthRuntimeConfig
 from .storage import (
     FileTooLargeError,
     InvalidFileTypeError,
@@ -40,7 +41,7 @@ app.add_middleware(
     secret_key=settings.session_secret,
     same_site="lax",
     https_only=settings.session_https,
-    max_age=60 * 60,
+    max_age=FastApiAuthRuntimeConfig.session_middleware_max_age_seconds,
 )
 
 mount_storage_backend(app, settings)

--- a/backend/app/naver_oauth.py
+++ b/backend/app/naver_oauth.py
@@ -10,6 +10,7 @@ from urllib.request import Request, urlopen
 from fastapi import HTTPException, status
 
 from .config import Settings
+from .runtime_config import FastApiAuthRuntimeConfig
 
 NAVER_AUTHORIZE_URL = "https://nid.naver.com/oauth2.0/authorize"
 NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token"
@@ -33,7 +34,7 @@ def build_redirect_url(base_url: str, **params: str) -> str:
 
 
 def generate_oauth_state() -> str:
-    return secrets.token_urlsafe(24)
+    return secrets.token_urlsafe(FastApiAuthRuntimeConfig.oauth_state_token_urlsafe_bytes)
 
 
 def ensure_naver_login_config(settings: Settings) -> None:
@@ -118,7 +119,7 @@ def _read_error_payload_detail(error: HTTPError, fallback_detail: str) -> str:
 
 def _load_json(request: Request, default_detail: str) -> dict:
     try:
-        with urlopen(request, timeout=10) as response:
+        with urlopen(request, timeout=FastApiAuthRuntimeConfig.oauth_http_timeout_seconds) as response:
             return json.loads(response.read().decode("utf-8"))
     except HTTPError as error:
         detail = _read_error_payload_detail(error, default_detail)

--- a/backend/app/public_data/event_normalizer.py
+++ b/backend/app/public_data/event_normalizer.py
@@ -7,6 +7,7 @@ import re
 from datetime import datetime, timedelta
 from typing import Any, Mapping
 
+from ..runtime_config import FastApiPublicDataRuntimeConfig
 from .event_schemas import NormalizedPublicEvent
 
 TITLE_KEYS = ("title", "eventTitle", "eventNm", "fstvlNm", "축제명", "행사명", "콘텐츠명")
@@ -25,6 +26,12 @@ LATITUDE_KEYS = ("latitude", "lat", "mapY", "위도", "y")
 LONGITUDE_KEYS = ("longitude", "lng", "mapX", "경도", "x")
 ID_KEYS = ("externalId", "id", "eventId", "contentid", "콘텐츠ID", "축제일련번호")
 UPDATED_KEYS = ("sourceUpdatedAt", "modifiedtime", "수정일시", "lastUpdatedAt")
+
+END_OF_DAY_DELTA = timedelta(
+    hours=FastApiPublicDataRuntimeConfig.end_of_day_hour,
+    minutes=FastApiPublicDataRuntimeConfig.end_of_day_minute,
+    seconds=FastApiPublicDataRuntimeConfig.end_of_day_second,
+)
 
 
 def first_value(payload: Mapping[str, Any], keys: tuple[str, ...]) -> Any:
@@ -73,7 +80,7 @@ def parse_datetime(value: Any, *, end_of_day: bool = False) -> datetime | None:
 
     if text.isdigit() and len(text) == 8:
         base = datetime.strptime(text, "%Y%m%d")
-        return base + timedelta(hours=23, minutes=59, seconds=59) if end_of_day else base
+        return base + END_OF_DAY_DELTA if end_of_day else base
 
     patterns = (
         "%Y-%m-%dT%H:%M:%S",
@@ -87,7 +94,7 @@ def parse_datetime(value: Any, *, end_of_day: bool = False) -> datetime | None:
         try:
             base = datetime.strptime(text, pattern)
             if pattern in {"%Y-%m-%d", "%Y.%m.%d", "%Y/%m/%d"} and end_of_day:
-                return base + timedelta(hours=23, minutes=59, seconds=59)
+                return base + END_OF_DAY_DELTA
             return base
         except ValueError:
             continue
@@ -170,9 +177,9 @@ def normalize_public_event(payload: Mapping[str, Any], city_keyword: str = "대�
     if not starts_at:
         starts_at = ends_at.replace(hour=0, minute=0, second=0, microsecond=0)
     if not ends_at:
-        ends_at = starts_at + timedelta(hours=23, minutes=59, seconds=59)
+        ends_at = starts_at + END_OF_DAY_DELTA
     if ends_at < starts_at:
-        ends_at = starts_at + timedelta(hours=23, minutes=59, seconds=59)
+        ends_at = starts_at + END_OF_DAY_DELTA
 
     venue_name = text_value(payload, VENUE_KEYS)
     district = derive_district(payload, city_keyword)

--- a/backend/app/repositories/notification_data_repository.py
+++ b/backend/app/repositories/notification_data_repository.py
@@ -4,6 +4,7 @@ from sqlalchemy.orm import Session, joinedload
 from ..db_models import UserNotification
 from ..models import NotificationDeleteResponse, NotificationReadResponse, UserNotificationOut
 from ..repository_support import format_datetime, utcnow_naive
+from ..runtime_config import FastApiNotificationRuntimeConfig
 from .errors import RepositoryNotFoundError, RepositoryValidationError
 
 
@@ -22,7 +23,12 @@ def to_notification_out(notification: UserNotification) -> UserNotificationOut:
     )
 
 
-def list_user_notifications(db: Session, user_id: str, *, limit: int = 50) -> list[UserNotificationOut]:
+def list_user_notifications(
+    db: Session,
+    user_id: str,
+    *,
+    limit: int = FastApiNotificationRuntimeConfig.user_notification_list_limit,
+) -> list[UserNotificationOut]:
     notifications = db.scalars(
         select(UserNotification)
         .options(joinedload(UserNotification.actor))

--- a/backend/app/repositories/route_data_repository.py
+++ b/backend/app/repositories/route_data_repository.py
@@ -8,10 +8,11 @@ from sqlalchemy.orm import Session, joinedload
 from ..db_models import MapPlace, TravelSession, UserRoute, UserRouteLike, UserRoutePlace, UserStamp
 from ..models import RouteSort, UserRouteCreate, UserRouteLikeResponse, UserRouteOut
 from ..repository_support import format_datetime, utcnow_naive
+from ..runtime_config import FastApiRouteRuntimeConfig
 from .errors import RepositoryNotFoundError, RepositoryPermissionError, RepositoryValidationError
 from .user_data_repository import get_or_create_user
 
-MIN_ROUTE_PLACE_COUNT = 2
+MIN_ROUTE_PLACE_COUNT = FastApiRouteRuntimeConfig.min_route_place_count
 
 
 def _to_user_route_out(route: UserRoute, current_user_id: str | None) -> UserRouteOut:

--- a/backend/app/repositories/stamp_data_repository.py
+++ b/backend/app/repositories/stamp_data_repository.py
@@ -17,6 +17,7 @@ from ..repository_support import (
     to_seoul_date,
     utcnow_naive,
 )
+from ..runtime_config import FastApiRouteRuntimeConfig, FastApiStampRuntimeConfig
 from .user_data_repository import get_or_create_user
 
 
@@ -83,7 +84,7 @@ def build_travel_sessions(
                 stampCount=session.stamp_count,
                 placeIds=unique_place_ids,
                 placeNames=unique_place_names,
-                canPublish=len(unique_place_ids) >= 2,
+                canPublish=len(unique_place_ids) >= FastApiRouteRuntimeConfig.min_route_place_count,
                 publishedRouteId=published_route_id_by_session.get(session.travel_session_id),
                 coverPlaceId=unique_place_ids[0] if unique_place_ids else None,
             )
@@ -130,7 +131,7 @@ def _build_stamp_state(db: Session, user_id: str | None) -> StampState:
 
 
 def _find_or_create_travel_session(db: Session, user_id: str, now: datetime, last_stamp: UserStamp | None) -> TravelSession:
-    if last_stamp and now - last_stamp.created_at <= timedelta(hours=24):
+    if last_stamp and now - last_stamp.created_at <= timedelta(hours=FastApiStampRuntimeConfig.travel_session_gap_hours):
         if last_stamp.travel_session_id:
             session = db.get(TravelSession, last_stamp.travel_session_id)
             if session:

--- a/backend/app/repository_support_geo.py
+++ b/backend/app/repository_support_geo.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from math import asin, cos, radians, sin, sqrt
 
 from .db_models import MapPlace
+from .runtime_config import FastApiStampRuntimeConfig
 
 
 def calculate_distance_meters(
@@ -13,7 +14,6 @@ def calculate_distance_meters(
     end_latitude: float,
     end_longitude: float,
 ) -> float:
-    earth_radius_meters = 6_371_000
     latitude_delta = radians(end_latitude - start_latitude)
     longitude_delta = radians(end_longitude - start_longitude)
     start_latitude_radians = radians(start_latitude)
@@ -22,7 +22,7 @@ def calculate_distance_meters(
         sin(latitude_delta / 2) ** 2
         + cos(start_latitude_radians) * cos(end_latitude_radians) * sin(longitude_delta / 2) ** 2
     )
-    return earth_radius_meters * (2 * asin(sqrt(haversine)))
+    return FastApiStampRuntimeConfig.earth_radius_meters * (2 * asin(sqrt(haversine)))
 
 
 def ensure_stamp_can_be_collected(

--- a/backend/app/routers/my.py
+++ b/backend/app/routers/my.py
@@ -12,6 +12,7 @@ from ..db import get_db
 from ..jwt_auth import clear_auth_cookie
 from ..models import MyPageResponse, NotificationDeleteResponse, NotificationReadResponse, SessionUser, UserNotificationOut, UserRouteOut
 from ..notification_broker import notification_broker
+from ..runtime_config import FastApiNotificationRuntimeConfig
 from ..services.account_service import delete_my_account_service
 from ..services.my_page_service import read_my_page_service
 from ..services.notification_service import (
@@ -73,7 +74,10 @@ async def stream_my_notifications(
                 if await request.is_disconnected():
                     break
                 try:
-                    event = await asyncio.wait_for(subscription.queue.get(), timeout=15)
+                    event = await asyncio.wait_for(
+                        subscription.queue.get(),
+                        timeout=FastApiNotificationRuntimeConfig.sse_heartbeat_timeout_seconds,
+                    )
                     event_name = str(event.get("event", "message"))
                     payload = {key: value for key, value in event.items() if key != "event"}
                     yield format_sse_event(event_name, payload, event_id=str(uuid4()))

--- a/backend/app/runtime_config.py
+++ b/backend/app/runtime_config.py
@@ -1,0 +1,40 @@
+"""Named FastAPI runtime defaults and non-env operational constants."""
+
+from __future__ import annotations
+
+
+class FastApiAuthRuntimeConfig:
+    default_secret_token_urlsafe_bytes = 32
+    default_jwt_access_token_minutes = 60 * 24 * 14
+    session_middleware_max_age_seconds = 60 * 60
+    oauth_state_token_urlsafe_bytes = 24
+    oauth_http_timeout_seconds = 10
+
+
+class FastApiPublicDataRuntimeConfig:
+    request_timeout_seconds = 3.0
+    event_refresh_minutes = 360
+    event_limit = 6
+    end_of_day_hour = 23
+    end_of_day_minute = 59
+    end_of_day_second = 59
+
+
+class FastApiUploadRuntimeConfig:
+    max_upload_size_bytes = 5 * 1024 * 1024
+
+
+class FastApiStampRuntimeConfig:
+    default_unlock_radius_meters = 120
+    earth_radius_meters = 6_371_000
+    travel_session_gap_hours = 24
+
+
+class FastApiRouteRuntimeConfig:
+    min_route_place_count = 2
+    max_route_place_count = 6
+
+
+class FastApiNotificationRuntimeConfig:
+    user_notification_list_limit = 50
+    sse_heartbeat_timeout_seconds = 15

--- a/backend/app/user_routes.py
+++ b/backend/app/user_routes.py
@@ -11,9 +11,10 @@ from .db_models import MapPlace, UserRoute, UserRouteLike, UserRoutePlace, UserS
 from .models import RouteSort, UserRouteCreate, UserRouteLikeResponse, UserRouteOut
 from .repository_support import format_datetime, utcnow_naive
 from .repositories.user_data_repository import get_or_create_user
+from .runtime_config import FastApiRouteRuntimeConfig
 
-MAX_ROUTE_PLACE_COUNT = 6
-MIN_ROUTE_PLACE_COUNT = 2
+MAX_ROUTE_PLACE_COUNT = FastApiRouteRuntimeConfig.max_route_place_count
+MIN_ROUTE_PLACE_COUNT = FastApiRouteRuntimeConfig.min_route_place_count
 
 
 def _normalize_place_ids(place_ids: list[str]) -> list[str]:

--- a/backend/tests/test_runtime_config.py
+++ b/backend/tests/test_runtime_config.py
@@ -1,0 +1,56 @@
+from datetime import timedelta
+
+from app.config import Settings
+from app.runtime_config import (
+    FastApiAuthRuntimeConfig,
+    FastApiNotificationRuntimeConfig,
+    FastApiPublicDataRuntimeConfig,
+    FastApiRouteRuntimeConfig,
+    FastApiStampRuntimeConfig,
+    FastApiUploadRuntimeConfig,
+)
+
+
+def test_fastapi_runtime_config_preserves_settings_defaults():
+    settings = Settings(env="development")
+
+    assert settings.jwt_access_token_minutes == 60 * 24 * 14
+    assert settings.public_data_request_timeout_seconds == 3.0
+    assert settings.public_event_request_timeout_seconds == 3.0
+    assert settings.public_event_refresh_minutes == 360
+    assert settings.public_event_limit == 6
+    assert settings.max_upload_size_bytes == 5 * 1024 * 1024
+    assert settings.stamp_unlock_radius_meters == 120
+
+
+def test_fastapi_runtime_config_preserves_auth_defaults():
+    assert FastApiAuthRuntimeConfig.default_secret_token_urlsafe_bytes == 32
+    assert FastApiAuthRuntimeConfig.default_jwt_access_token_minutes == 60 * 24 * 14
+    assert FastApiAuthRuntimeConfig.session_middleware_max_age_seconds == 60 * 60
+    assert FastApiAuthRuntimeConfig.oauth_state_token_urlsafe_bytes == 24
+    assert FastApiAuthRuntimeConfig.oauth_http_timeout_seconds == 10
+
+
+def test_fastapi_runtime_config_preserves_public_data_defaults():
+    assert FastApiPublicDataRuntimeConfig.request_timeout_seconds == 3.0
+    assert FastApiPublicDataRuntimeConfig.event_refresh_minutes == 360
+    assert FastApiPublicDataRuntimeConfig.event_limit == 6
+    assert (
+        timedelta(
+            hours=FastApiPublicDataRuntimeConfig.end_of_day_hour,
+            minutes=FastApiPublicDataRuntimeConfig.end_of_day_minute,
+            seconds=FastApiPublicDataRuntimeConfig.end_of_day_second,
+        )
+        == timedelta(hours=23, minutes=59, seconds=59)
+    )
+
+
+def test_fastapi_runtime_config_preserves_domain_limits():
+    assert FastApiUploadRuntimeConfig.max_upload_size_bytes == 5 * 1024 * 1024
+    assert FastApiStampRuntimeConfig.default_unlock_radius_meters == 120
+    assert FastApiStampRuntimeConfig.earth_radius_meters == 6_371_000
+    assert FastApiStampRuntimeConfig.travel_session_gap_hours == 24
+    assert FastApiRouteRuntimeConfig.min_route_place_count == 2
+    assert FastApiRouteRuntimeConfig.max_route_place_count == 6
+    assert FastApiNotificationRuntimeConfig.user_notification_list_limit == 50
+    assert FastApiNotificationRuntimeConfig.sse_heartbeat_timeout_seconds == 15

--- a/scripts/numeric-literal-audit.ts
+++ b/scripts/numeric-literal-audit.ts
@@ -111,6 +111,14 @@ function inferClassification(path: string): Pick<NumericLiteralFileAudit, 'owner
       reason: 'Worker session, cache, pagination, festival, notification, and stamp runtime values are owned by Worker runtime config.',
     };
   }
+  if (path === 'backend/app/runtime_config.py') {
+    return {
+      owner: 'fastapi-backend',
+      category: 'fastapi-runtime-config-baseline',
+      scopeId: 'TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW',
+      reason: 'FastAPI auth, public-data, upload, stamp, route, and notification runtime values are owned by FastAPI runtime config.',
+    };
+  }
   if (path.includes('/naver-map/') || path.includes('mapViewportState')) {
     return {
       owner: 'frontend-map',

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "a20928a7ed64dd88fd91c3b6b9eb85781c1c15be",
+  "generatedFrom": "3bcbbc4fd9e28d3b70f4899461e95dafbb7eb9e4",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -20,7 +20,7 @@
     },
     {
       "path": "backend/app/config.py",
-      "count": 24,
+      "count": 11,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
@@ -28,32 +28,32 @@
       "examples": [
         {
           "value": "127.0",
-          "line": 36,
+          "line": 42,
           "column": 18
         },
         {
           "value": "8001",
-          "line": 37,
+          "line": 43,
           "column": 17
         },
         {
           "value": "8000",
-          "line": 38,
+          "line": 44,
           "column": 43
         },
         {
           "value": "127.0",
-          "line": 38,
+          "line": 44,
           "column": 55
         },
         {
           "value": "8000",
-          "line": 38,
+          "line": 44,
           "column": 65
         },
         {
           "value": "8000",
-          "line": 39,
+          "line": 45,
           "column": 43
         }
       ]
@@ -235,7 +235,7 @@
     },
     {
       "path": "backend/app/main.py",
-      "count": 3,
+      "count": 1,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
@@ -243,18 +243,8 @@
       "examples": [
         {
           "value": "1.0",
-          "line": 27,
+          "line": 28,
           "column": 14
-        },
-        {
-          "value": "60",
-          "line": 43,
-          "column": 13
-        },
-        {
-          "value": "60",
-          "line": 43,
-          "column": 18
         }
       ]
     },
@@ -315,35 +305,25 @@
     },
     {
       "path": "backend/app/naver_oauth.py",
-      "count": 5,
+      "count": 3,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
       "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
       "examples": [
         {
-          "value": "24",
-          "line": 36,
-          "column": 34
-        },
-        {
           "value": "00",
-          "line": 95,
+          "line": 96,
           "column": 38
         },
         {
           "value": "8",
-          "line": 113,
+          "line": 114,
           "column": 55
         },
         {
-          "value": "10",
-          "line": 121,
-          "column": 39
-        },
-        {
           "value": "8",
-          "line": 122,
+          "line": 123,
           "column": 59
         }
       ]
@@ -440,7 +420,7 @@
     },
     {
       "path": "backend/app/public_data/event_normalizer.py",
-      "count": 20,
+      "count": 8,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
@@ -448,33 +428,33 @@
       "examples": [
         {
           "value": "8",
-          "line": 74,
+          "line": 81,
           "column": 40
         },
         {
-          "value": "23",
-          "line": 76,
-          "column": 39
+          "value": "1",
+          "line": 123,
+          "column": 28
         },
         {
-          "value": "59",
-          "line": 76,
-          "column": 51
+          "value": "8",
+          "line": 142,
+          "column": 44
         },
         {
-          "value": "59",
-          "line": 76,
-          "column": 63
+          "value": "12",
+          "line": 143,
+          "column": 36
         },
         {
-          "value": "23",
-          "line": 90,
-          "column": 47
+          "value": "0",
+          "line": 178,
+          "column": 42
         },
         {
-          "value": "59",
-          "line": 90,
-          "column": 59
+          "value": "0",
+          "line": 178,
+          "column": 52
         }
       ]
     },
@@ -615,30 +595,25 @@
     },
     {
       "path": "backend/app/repositories/notification_data_repository.py",
-      "count": 4,
+      "count": 3,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
       "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
       "examples": [
         {
-          "value": "50",
-          "line": 25,
-          "column": 72
-        },
-        {
           "value": "0",
-          "line": 43,
+          "line": 49,
           "column": 12
         },
         {
           "value": "0",
-          "line": 59,
+          "line": 65,
           "column": 42
         },
         {
           "value": "0",
-          "line": 131,
+          "line": 137,
           "column": 16
         }
       ]
@@ -730,7 +705,7 @@
     },
     {
       "path": "backend/app/repositories/route_data_repository.py",
-      "count": 8,
+      "count": 7,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
@@ -738,73 +713,73 @@
       "examples": [
         {
           "value": "2",
-          "line": 14,
-          "column": 25
-        },
-        {
-          "value": "2",
-          "line": 92,
+          "line": 93,
           "column": 21
         },
         {
           "value": "8",
-          "line": 94,
+          "line": 95,
           "column": 27
         },
         {
           "value": "0",
-          "line": 142,
+          "line": 143,
           "column": 20
         },
         {
           "value": "1",
-          "line": 149,
+          "line": 150,
           "column": 62
         },
         {
           "value": "1",
-          "line": 176,
+          "line": 177,
           "column": 51
+        },
+        {
+          "value": "0",
+          "line": 177,
+          "column": 54
         }
       ]
     },
     {
       "path": "backend/app/repositories/stamp_data_repository.py",
-      "count": 9,
+      "count": 7,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
       "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
       "examples": [
         {
-          "value": "2",
-          "line": 86,
-          "column": 53
-        },
-        {
           "value": "0",
-          "line": 88,
+          "line": 89,
           "column": 47
         },
         {
-          "value": "24",
-          "line": 133,
-          "column": 70
-        },
-        {
           "value": "1",
-          "line": 139,
+          "line": 140,
           "column": 40
         },
         {
           "value": "2",
-          "line": 148,
+          "line": 149,
           "column": 25
         },
         {
           "value": "1",
-          "line": 162,
+          "line": 163,
           "column": 21
+        },
+        {
+          "value": "0",
+          "line": 204,
+          "column": 10
+        },
+        {
+          "value": "1",
+          "line": 209,
+          "column": 16
         }
       ]
     },
@@ -840,17 +815,12 @@
     },
     {
       "path": "backend/app/repository_support_geo.py",
-      "count": 6,
+      "count": 5,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
       "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
       "examples": [
-        {
-          "value": "6_371_000",
-          "line": 16,
-          "column": 27
-        },
         {
           "value": "2",
           "line": 22,
@@ -874,7 +844,7 @@
         {
           "value": "2",
           "line": 25,
-          "column": 35
+          "column": 61
         }
       ]
     },
@@ -929,17 +899,42 @@
       ]
     },
     {
-      "path": "backend/app/routers/my.py",
-      "count": 1,
+      "path": "backend/app/runtime_config.py",
+      "count": 24,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
-      "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
+      "reason": "FastAPI auth, public-data, upload, stamp, route, and notification runtime values are owned by FastAPI runtime config.",
       "examples": [
         {
-          "value": "15",
-          "line": 76,
-          "column": 86
+          "value": "32",
+          "line": 7,
+          "column": 42
+        },
+        {
+          "value": "60",
+          "line": 8,
+          "column": 40
+        },
+        {
+          "value": "24",
+          "line": 8,
+          "column": 45
+        },
+        {
+          "value": "14",
+          "line": 8,
+          "column": 50
+        },
+        {
+          "value": "60",
+          "line": 9,
+          "column": 42
+        },
+        {
+          "value": "60",
+          "line": 9,
+          "column": 47
         }
       ]
     },
@@ -1060,41 +1055,41 @@
     },
     {
       "path": "backend/app/user_routes.py",
-      "count": 11,
+      "count": 9,
       "owner": "fastapi-backend",
       "category": "fastapi-runtime-config-baseline",
       "scopeId": "TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW",
       "reason": "FastAPI settings, model limits, service thresholds, and repository constants are reviewed through FastAPI config work.",
       "examples": [
         {
-          "value": "6",
-          "line": 15,
-          "column": 25
-        },
-        {
           "value": "2",
-          "line": 16,
-          "column": 25
-        },
-        {
-          "value": "2",
-          "line": 22,
+          "line": 23,
           "column": 37
         },
         {
           "value": "6",
-          "line": 24,
+          "line": 25,
           "column": 37
         },
         {
           "value": "2",
-          "line": 103,
+          "line": 104,
           "column": 21
         },
         {
           "value": "8",
-          "line": 105,
+          "line": 106,
           "column": 27
+        },
+        {
+          "value": "0",
+          "line": 134,
+          "column": 20
+        },
+        {
+          "value": "1",
+          "line": 141,
+          "column": 60
         }
       ]
     },


### PR DESCRIPTION
## 요약

- Scope-ID: `TSK-002-06-FASTAPI-RUNTIME-CONFIG-REVIEW`
- Parent Issue: #238
- Child Issue: Closes #244
- Branch: `fastapi-runtime-config-review`

FastAPI 백엔드의 env-backed 기본값과 비-env 운영 상수를 `backend/app/runtime_config.py`로 분리했습니다. `Settings`에 남아야 하는 값은 그대로 `Settings`에 두되, JWT 기본 만료, 세션 middleware max-age, OAuth state entropy/HTTP timeout, public data timeout/limit, upload limit, stamp/route/notification 한계값의 의미를 이름 있는 config class로 고정했습니다.

## 변경 내용

- `FastApiAuthRuntimeConfig`: JWT 기본 만료, session middleware max-age, OAuth state entropy, OAuth HTTP timeout을 관리합니다.
- `FastApiPublicDataRuntimeConfig`: 공공데이터 timeout, event refresh/limit, end-of-day normalization 값을 관리합니다.
- `FastApiUploadRuntimeConfig`: 기본 업로드 byte limit을 관리합니다.
- `FastApiStampRuntimeConfig`: stamp unlock radius, 지구 반경, travel-session gap을 관리합니다.
- `FastApiRouteRuntimeConfig`: route 최소/최대 place count를 관리합니다.
- `FastApiNotificationRuntimeConfig`: notification list limit과 SSE heartbeat timeout을 관리합니다.
- numeric literal audit 분류에 FastAPI runtime config 소유권을 추가하고 baseline을 갱신했습니다.

## 검증

- `npm run check:numeric-literals` 통과
- `npm run lint` 통과
- `npm run typecheck` 통과
- `npm run test:unit` 통과
- `npm run build` 통과
- `cd backend && ..\\.tools\\python313\\python.exe -m pytest tests` 통과: 95 passed, 2 pytest cache warnings
- `git diff --check` 통과
- `.\\.tools\\python313\\python.exe .tmp\\check_utf8_integrity.py --staged` 통과

## 비목표

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음
