### PR TITLE
TSK-003-04 Frontend stage prop locality

### DIFF
--- a/src/components/page-stage/PageStageCourseView.tsx
+++ b/src/components/page-stage/PageStageCourseView.tsx
@@ -1,7 +1,5 @@
 import { CourseTab } from '../CourseTab';
-import type { AppPageStageProps } from './appPageStageTypes';
-
-type PageStageCourseViewProps = Pick<AppPageStageProps, 'sharedData' | 'courseData' | 'sharedActions' | 'courseActions'>;
+import type { PageStageCourseViewProps } from './appPageStageTypes';
 
 export function PageStageCourseView({
   sharedData,

--- a/src/components/page-stage/PageStageFeedView.tsx
+++ b/src/components/page-stage/PageStageFeedView.tsx
@@ -1,8 +1,6 @@
 import { useMemo } from 'react';
 import { FeedTab } from '../FeedTab';
-import type { AppPageStageProps } from './appPageStageTypes';
-
-type PageStageFeedViewProps = Pick<AppPageStageProps, 'sharedData' | 'feedData' | 'sharedActions' | 'feedActions'>;
+import type { PageStageFeedViewProps } from './appPageStageTypes';
 
 export function PageStageFeedView({
   sharedData,

--- a/src/components/page-stage/PageStageMyView.tsx
+++ b/src/components/page-stage/PageStageMyView.tsx
@@ -1,7 +1,5 @@
 import { MyPagePanel } from '../MyPagePanel';
-import type { AppPageStageProps } from './appPageStageTypes';
-
-type PageStageMyViewProps = Pick<AppPageStageProps, 'sharedData' | 'myPageData' | 'sharedActions' | 'myPageActions'>;
+import type { PageStageMyViewProps } from './appPageStageTypes';
 
 export function PageStageMyView({
   sharedData,

--- a/src/components/page-stage/appPageStageTypes.ts
+++ b/src/components/page-stage/appPageStageTypes.ts
@@ -16,86 +16,123 @@ import type {
   UserRoute,
 } from '../../types';
 
+export interface AppPageStageSharedData {
+  sessionUser: SessionUser | null;
+  placeNameById: Record<string, string>;
+  festivals: FestivalItem[];
+}
+
+export interface AppPageStageFeedData {
+  reviews: Review[];
+  reviewLikeUpdatingId: string | null;
+  feedPlaceFilterId: string | null;
+  commentSubmittingReviewId: string | null;
+  commentMutatingId: string | null;
+  deletingReviewId: string | null;
+  activeCommentReviewId: string | null;
+  activeCommentReviewComments: Comment[];
+  activeCommentReviewStatus: ApiStatus;
+  highlightedCommentId: string | null;
+  highlightedReviewId: string | null;
+  feedHasMore: boolean;
+  feedLoadingMore: boolean;
+}
+
+export interface AppPageStageCourseData {
+  courses: Course[];
+  communityRoutes: UserRoute[];
+  communityRouteSort: CommunityRouteSort;
+  routeLikeUpdatingId: string | null;
+  highlightedRouteId: string | null;
+}
+
+export interface AppPageStageMyPageData {
+  myPage: MyPageResponse | null;
+  providers: AuthProvider[];
+  myPageError: string | null;
+  myPageTab: MyPageTabKey;
+  isLoggingOut: boolean;
+  profileSaving: boolean;
+  profileError: string | null;
+  routeSubmitting: boolean;
+  routeError: string | null;
+  adminSummary: AdminSummaryResponse | null;
+  adminBusyPlaceId: string | null;
+  adminLoading: boolean;
+  commentsHasMore: boolean;
+  commentsLoadingMore: boolean;
+}
+
+export interface AppPageStageSharedActions {
+  onRequestLogin: () => void;
+  onOpenPlace: (placeId: string) => void;
+}
+
+export interface AppPageStageFeedActions {
+  onLoadMoreFeed: () => Promise<void>;
+  onToggleReviewLike: (reviewId: string) => Promise<void>;
+  onCreateComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
+  onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
+  onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
+  onDeleteReview: (reviewId: string) => Promise<void>;
+  onClearPlaceFilter: () => void;
+  onOpenComments: (reviewId: string, commentId?: string | null) => void;
+  onCloseComments: () => void;
+}
+
+export interface AppPageStageCourseActions {
+  onChangeRouteSort: (sort: CommunityRouteSort) => void;
+  onToggleRouteLike: (routeId: string) => Promise<void>;
+  onOpenRoutePreview: (route: RoutePreview) => void;
+}
+
+export interface AppPageStageMyPageActions {
+  onChangeMyPageTab: (tab: MyPageTabKey) => void;
+  onLogin: (provider: 'naver' | 'kakao') => void;
+  onRetryMyPage: () => Promise<void>;
+  onLogout: () => Promise<void>;
+  onSaveNickname: (nickname: string) => Promise<void>;
+  onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
+  onOpenCommentFromMyPage: (reviewId: string, commentId: string) => void;
+  onOpenRouteFromMyPage: (routeId: string) => Promise<void>;
+  onOpenReview: (reviewId: string) => Promise<void>;
+  onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
+  onDeleteReview: (reviewId: string) => Promise<void>;
+  onLoadMoreComments: (initial?: boolean) => Promise<void>;
+  onRefreshAdmin: () => Promise<void>;
+  onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
+  onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
+}
+
 export interface AppPageStageProps {
   activeTab: Exclude<Tab, 'map'>;
-  sharedData: {
-    sessionUser: SessionUser | null;
-    placeNameById: Record<string, string>;
-    festivals: FestivalItem[];
-  };
-  feedData: {
-    reviews: Review[];
-    reviewLikeUpdatingId: string | null;
-    feedPlaceFilterId: string | null;
-    commentSubmittingReviewId: string | null;
-    commentMutatingId: string | null;
-    deletingReviewId: string | null;
-    activeCommentReviewId: string | null;
-    activeCommentReviewComments: Comment[];
-    activeCommentReviewStatus: ApiStatus;
-    highlightedCommentId: string | null;
-    highlightedReviewId: string | null;
-    feedHasMore: boolean;
-    feedLoadingMore: boolean;
-  };
-  courseData: {
-    courses: Course[];
-    communityRoutes: UserRoute[];
-    communityRouteSort: CommunityRouteSort;
-    routeLikeUpdatingId: string | null;
-    highlightedRouteId: string | null;
-  };
-  myPageData: {
-    myPage: MyPageResponse | null;
-    providers: AuthProvider[];
-    myPageError: string | null;
-    myPageTab: MyPageTabKey;
-    isLoggingOut: boolean;
-    profileSaving: boolean;
-    profileError: string | null;
-    routeSubmitting: boolean;
-    routeError: string | null;
-    adminSummary: AdminSummaryResponse | null;
-    adminBusyPlaceId: string | null;
-    adminLoading: boolean;
-    commentsHasMore: boolean;
-    commentsLoadingMore: boolean;
-  };
-  sharedActions: {
-    onRequestLogin: () => void;
-    onOpenPlace: (placeId: string) => void;
-  };
-  feedActions: {
-    onLoadMoreFeed: () => Promise<void>;
-    onToggleReviewLike: (reviewId: string) => Promise<void>;
-    onCreateComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
-    onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
-    onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
-    onDeleteReview: (reviewId: string) => Promise<void>;
-    onClearPlaceFilter: () => void;
-    onOpenComments: (reviewId: string, commentId?: string | null) => void;
-    onCloseComments: () => void;
-  };
-  courseActions: {
-    onChangeRouteSort: (sort: CommunityRouteSort) => void;
-    onToggleRouteLike: (routeId: string) => Promise<void>;
-    onOpenRoutePreview: (route: RoutePreview) => void;
-  };
-  myPageActions: {
-    onChangeMyPageTab: (tab: MyPageTabKey) => void;
-    onLogin: (provider: 'naver' | 'kakao') => void;
-    onRetryMyPage: () => Promise<void>;
-    onLogout: () => Promise<void>;
-    onSaveNickname: (nickname: string) => Promise<void>;
-    onPublishRoute: (payload: { travelSessionId: string; title: string; description: string; mood: string }) => Promise<void>;
-    onOpenCommentFromMyPage: (reviewId: string, commentId: string) => void;
-    onOpenRouteFromMyPage: (routeId: string) => Promise<void>;
-    onOpenReview: (reviewId: string) => Promise<void>;
-    onUpdateReview: (reviewId: string, payload: { body: string; mood: ReviewMood; file?: File | null; removeImage?: boolean }) => Promise<void>;
-    onDeleteReview: (reviewId: string) => Promise<void>;
-    onLoadMoreComments: (initial?: boolean) => Promise<void>;
-    onRefreshAdmin: () => Promise<void>;
-    onToggleAdminPlace: (placeId: string, nextValue: boolean) => Promise<void>;
-    onToggleAdminManualOverride: (placeId: string, nextValue: boolean) => Promise<void>;
-  };
+  sharedData: AppPageStageSharedData;
+  feedData: AppPageStageFeedData;
+  courseData: AppPageStageCourseData;
+  myPageData: AppPageStageMyPageData;
+  sharedActions: AppPageStageSharedActions;
+  feedActions: AppPageStageFeedActions;
+  courseActions: AppPageStageCourseActions;
+  myPageActions: AppPageStageMyPageActions;
+}
+
+export interface PageStageFeedViewProps {
+  sharedData: Pick<AppPageStageSharedData, 'sessionUser' | 'placeNameById'>;
+  feedData: AppPageStageFeedData;
+  sharedActions: AppPageStageSharedActions;
+  feedActions: AppPageStageFeedActions;
+}
+
+export interface PageStageCourseViewProps {
+  sharedData: Pick<AppPageStageSharedData, 'sessionUser' | 'placeNameById'>;
+  courseData: AppPageStageCourseData;
+  sharedActions: AppPageStageSharedActions;
+  courseActions: AppPageStageCourseActions;
+}
+
+export interface PageStageMyViewProps {
+  sharedData: Pick<AppPageStageSharedData, 'sessionUser'>;
+  myPageData: AppPageStageMyPageData;
+  sharedActions: Pick<AppPageStageSharedActions, 'onOpenPlace'>;
+  myPageActions: AppPageStageMyPageActions;
 }

--- a/test/unit/interface-locality-source-quality.test.ts
+++ b/test/unit/interface-locality-source-quality.test.ts
@@ -71,7 +71,8 @@ describe('interface locality source quality baseline', () => {
         'src/components/AppPageStage.tsx',
         'src/hooks/usePageStageProps.ts',
       ]),
-    ).toBeLessThanOrEqual(11);
+    ).toBeLessThanOrEqual(5);
+    expect(gitGrepCount('Pick<AppPageStageProps', ['src/components/page-stage'])).toBe(0);
   });
 
   it('keeps FastAPI compatibility model facade imports from growing', () => {


### PR DESCRIPTION
﻿## Scope

- Scope-ID: `TSK-003-04-FRONTEND-STAGE-PROP-LOCALITY`
- Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
- Child Issue: Closes #258
- Branch: `frontend-stage-prop-locality`

## 변경 요약

- `AppPageStageProps`의 하위 data/action contract를 명시 interface로 분리했습니다.
- `PageStageFeedView`, `PageStageCourseView`, `PageStageMyView`가 `Pick<AppPageStageProps>`에 의존하지 않도록 stage-local props를 사용하게 했습니다.
- source-quality gate를 wide stage props coupling 회귀 금지 기준으로 갱신했습니다.

## 변경 금지 범위 확인

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver REST OAuth 성공 경로 변경 없음
- 제품 동작 변경 없음

## 검증

- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- UTF-8 integrity check: changed files pass
