### PR TITLE
TSK-003-03 Type base-data runtime rows

### DIFF
--- a/deploy/api-worker-shell/runtime/base-data-assembler.ts
+++ b/deploy/api-worker-shell/runtime/base-data-assembler.ts
@@ -29,18 +29,18 @@ export function createLoadBaseData(reviewReadService: WorkerReviewReadService) {
 
     const allStampRows = [
       ...reviewStampRows,
-      ...userStampRows.filter((row: any) => !reviewStampRows.some((stamp: any) => String(stamp.stamp_id) === String(row.stamp_id))),
+      ...userStampRows.filter((row) => !reviewStampRows.some((stamp) => String(stamp.stamp_id) === String(row.stamp_id))),
     ];
     const placeVisitCounts = buildPlaceVisitCountMap(allPlaceStampRows);
     const places = placeRows.map((row) => mapPlace({ ...row, total_visit_count: placeVisitCounts.get(String(row.position_id)) ?? 0 }));
     const placesByPositionId = new Map<string, WorkerPlace>(places.map((place) => [place.positionId, place]));
-    const usersById = new Map<string, WorkerJsonRecord>(userRows.map((row: any) => [row.user_id, row]));
-    const stampRowsById = new Map<string, WorkerJsonRecord>((allStampRows ?? []).map((row: any) => [String(row.stamp_id), row]));
-    const likedFeedIds = new Set<string>((userFeedLikeRows ?? []).map((row: any) => String(row.feed_id)));
+    const usersById = new Map<string, WorkerJsonRecord>(userRows.map((row) => [row.user_id, row]));
+    const stampRowsById = new Map<string, WorkerJsonRecord>((allStampRows ?? []).map((row) => [String(row.stamp_id), row]));
+    const likedFeedIds = new Set<string>((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
     const collectedPlaceIds = [
       ...new Set<string>(
         userStampRows
-          .map((row: any) => placesByPositionId.get(String(row.position_id))?.id)
+          .map((row) => placesByPositionId.get(String(row.position_id))?.id)
           .filter((placeId: unknown): placeId is string => typeof placeId === 'string' && placeId.length > 0),
       ),
     ];

--- a/deploy/api-worker-shell/runtime/base-data-contracts.ts
+++ b/deploy/api-worker-shell/runtime/base-data-contracts.ts
@@ -48,6 +48,48 @@ export interface SupabaseCoursePlaceRow extends WorkerJsonRecord {
   stop_order: number;
 }
 
+export interface WorkerFeedRow extends WorkerJsonRecord {
+  feed_id: string | number;
+  position_id: string | number;
+  user_id: string;
+  stamp_id?: string | number | null;
+  created_at: string;
+}
+
+export interface WorkerFeedLikeRow extends WorkerJsonRecord {
+  feed_id: string | number;
+  user_id?: string | null;
+}
+
+export interface WorkerPositionStampRow extends WorkerJsonRecord {
+  position_id: string | number;
+}
+
+export interface WorkerStampRow extends WorkerPositionStampRow {
+  stamp_id: string | number;
+  travel_session_id?: string | number | null;
+  stamp_date?: string | null;
+  visit_ordinal?: string | number | null;
+  created_at: string;
+}
+
+export interface WorkerTravelSessionRow extends WorkerJsonRecord {
+  travel_session_id: string | number;
+  started_at: string;
+  ended_at: string;
+  stamp_count?: string | number | null;
+}
+
+export interface WorkerUserRouteRow extends WorkerJsonRecord {
+  route_id: string | number;
+  travel_session_id?: string | number | null;
+}
+
+export interface WorkerUserSummaryRow extends WorkerJsonRecord {
+  user_id: string;
+  nickname?: string | null;
+}
+
 export interface WorkerPlace extends WorkerJsonRecord {
   id: string;
   positionId: string;

--- a/deploy/api-worker-shell/runtime/base-data-mappers.ts
+++ b/deploy/api-worker-shell/runtime/base-data-mappers.ts
@@ -5,9 +5,13 @@ import type {
   SupabaseCourseRow,
   SupabaseMapRow,
   WorkerCourse,
+  WorkerPositionStampRow,
   WorkerPlace,
   WorkerStampLog,
+  WorkerStampRow,
   WorkerTravelSession,
+  WorkerTravelSessionRow,
+  WorkerUserRouteRow,
 } from './base-data-contracts';
 
 export const BADGE_BY_MOOD = {
@@ -23,7 +27,7 @@ export function formatVisitLabel(visitNumber: unknown) {
   return `${safeVisitNumber}번째 방문`;
 }
 
-function buildSessionDurationLabel(session: any) {
+function buildSessionDurationLabel(session: WorkerTravelSessionRow) {
   const startedAt = new Date(session.started_at);
   const endedAt = new Date(session.ended_at);
   const diffMs = Math.max(0, endedAt.getTime() - startedAt.getTime());
@@ -34,7 +38,7 @@ function buildSessionDurationLabel(session: any) {
   return `${diffDays}박 ${diffDays + 1}일 · 스탬프 ${session.stamp_count ?? 0}개`;
 }
 
-export function buildStampLogs(stampRows: any[], placesByPositionId: Map<string, WorkerPlace>): WorkerStampLog[] {
+export function buildStampLogs(stampRows: WorkerStampRow[], placesByPositionId: Map<string, WorkerPlace>): WorkerStampLog[] {
   const todayKey = toSeoulDateKey();
   const sessionCounts = new Map<string, number>();
 
@@ -67,12 +71,12 @@ export function buildStampLogs(stampRows: any[], placesByPositionId: Map<string,
 }
 
 export function buildTravelSessions(
-  sessionRows: any[],
-  userStampRows: any[],
+  sessionRows: WorkerTravelSessionRow[],
+  userStampRows: WorkerStampRow[],
   placesByPositionId: Map<string, WorkerPlace>,
-  ownerRouteRows: any[] = [],
+  ownerRouteRows: WorkerUserRouteRow[] = [],
 ): WorkerTravelSession[] {
-  const stampsBySessionId = new Map<string, any[]>();
+  const stampsBySessionId = new Map<string, WorkerStampRow[]>();
   for (const stampRow of userStampRows) {
     if (!stampRow.travel_session_id) {
       continue;
@@ -188,7 +192,7 @@ export function mapPlace(row: SupabaseMapRow): WorkerPlace {
   };
 }
 
-export function buildPlaceVisitCountMap(stampRows: any[]) {
+export function buildPlaceVisitCountMap(stampRows: WorkerPositionStampRow[]) {
   const counts = new Map<string, number>();
   for (const row of stampRows ?? []) {
     const key = String(row.position_id);

--- a/deploy/api-worker-shell/runtime/base-data-repository.ts
+++ b/deploy/api-worker-shell/runtime/base-data-repository.ts
@@ -4,7 +4,14 @@ import type {
   SupabaseCoursePlaceRow,
   SupabaseCourseRow,
   SupabaseMapRow,
+  WorkerFeedLikeRow,
+  WorkerFeedRow,
+  WorkerPositionStampRow,
+  WorkerStampRow,
   WorkerStaticBaseRows,
+  WorkerTravelSessionRow,
+  WorkerUserRouteRow,
+  WorkerUserSummaryRow,
 } from './base-data-contracts';
 import type { SupabaseCacheState } from '../lib/supabase';
 import type {
@@ -24,17 +31,17 @@ let staticBaseCache: SupabaseCacheState<WorkerStaticBaseRows> & {
 
 export interface WorkerBaseDataRows {
   staticRows: WorkerStaticBaseRows;
-  feedRows: WorkerJsonRecord[];
+  feedRows: WorkerFeedRow[];
   commentRows: WorkerJsonRecord[];
-  likeRows: WorkerJsonRecord[];
-  reviewStampRows: WorkerJsonRecord[];
-  userFeedLikeRows: WorkerJsonRecord[];
-  userSessionRows: WorkerJsonRecord[];
-  ownerRouteRows: WorkerJsonRecord[];
-  userStampRows: WorkerJsonRecord[];
-  allPlaceStampRows: WorkerJsonRecord[];
-  reviewRouteRows: WorkerJsonRecord[];
-  userRows: WorkerJsonRecord[];
+  likeRows: WorkerFeedLikeRow[];
+  reviewStampRows: WorkerStampRow[];
+  userFeedLikeRows: WorkerFeedLikeRow[];
+  userSessionRows: WorkerTravelSessionRow[];
+  ownerRouteRows: WorkerUserRouteRow[];
+  userStampRows: WorkerStampRow[];
+  allPlaceStampRows: WorkerPositionStampRow[];
+  reviewRouteRows: WorkerUserRouteRow[];
+  userRows: WorkerUserSummaryRow[];
 }
 
 export async function loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBaseRows> {
@@ -61,14 +68,14 @@ export async function loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBa
 export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | null = null): Promise<WorkerBaseDataRows> {
   const [staticRows, feedRows] = await Promise.all([
     loadStaticBaseRows(env),
-    supabaseRequest<WorkerJsonRecord[]>(
+    supabaseRequest<WorkerFeedRow[]>(
       env,
       'feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&order=created_at.desc',
     ),
   ]);
 
-  const feedIdsFilter = buildInFilter(feedRows.map((row: any) => row.feed_id));
-  const reviewStampIdsFilter = buildInFilter(feedRows.map((row: any) => row.stamp_id).filter(Boolean));
+  const feedIdsFilter = buildInFilter(feedRows.map((row) => row.feed_id));
+  const reviewStampIdsFilter = buildInFilter(feedRows.map((row) => row.stamp_id).filter(Boolean));
   const [
     commentRows,
     likeRows,
@@ -80,20 +87,20 @@ export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | n
     allPlaceStampRows = [],
   ] = await Promise.all([
     feedIdsFilter
-      ? supabaseRequest<WorkerJsonRecord[]>(
+        ? supabaseRequest<WorkerStampRow[]>(
           env,
           `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`,
         )
       : Promise.resolve([]),
-    feedIdsFilter ? supabaseRequest<WorkerJsonRecord[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
+    feedIdsFilter ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
     reviewStampIdsFilter
-      ? supabaseRequest<WorkerJsonRecord[]>(
+        ? supabaseRequest<WorkerTravelSessionRow[]>(
           env,
           `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`,
         )
       : Promise.resolve([]),
     sessionUserId && feedIdsFilter
-      ? supabaseRequest<WorkerJsonRecord[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
+      ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
       : Promise.resolve([]),
     sessionUserId
       ? supabaseRequest<WorkerJsonRecord[]>(
@@ -104,37 +111,37 @@ export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | n
         )
       : Promise.resolve([]),
     sessionUserId
-      ? supabaseRequest<WorkerJsonRecord[]>(env, `user_route?select=route_id,travel_session_id&user_id=eq.${encodeFilterValue(sessionUserId)}&order=created_at.desc`)
+        ? supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&user_id=eq.${encodeFilterValue(sessionUserId)}&order=created_at.desc`)
       : Promise.resolve([]),
     sessionUserId
-      ? supabaseRequest<WorkerJsonRecord[]>(
+        ? supabaseRequest<WorkerStampRow[]>(
           env,
           `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&user_id=eq.${encodeFilterValue(
             sessionUserId,
           )}&order=created_at.desc`,
         )
       : Promise.resolve([]),
-    supabaseRequest<WorkerJsonRecord[]>(env, 'user_stamp?select=position_id'),
+    supabaseRequest<WorkerPositionStampRow[]>(env, 'user_stamp?select=position_id'),
   ]);
 
   const reviewTravelSessionIds = [
     ...new Set(
       (reviewStampRows ?? [])
-        .map((row: any) => row.travel_session_id)
+        .map((row) => row.travel_session_id)
         .filter(Boolean)
-        .map((value: any) => String(value)),
+        .map((value) => String(value)),
     ),
   ];
   const reviewRouteRows =
     reviewTravelSessionIds.length > 0
-      ? await supabaseRequest<WorkerJsonRecord[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+      ? await supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
       : [];
   const userIdsFilter = buildInFilter([
-    ...feedRows.map((row: any) => row.user_id),
-    ...commentRows.map((row: any) => row.user_id),
+    ...feedRows.map((row) => row.user_id),
+    ...commentRows.map((row) => row.user_id),
     ...(sessionUserId ? [sessionUserId] : []),
   ]);
-  const userRows = userIdsFilter ? await supabaseRequest<WorkerJsonRecord[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+  const userRows = userIdsFilter ? await supabaseRequest<WorkerUserSummaryRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
 
   return {
     staticRows,


### PR DESCRIPTION
﻿## Scope

- Scope-ID: `TSK-003-03-WORKER-DATA-CONTRACT-LOCALITY`
- Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
- Child Issue: Closes #257
- Branch: `worker-data-contract-locality`

## 변경 요약

- #264 이후 남은 체크리스트 항목인 base-data runtime `any` 사용을 local row type으로 축소했습니다.
- `WorkerFeedRow`, `WorkerFeedLikeRow`, `WorkerStampRow`, `WorkerTravelSessionRow`, `WorkerUserRouteRow`, `WorkerUserSummaryRow`를 base-data contract에 추가했습니다.
- base-data repository/assembler/mapper에서 row 처리 callback의 `any`를 제거했습니다.

## 변경 금지 범위 확인

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver REST OAuth 성공 경로 변경 없음
- 제품 동작 변경 없음

## 검증

- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts test/unit/worker-source-quality.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- UTF-8 integrity check: changed files pass
