### PR TITLE
Refactor frontend type import locality

### DIFF
--- a/src/components/AdminPanel.tsx
+++ b/src/components/AdminPanel.tsx
@@ -1,4 +1,4 @@
-﻿import type { AdminSummaryResponse } from '../types';
+﻿import type { AdminSummaryResponse } from '../types/admin';
 
 interface AdminPanelProps {
   summary: AdminSummaryResponse | null;

--- a/src/components/AppMapStageView.tsx
+++ b/src/components/AppMapStageView.tsx
@@ -1,16 +1,8 @@
 import { memo } from 'react';
 import { MapTabStage } from './MapTabStage';
-import type {
-  ApiStatus,
-  BootstrapResponse,
-  Category,
-  DrawerState,
-  FestivalItem,
-  Place,
-  ReviewMood,
-  RoutePreview,
-  SessionUser,
-} from '../types';
+import type { ApiStatus, Category, DrawerState, FestivalItem, Place, ReviewMood, RoutePreview } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { BootstrapResponse } from '../types/review';
 
 interface AppMapStageViewProps {
   mapData: {

--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -1,4 +1,4 @@
-﻿import type { Tab } from '../types';
+﻿import type { Tab } from '../types/core';
 
 interface BottomNavProps {
   activeTab: Tab;

--- a/src/components/EventTab.tsx
+++ b/src/components/EventTab.tsx
@@ -1,5 +1,5 @@
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
-import type { FestivalItem } from '../types';
+import type { FestivalItem } from '../types/core';
 
 interface EventTabProps {
   festivals: FestivalItem[];

--- a/src/components/FeedCommentSheet.tsx
+++ b/src/components/FeedCommentSheet.tsx
@@ -1,6 +1,7 @@
 ﻿import { useRef } from 'react';
 import { CommentThread } from './CommentThread';
-import type { ApiStatus, Comment, Review } from '../types';
+import type { ApiStatus } from '../types/core';
+import type { Comment, Review } from '../types/review';
 
 interface FeedCommentSheetProps {
   review: Review | null;

--- a/src/components/FeedTab.tsx
+++ b/src/components/FeedTab.tsx
@@ -5,7 +5,9 @@ import { FeedLoadMoreRow } from './feed/FeedLoadMoreRow';
 import { FeedTabHeader } from './feed/FeedTabHeader';
 import { FeedCommentSheet } from './FeedCommentSheet';
 import { ReviewList } from './ReviewList';
-import type { ApiStatus, Comment, Review, SessionUser } from '../types';
+import type { ApiStatus } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { Comment, Review } from '../types/review';
 
 interface FeedTabProps {
   feedData: {

--- a/src/components/FestivalDetailSheet.tsx
+++ b/src/components/FestivalDetailSheet.tsx
@@ -1,4 +1,4 @@
-import type { DrawerState, FestivalItem } from '../types';
+import type { DrawerState, FestivalItem } from '../types/core';
 
 interface FestivalDetailSheetProps {
   festival: FestivalItem | null;

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -1,6 +1,6 @@
 import { useRef } from 'react';
 import { getClientConfig } from '../config';
-import type { ApiStatus, FestivalItem, Place } from '../types';
+import type { ApiStatus, FestivalItem, Place } from '../types/core';
 import { NaverMapStatus } from './naver-map/NaverMapStatus';
 import { useNaverMapInstance } from './naver-map/useNaverMapInstance';
 import { useNaverMapInteractions } from './naver-map/useNaverMapInteractions';

--- a/src/components/ProviderButtons.tsx
+++ b/src/components/ProviderButtons.tsx
@@ -1,4 +1,4 @@
-﻿import type { AuthProvider, ProviderKey } from '../types';
+﻿import type { AuthProvider, ProviderKey } from '../types/auth';
 
 interface ProviderButtonsProps {
   providers: AuthProvider[];

--- a/src/components/ReviewComposer.tsx
+++ b/src/components/ReviewComposer.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { ReviewFormFields } from './ReviewFormFields';
-import type { ReviewMood } from '../types';
+import type { ReviewMood } from '../types/core';
 
 type ReviewComposerStatus = 'login' | 'claim' | 'ready' | 'daily-limit';
 

--- a/src/components/ReviewFormFields.tsx
+++ b/src/components/ReviewFormFields.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useId, useState } from 'react';
-import type { ReviewMood } from '../types';
+import type { ReviewMood } from '../types/core';
 
 interface ReviewFormFieldsProps {
   moodOptions: ReviewMood[];

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -1,5 +1,5 @@
 import { memo, useRef } from 'react';
-import type { Review } from '../types';
+import type { Review } from '../types/review';
 import { ReviewListEmptyState } from './review/ReviewListEmptyState';
 import { ReviewListItem } from './review/ReviewListItem';
 import { useScrollToHighlightedReview } from './review/useScrollToHighlightedReview';

--- a/src/components/comment-thread/types.ts
+++ b/src/components/comment-thread/types.ts
@@ -1,4 +1,4 @@
-import type { Comment } from '../../types';
+import type { Comment } from '../../types/review';
 
 export interface CommentThreadProps {
   comments: Comment[];

--- a/src/components/course/CommunityRouteCard.tsx
+++ b/src/components/course/CommunityRouteCard.tsx
@@ -1,5 +1,6 @@
 import { memo, type MutableRefObject } from 'react';
-import type { SessionUser, UserRoute } from '../../types';
+import type { SessionUser } from '../../types/auth';
+import type { UserRoute } from '../../types/review';
 import { HeartIcon } from '../review/ReviewActionIcons';
 import type { RoutePreviewPayload } from './courseTabTypes';
 

--- a/src/components/course/courseTabTypes.ts
+++ b/src/components/course/courseTabTypes.ts
@@ -1,4 +1,6 @@
-import type { CommunityRouteSort, Course, SessionUser, UserRoute } from '../../types';
+import type { CommunityRouteSort, Course } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { UserRoute } from '../../types/review';
 
 export interface RoutePreviewPayload {
   id: string;

--- a/src/components/map-stage/MapStageCategoryStrip.tsx
+++ b/src/components/map-stage/MapStageCategoryStrip.tsx
@@ -1,5 +1,5 @@
 import { categoryInfo, categoryItems } from '../../lib/categories';
-import type { Category } from '../../types';
+import type { Category } from '../../types/core';
 
 type MapStageCategoryStripProps = {
   activeCategory: Category;

--- a/src/components/map-stage/MapStageRoutePreviewCard.tsx
+++ b/src/components/map-stage/MapStageRoutePreviewCard.tsx
@@ -1,4 +1,4 @@
-import type { RoutePreview } from '../../types';
+import type { RoutePreview } from '../../types/core';
 
 type MapStageRoutePreviewCardProps = {
   routePreview: RoutePreview | null;

--- a/src/components/map-stage/mapTabStageTypes.ts
+++ b/src/components/map-stage/mapTabStageTypes.ts
@@ -1,14 +1,6 @@
-import type {
-  ApiStatus,
-  BootstrapResponse,
-  Category,
-  DrawerState,
-  FestivalItem,
-  Place,
-  ReviewMood,
-  RoutePreview,
-  SessionUser,
-} from '../../types';
+import type { ApiStatus, Category, DrawerState, FestivalItem, Place, ReviewMood, RoutePreview } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { BootstrapResponse } from '../../types/review';
 
 export interface MapTabStageProps {
   mapData: {

--- a/src/components/my-page/MyCommentsTabSection.tsx
+++ b/src/components/my-page/MyCommentsTabSection.tsx
@@ -1,5 +1,5 @@
 import type { RefObject } from 'react';
-import type { MyPageResponse } from '../../types';
+import type { MyPageResponse } from '../../types/my-page';
 
 type MyComment = NonNullable<MyPageResponse>['comments'][number];
 

--- a/src/components/my-page/MyPageAccountSection.tsx
+++ b/src/components/my-page/MyPageAccountSection.tsx
@@ -1,4 +1,4 @@
-import type { SessionUser } from '../../types';
+import type { SessionUser } from '../../types/auth';
 
 type MyPageAccountSectionProps = {
   sessionUser: SessionUser;

--- a/src/components/my-page/MyPageGuestState.tsx
+++ b/src/components/my-page/MyPageGuestState.tsx
@@ -1,4 +1,4 @@
-import type { AuthProvider, ProviderKey } from '../../types';
+import type { AuthProvider, ProviderKey } from '../../types/auth';
 import { ProviderButtons } from '../ProviderButtons';
 
 interface MyPageGuestStateProps {

--- a/src/components/my-page/MyPageHeader.tsx
+++ b/src/components/my-page/MyPageHeader.tsx
@@ -1,4 +1,4 @@
-import type { SessionUser } from '../../types';
+import type { SessionUser } from '../../types/auth';
 
 interface MyPageHeaderProps {
   sessionUser: SessionUser;

--- a/src/components/my-page/MyPageOverviewSection.tsx
+++ b/src/components/my-page/MyPageOverviewSection.tsx
@@ -1,4 +1,5 @@
-import type { Place, TravelSession } from '../../types';
+import type { Place } from '../../types/core';
+import type { TravelSession } from '../../types/review';
 
 type MyPageOverviewSectionProps = {
   uniquePlaceCount: number;

--- a/src/components/my-page/MyPagePrimaryTabs.tsx
+++ b/src/components/my-page/MyPagePrimaryTabs.tsx
@@ -1,4 +1,4 @@
-import type { MyPageTabKey } from '../../types';
+import type { MyPageTabKey } from '../../types/core';
 
 type MyPagePrimaryTabsProps = {
   activeTab: MyPageTabKey;

--- a/src/components/my-page/MyPageTabContent.tsx
+++ b/src/components/my-page/MyPageTabContent.tsx
@@ -1,5 +1,8 @@
 import { Suspense, lazy, type RefObject } from 'react';
-import type { AdminSummaryResponse, MyPageResponse, MyPageTabKey, ReviewMood, SessionUser } from '../../types';
+import type { MyPageTabKey, ReviewMood } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { MyPageResponse } from '../../types/my-page';
+import type { AdminSummaryResponse } from '../../types/admin';
 import { MyCommentsTabSection } from './MyCommentsTabSection';
 import { MyFeedTabSection } from './MyFeedTabSection';
 import { MyPagePrimaryTabs } from './MyPagePrimaryTabs';

--- a/src/components/my-page/MyStampTabSection.tsx
+++ b/src/components/my-page/MyStampTabSection.tsx
@@ -1,4 +1,4 @@
-import type { MyPageResponse } from '../../types';
+import type { MyPageResponse } from '../../types/my-page';
 
 type StampLog = NonNullable<MyPageResponse>['stampLogs'][number];
 type TravelSession = NonNullable<MyPageResponse>['travelSessions'][number];

--- a/src/components/my-page/myFeedTabTypes.ts
+++ b/src/components/my-page/myFeedTabTypes.ts
@@ -1,4 +1,5 @@
-import type { MyPageResponse, ReviewMood } from '../../types';
+import type { ReviewMood } from '../../types/core';
+import type { MyPageResponse } from '../../types/my-page';
 
 export const reviewMoodOptions: ReviewMood[] = ['혼자서', '친구랑', '데이트', '야경 맛집'];
 

--- a/src/components/my-page/myPagePanelTypes.ts
+++ b/src/components/my-page/myPagePanelTypes.ts
@@ -1,11 +1,7 @@
-import type {
-  AdminSummaryResponse,
-  AuthProvider,
-  MyPageResponse,
-  MyPageTabKey,
-  ReviewMood,
-  SessionUser,
-} from '../../types';
+import type { MyPageTabKey, ReviewMood } from '../../types/core';
+import type { AuthProvider, SessionUser } from '../../types/auth';
+import type { MyPageResponse } from '../../types/my-page';
+import type { AdminSummaryResponse } from '../../types/admin';
 
 export interface MyPagePanelProps {
   sessionData: {

--- a/src/components/my-page/myRoutesTabTypes.ts
+++ b/src/components/my-page/myRoutesTabTypes.ts
@@ -1,4 +1,5 @@
-import type { CourseMood, MyPageResponse } from '../../types';
+import type { CourseMood } from '../../types/core';
+import type { MyPageResponse } from '../../types/my-page';
 
 export const routeMoodOptions: CourseMood[] = ['데이트', '사진', '힐링', '비 오는 날'];
 

--- a/src/components/my-page/useMyFeedReviewEditor.ts
+++ b/src/components/my-page/useMyFeedReviewEditor.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { useEventCallback } from '../../hooks/useEventCallback';
-import type { ReviewMood } from '../../types';
+import type { ReviewMood } from '../../types/core';
 import type { MyReview, ReviewUpdatePayload } from './myFeedTabTypes';
 
 export function useMyFeedReviewEditor(onUpdateReview: (reviewId: string, payload: ReviewUpdatePayload) => Promise<void>) {

--- a/src/components/naver-map/NaverMapStatus.tsx
+++ b/src/components/naver-map/NaverMapStatus.tsx
@@ -1,4 +1,4 @@
-import type { ApiStatus } from '../../types';
+import type { ApiStatus } from '../../types/core';
 
 type NaverMapStatusProps = {
   clientId: string;

--- a/src/components/naver-map/markerContent.ts
+++ b/src/components/naver-map/markerContent.ts
@@ -1,6 +1,6 @@
 import { cssPx, UiNaverMarkerVisualConfig } from '../../config/uiTokenConfig';
 import { categoryInfo } from '../../lib/categories';
-import type { FestivalItem, Place } from '../../types';
+import type { FestivalItem, Place } from '../../types/core';
 
 export function placeMarkerContent(place: Place, isActive: boolean) {
   const info = categoryInfo[place.category];

--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
-import type { FestivalItem } from '../../types';
+import type { FestivalItem } from '../../types/core';
 import { festivalMarkerContent, hasFestivalCoordinates } from './markerContent';
 
 type MapsApi = typeof window.naver.maps;

--- a/src/components/naver-map/useNaverMapInteractions.ts
+++ b/src/components/naver-map/useNaverMapInteractions.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import type { FestivalItem, Place } from '../../types';
+import type { FestivalItem, Place } from '../../types/core';
 import { useNaverCurrentLocationMarker } from './useNaverCurrentLocationMarker';
 import { useNaverCurrentLocationFocus } from './useNaverCurrentLocationFocus';
 import { useNaverFestivalMarkers } from './useNaverFestivalMarkers';

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -1,7 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
-import type { Place } from '../../types';
+import type { Place } from '../../types/core';
 import { placeMarkerContent } from './markerContent';
 
 type MapsApi = typeof window.naver.maps;

--- a/src/components/naver-map/useNaverRoutePreviewOverlay.ts
+++ b/src/components/naver-map/useNaverRoutePreviewOverlay.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
-import type { Place } from '../../types';
+import type { Place } from '../../types/core';
 import { routeStepMarkerContent } from './markerContent';
 
 type NaverMapInstance = {

--- a/src/components/naver-map/useNaverSelectionSync.ts
+++ b/src/components/naver-map/useNaverSelectionSync.ts
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import { MapViewportConfig, SelectionMotionConfig } from '../../config/mapConfig';
-import type { FestivalItem, Place } from '../../types';
+import type { FestivalItem, Place } from '../../types/core';
 import { hasFestivalCoordinates } from './markerContent';
 import { getSelectionVerticalOffset } from './selectionOffset';
 

--- a/src/components/notifications/notificationTypes.ts
+++ b/src/components/notifications/notificationTypes.ts
@@ -1,4 +1,4 @@
-import type { MyPageResponse } from '../../types';
+import type { MyPageResponse } from '../../types/my-page';
 
 export type NotificationItem = NonNullable<MyPageResponse>['notifications'][number];
 

--- a/src/components/page-stage/appPageStageTypes.ts
+++ b/src/components/page-stage/appPageStageTypes.ts
@@ -1,20 +1,8 @@
-import type {
-  AdminSummaryResponse,
-  ApiStatus,
-  AuthProvider,
-  Comment,
-  CommunityRouteSort,
-  Course,
-  FestivalItem,
-  MyPageResponse,
-  MyPageTabKey,
-  Review,
-  ReviewMood,
-  RoutePreview,
-  SessionUser,
-  Tab,
-  UserRoute,
-} from '../../types';
+import type { ApiStatus, CommunityRouteSort, Course, FestivalItem, MyPageTabKey, ReviewMood, RoutePreview, Tab } from '../../types/core';
+import type { AuthProvider, SessionUser } from '../../types/auth';
+import type { Comment, Review, UserRoute } from '../../types/review';
+import type { MyPageResponse } from '../../types/my-page';
+import type { AdminSummaryResponse } from '../../types/admin';
 
 export interface AppPageStageSharedData {
   sessionUser: SessionUser | null;

--- a/src/components/place/PlaceProofCard.tsx
+++ b/src/components/place/PlaceProofCard.tsx
@@ -1,4 +1,4 @@
-import type { ApiStatus } from '../../types';
+import type { ApiStatus } from '../../types/core';
 
 interface PlaceProofCardProps {
   loggedIn: boolean;

--- a/src/components/place/placeDetailSheetTypes.ts
+++ b/src/components/place/placeDetailSheetTypes.ts
@@ -1,4 +1,5 @@
-import type { ApiStatus, DrawerState, Place, Review, ReviewMood, StampLog } from '../../types';
+import type { ApiStatus, DrawerState, Place, ReviewMood } from '../../types/core';
+import type { Review, StampLog } from '../../types/review';
 
 export interface PlaceDetailSheetProps {
   place: Place | null;

--- a/src/components/place/usePlaceDrawerHandle.ts
+++ b/src/components/place/usePlaceDrawerHandle.ts
@@ -1,5 +1,5 @@
 import { useRef } from 'react';
-import type { DrawerState } from '../../types';
+import type { DrawerState } from '../../types/core';
 
 interface UsePlaceDrawerHandleOptions {
   drawerState: DrawerState;

--- a/src/components/review/PlaceReviewPreviewList.tsx
+++ b/src/components/review/PlaceReviewPreviewList.tsx
@@ -1,5 +1,5 @@
 import { formatReviewVisitedAt } from '../../lib/visits';
-import type { Review } from '../../types';
+import type { Review } from '../../types/review';
 
 interface PlaceReviewPreviewListProps {
   reviews: Review[];

--- a/src/components/review/ReviewListItem.tsx
+++ b/src/components/review/ReviewListItem.tsx
@@ -1,6 +1,6 @@
 import { memo } from 'react';
 import { CommentThread } from '../CommentThread';
-import type { Review } from '../../types';
+import type { Review } from '../../types/review';
 import { CommentIcon, HeartIcon } from './ReviewActionIcons';
 import { ReviewFeedCardHeader } from './ReviewFeedCardHeader';
 import { ReviewImageFrame } from './ReviewImageFrame';

--- a/src/hooks/app-bootstrap/bootstrapAuthNotice.ts
+++ b/src/hooks/app-bootstrap/bootstrapAuthNotice.ts
@@ -1,4 +1,4 @@
-import type { SessionUser } from '../../types';
+import type { SessionUser } from '../../types/auth';
 
 const PROFILE_COMPLETION_NOTICE =
   '프로필을 먼저 완성하면 같은 계정으로 스탬프와 리뷰를 이어서 남길 수 있어요.';

--- a/src/hooks/app-bootstrap/bootstrapFestivalLoader.ts
+++ b/src/hooks/app-bootstrap/bootstrapFestivalLoader.ts
@@ -1,7 +1,7 @@
 import type * as React from 'react';
 
 import { getFestivals } from '../../api/bootstrapClient';
-import type { FestivalItem } from '../../types';
+import type { FestivalItem } from '../../types/core';
 import { resetFestivalSelection } from './bootstrapRuntimeReset';
 
 interface BootstrapFestivalLoaderParams {

--- a/src/hooks/app-bootstrap/bootstrapMapSession.ts
+++ b/src/hooks/app-bootstrap/bootstrapMapSession.ts
@@ -1,7 +1,10 @@
 import type * as React from 'react';
 
 import { getMapBootstrap } from '../../api/bootstrapClient';
-import type { MyPageResponse, Place, SessionUser, StampState } from '../../types';
+import type { Place } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { StampState } from '../../types/review';
+import type { MyPageResponse } from '../../types/my-page';
 import { handleBootstrapAuthNotice } from './bootstrapAuthNotice';
 import { applyBootstrapSelections, resetBootstrapRuntime } from './bootstrapRuntimeReset';
 

--- a/src/hooks/app-data/useCommunityRouteState.ts
+++ b/src/hooks/app-data/useCommunityRouteState.ts
@@ -1,5 +1,6 @@
 import { useRef, useState } from 'react';
-import type { CommunityRouteSort, UserRoute } from '../../types';
+import type { CommunityRouteSort } from '../../types/core';
+import type { UserRoute } from '../../types/review';
 
 export function useCommunityRouteState() {
   const [communityRoutes, setCommunityRoutes] = useState<UserRoute[]>([]);

--- a/src/hooks/app-data/useReviewCollectionState.ts
+++ b/src/hooks/app-data/useReviewCollectionState.ts
@@ -1,6 +1,6 @@
 import { useRef, useState } from 'react';
 import { toReviewSummary } from '../../lib/reviews';
-import type { BootstrapResponse } from '../../types';
+import type { BootstrapResponse } from '../../types/review';
 
 type ReviewSummary = BootstrapResponse['reviews'][number];
 

--- a/src/hooks/app-navigation/navigationTypes.ts
+++ b/src/hooks/app-navigation/navigationTypes.ts
@@ -1,11 +1,6 @@
 import type { ReturnViewState } from '../../store/app-ui-store';
-import type {
-  DrawerState,
-  MyPageTabKey,
-  Review,
-  RoutePreview,
-  Tab,
-} from '../../types';
+import type { DrawerState, MyPageTabKey, RoutePreview, Tab } from '../../types/core';
+import type { Review } from '../../types/review';
 import type { RouteStateCommitOptions } from '../useAppRouteState';
 
 export interface UseAppNavigationHelpersParams {

--- a/src/hooks/app-navigation/shellBackNavigation.ts
+++ b/src/hooks/app-navigation/shellBackNavigation.ts
@@ -1,4 +1,5 @@
-import type { DrawerState, MyPageTabKey, RoutePreview, SessionUser, Tab } from '../../types';
+import type { DrawerState, MyPageTabKey, RoutePreview, Tab } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
 import type { ReturnViewState } from '../../store/app-ui-store';
 import type { RouteStateCommitOptions } from '../useAppRouteState';
 

--- a/src/hooks/app-navigation/shellBottomNav.ts
+++ b/src/hooks/app-navigation/shellBottomNav.ts
@@ -1,4 +1,4 @@
-import type { DrawerState, RoutePreview, Tab } from '../../types';
+import type { DrawerState, RoutePreview, Tab } from '../../types/core';
 import type { RouteStateCommitOptions } from '../useAppRouteState';
 
 interface CreateBottomNavChangeHandlerParams {

--- a/src/hooks/app-route-actions/publishRouteAction.ts
+++ b/src/hooks/app-route-actions/publishRouteAction.ts
@@ -1,6 +1,9 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { createUserRoute } from '../../api/routesClient';
-import type { MyPageResponse, MyPageTabKey, SessionUser, Tab, UserRoute } from '../../types';
+import type { MyPageTabKey, Tab } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { UserRoute } from '../../types/review';
+import type { MyPageResponse } from '../../types/my-page';
 
 type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
 type HistoryMode = 'push' | 'replace';

--- a/src/hooks/app-route-actions/routeLikeAction.ts
+++ b/src/hooks/app-route-actions/routeLikeAction.ts
@@ -1,6 +1,9 @@
 import type { Dispatch, SetStateAction } from 'react';
 import { toggleCommunityRouteLike } from '../../api/routesClient';
-import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../../types';
+import type { Tab } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { UserRoute } from '../../types/review';
+import type { MyPageResponse } from '../../types/my-page';
 
 type HistoryMode = 'push' | 'replace';
 

--- a/src/hooks/app-route/authQueryState.ts
+++ b/src/hooks/app-route/authQueryState.ts
@@ -1,4 +1,4 @@
-import type { Tab } from '../../types';
+import type { Tab } from '../../types/core';
 
 type RouteDrawerState = 'closed' | 'partial' | 'full';
 

--- a/src/hooks/app-route/routeHistoryState.ts
+++ b/src/hooks/app-route/routeHistoryState.ts
@@ -1,4 +1,4 @@
-import type { DrawerState, RoutePreview, Tab } from '../../types';
+import type { DrawerState, RoutePreview, Tab } from '../../types/core';
 
 export type RouteState = {
   tab: Tab;

--- a/src/hooks/app-route/routeStateActions.ts
+++ b/src/hooks/app-route/routeStateActions.ts
@@ -1,4 +1,4 @@
-import type { RoutePreview, Tab } from '../../types';
+import type { RoutePreview, Tab } from '../../types/core';
 import type { RouteState, RouteStateCommitOptions } from './routeHistoryState';
 import { buildHistoryState, buildRouteUrl } from './routeHistoryState';
 

--- a/src/hooks/app-tab-loaders/communityRouteLoader.ts
+++ b/src/hooks/app-tab-loaders/communityRouteLoader.ts
@@ -1,6 +1,7 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getCommunityRoutes } from '../../api/routesClient';
-import type { CommunityRouteSort, UserRoute } from '../../types';
+import type { CommunityRouteSort } from '../../types/core';
+import type { UserRoute } from '../../types/review';
 
 type CommunityRoutesCache = Partial<Record<CommunityRouteSort, UserRoute[]>>;
 

--- a/src/hooks/app-tab-loaders/feedReviewLoader.ts
+++ b/src/hooks/app-tab-loaders/feedReviewLoader.ts
@@ -2,7 +2,7 @@ import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getReviewFeedPage } from '../../api/reviewsClient';
 import { PaginationRuntimeConfig } from '../../config/runtimeLimitConfig';
 import { toReviewSummaryList } from '../../lib/reviews';
-import type { Review } from '../../types';
+import type { Review } from '../../types/review';
 
 interface CreateFeedReviewLoaderParams {
   feedLoadedRef: MutableRefObject<boolean>;

--- a/src/hooks/app-tab-loaders/summaryLoaders.ts
+++ b/src/hooks/app-tab-loaders/summaryLoaders.ts
@@ -2,7 +2,10 @@ import type { Dispatch, SetStateAction } from 'react';
 import { getAdminSummary } from '../../api/adminClient';
 import { getMySummary } from '../../api/myClient';
 import { toReviewSummaryList } from '../../lib/reviews';
-import type { AdminSummaryResponse, MyPageResponse, SessionUser, Tab } from '../../types';
+import type { Tab } from '../../types/core';
+import type { SessionUser } from '../../types/auth';
+import type { MyPageResponse } from '../../types/my-page';
+import type { AdminSummaryResponse } from '../../types/admin';
 
 interface CreateAdminSummaryLoaderParams {
   activeTab: Tab;

--- a/src/hooks/app-view-models/placeSelections.ts
+++ b/src/hooks/app-view-models/placeSelections.ts
@@ -1,4 +1,4 @@
-import type { Category, FestivalItem, Place, RoutePreview } from '../../types';
+import type { Category, FestivalItem, Place, RoutePreview } from '../../types/core';
 
 export function filterPlacesByCategory(places: Place[], category: Category) {
   if (category === 'all') {

--- a/src/hooks/app-view-models/reviewCapability.ts
+++ b/src/hooks/app-view-models/reviewCapability.ts
@@ -1,4 +1,6 @@
-import type { MyPageResponse, Review, SessionUser, StampLog } from '../../types';
+import type { SessionUser } from '../../types/auth';
+import type { Review, StampLog } from '../../types/review';
+import type { MyPageResponse } from '../../types/my-page';
 
 export function getKnownMyReviews({
   reviews,

--- a/src/hooks/app-view-models/statusModels.ts
+++ b/src/hooks/app-view-models/statusModels.ts
@@ -1,4 +1,5 @@
-import type { ApiStatus, MyPageResponse } from '../../types';
+import type { ApiStatus } from '../../types/core';
+import type { MyPageResponse } from '../../types/my-page';
 
 export function getHydratedMyPage({
   myPage,

--- a/src/hooks/useActiveReviewComments.ts
+++ b/src/hooks/useActiveReviewComments.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { getReviewComments } from '../api/reviewsClient';
-import type { ApiStatus, Comment } from '../types';
+import type { ApiStatus } from '../types/core';
+import type { Comment } from '../types/review';
 
 interface UseActiveReviewCommentsParams {
   activeCommentReviewId: string | null;

--- a/src/hooks/useAppAdminActions.ts
+++ b/src/hooks/useAppAdminActions.ts
@@ -2,13 +2,10 @@
 import { importPublicData, updatePlaceVisibility } from '../api/adminClient';
 import { getFestivals, getMapBootstrap } from '../api/bootstrapClient';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type {
-  AdminSummaryResponse,
-  FestivalItem,
-  Place,
-  SessionUser,
-  StampState,
-} from '../types';
+import type { FestivalItem, Place } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { StampState } from '../types/review';
+import type { AdminSummaryResponse } from '../types/admin';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 

--- a/src/hooks/useAppAuthActions.ts
+++ b/src/hooks/useAppAuthActions.ts
@@ -4,7 +4,7 @@ import type { Dispatch, SetStateAction } from 'react';
 import { useAuthStore } from '../store/auth-store';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type { MyPageResponse } from '../types';
+import type { MyPageResponse } from '../types/my-page';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 

--- a/src/hooks/useAppBootstrapEffects.ts
+++ b/src/hooks/useAppBootstrapEffects.ts
@@ -1,13 +1,10 @@
 import { useEffect } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 
-import type {
-  FestivalItem,
-  MyPageResponse,
-  Place,
-  SessionUser,
-  StampState,
-} from '../types';
+import type { FestivalItem, Place } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { StampState } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
 import { bootstrapFestivalLoader } from './app-bootstrap/bootstrapFestivalLoader';
 import { bootstrapMapSession } from './app-bootstrap/bootstrapMapSession';
 import { clearAuthQueryParams } from './useAppRouteState';

--- a/src/hooks/useAppBootstrapLifecycle.ts
+++ b/src/hooks/useAppBootstrapLifecycle.ts
@@ -4,16 +4,11 @@ import { useSelectedPlaceReviewSync } from './useSelectedPlaceReviewSync';
 import { useAppBootstrapSharedRefs } from './useAppBootstrapSharedRefs';
 import { useFestivalBootstrapEffect, useMapBootstrapEffect } from './useAppBootstrapEffects';
 import { useAppBootstrapStoreBindings } from './useAppBootstrapStoreBindings';
-import type {
-  AdminSummaryResponse,
-  FestivalItem,
-  MyPageResponse,
-  Place,
-  Review,
-  SessionUser,
-  StampState,
-  Tab,
-} from '../types';
+import type { FestivalItem, Place, Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { Review, StampState } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
+import type { AdminSummaryResponse } from '../types/admin';
 
 interface UseAppBootstrapLifecycleParams {
   activeTab: Tab;

--- a/src/hooks/useAppBootstrapSharedRefs.ts
+++ b/src/hooks/useAppBootstrapSharedRefs.ts
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
-import type { MyPageResponse, SessionUser, Tab } from '../types';
+import type { Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { MyPageResponse } from '../types/my-page';
 
 type RefreshMyPageForUser = (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
 type ResetReviewCaches = () => void;

--- a/src/hooks/useAppDataState.ts
+++ b/src/hooks/useAppDataState.ts
@@ -1,10 +1,8 @@
 import { useState } from 'react';
-import type {
-  AdminSummaryResponse,
-  BootstrapResponse,
-  FestivalItem,
-  MyPageResponse,
-} from '../types';
+import type { FestivalItem } from '../types/core';
+import type { BootstrapResponse } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
+import type { AdminSummaryResponse } from '../types/admin';
 import { useCommunityRouteState } from './app-data/useCommunityRouteState';
 import { useReviewCollectionState } from './app-data/useReviewCollectionState';
 

--- a/src/hooks/useAppFeedbackEffects.ts
+++ b/src/hooks/useAppFeedbackEffects.ts
@@ -1,7 +1,9 @@
 ﻿import { useEffect } from 'react';
 import { formatDistanceMeters } from '../lib/visits';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type { Place, SessionUser, StampLog } from '../types';
+import type { Place } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { StampLog } from '../types/review';
 
 interface UseAppFeedbackEffectsParams {
   selectedPlace: Place | null;

--- a/src/hooks/useAppMapActions.ts
+++ b/src/hooks/useAppMapActions.ts
@@ -3,7 +3,9 @@ import { claimStamp } from '../api/stampClient';
 import { getCurrentDevicePosition } from '../lib/geolocation';
 import { formatDistanceMeters } from '../lib/visits';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
-import type { DrawerState, Place, SessionUser, StampState, Tab } from '../types';
+import type { DrawerState, Place, Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { StampState } from '../types/review';
 import type { RouteStateCommitOptions } from './useAppRouteState';
 
 type HistoryMode = 'push' | 'replace';

--- a/src/hooks/useAppPagePaginationActions.ts
+++ b/src/hooks/useAppPagePaginationActions.ts
@@ -4,7 +4,9 @@ import { getReviewFeedPage } from '../api/reviewsClient';
 import { PaginationRuntimeConfig } from '../config/runtimeLimitConfig';
 import { toReviewSummaryList } from '../lib/reviews';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
-import type { MyPageResponse, Review, SessionUser } from '../types';
+import type { SessionUser } from '../types/auth';
+import type { Review } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 

--- a/src/hooks/useAppPageStageActions.ts
+++ b/src/hooks/useAppPageStageActions.ts
@@ -1,5 +1,5 @@
 import { useEventCallback } from './useEventCallback';
-import type { SessionUser } from '../types';
+import type { SessionUser } from '../types/auth';
 
 interface UseAppPageStageActionsParams {
   sessionUser: SessionUser | null;

--- a/src/hooks/useAppReviewActions.types.ts
+++ b/src/hooks/useAppReviewActions.types.ts
@@ -1,14 +1,9 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import type { RouteStateCommitOptions } from './useAppRouteState';
-import type {
-  Comment,
-  DrawerState,
-  MyPageResponse,
-  Place,
-  Review,
-  SessionUser,
-  Tab,
-} from '../types';
+import type { DrawerState, Place, Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { Comment, Review } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
 export type HistoryMode = 'push' | 'replace';

--- a/src/hooks/useAppReviewCrudActions.ts
+++ b/src/hooks/useAppReviewCrudActions.ts
@@ -8,7 +8,7 @@ import {
 import { toReviewSummary } from '../lib/reviews';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import { useReviewUIStore } from '../store/review-ui-store';
-import type { ReviewMood } from '../types';
+import type { ReviewMood } from '../types/core';
 import type { UseAppReviewActionsParams } from './useAppReviewActions.types';
 
 export function useAppReviewCrudActions({

--- a/src/hooks/useAppRouteActions.ts
+++ b/src/hooks/useAppRouteActions.ts
@@ -1,5 +1,8 @@
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import type { MyPageResponse, SessionUser, Tab, UserRoute } from '../types';
+import type { Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { UserRoute } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
 import { createPublishRouteHandler } from './app-route-actions/publishRouteAction';
 import { createToggleRouteLikeHandler } from './app-route-actions/routeLikeAction';
 import { useAppRouteActionStoreBindings } from './useAppRouteActionStoreBindings';

--- a/src/hooks/useAppRouteState.ts
+++ b/src/hooks/useAppRouteState.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect } from 'react';
 import { useAppMapStore } from '../store/app-map-store';
 import { useAppRouteStore } from '../store/app-route-store';
-import type { Tab } from '../types';
+import type { Tab } from '../types/core';
 import {
   clearAuthQueryParams,
   getInitialRouteState,

--- a/src/hooks/useAppShellNavigation.ts
+++ b/src/hooks/useAppShellNavigation.ts
@@ -1,4 +1,5 @@
-import type { DrawerState, MyPageTabKey, RoutePreview, SessionUser, Tab } from '../types';
+import type { DrawerState, MyPageTabKey, RoutePreview, Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
 import type { ReturnViewState } from '../store/app-ui-store';
 import type { RouteStateCommitOptions } from './useAppRouteState';
 import { createNavigateBackHandler } from './app-navigation/shellBackNavigation';

--- a/src/hooks/useAppStageActions.ts
+++ b/src/hooks/useAppStageActions.ts
@@ -1,6 +1,6 @@
 import { useCallback } from 'react';
 import type { RouteStateCommitOptions } from './useAppRouteState';
-import type { DrawerState, Place, RoutePreview } from '../types';
+import type { DrawerState, Place, RoutePreview } from '../types/core';
 
 interface UseAppStageActionsParams {
   selectedPlace: Place | null;

--- a/src/hooks/useAppTabDataLoaders.ts
+++ b/src/hooks/useAppTabDataLoaders.ts
@@ -1,15 +1,10 @@
 import { useCallback } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import type {
-  AdminSummaryResponse,
-  CommunityRouteSort,
-  Course,
-  MyPageResponse,
-  Review,
-  SessionUser,
-  Tab,
-  UserRoute,
-} from '../types';
+import type { CommunityRouteSort, Course, Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { Review, UserRoute } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
+import type { AdminSummaryResponse } from '../types/admin';
 import { createCommunityRouteLoader } from './app-tab-loaders/communityRouteLoader';
 import { createFeedReviewLoader } from './app-tab-loaders/feedReviewLoader';
 import { createAdminSummaryLoader, createMyPageSummaryLoader } from './app-tab-loaders/summaryLoaders';

--- a/src/hooks/useAppTabWarmup.ts
+++ b/src/hooks/useAppTabWarmup.ts
@@ -1,5 +1,8 @@
 import { useEffect } from 'react';
-import type { AdminSummaryResponse, MyPageResponse, SessionUser, Tab } from '../types';
+import type { Tab } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { MyPageResponse } from '../types/my-page';
+import type { AdminSummaryResponse } from '../types/admin';
 
 interface UseAppTabWarmupParams {
   activeTab: Tab;

--- a/src/hooks/useAppViewModels.ts
+++ b/src/hooks/useAppViewModels.ts
@@ -1,16 +1,9 @@
 import { useMemo } from 'react';
 import { calculateDistanceMeters, getLatestPlaceStamp, getTodayStampLog } from '../lib/visits';
-import type {
-  ApiStatus,
-  BootstrapResponse,
-  Category,
-  FestivalItem,
-  MyPageResponse,
-  Place,
-  Review,
-  RoutePreview,
-  SessionUser,
-} from '../types';
+import type { ApiStatus, Category, FestivalItem, Place, RoutePreview } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { BootstrapResponse, Review } from '../types/review';
+import type { MyPageResponse } from '../types/my-page';
 import {
   buildPlaceNameById,
   filterPlacesByCategory,

--- a/src/hooks/useGlobalNotifications.ts
+++ b/src/hooks/useGlobalNotifications.ts
@@ -1,7 +1,9 @@
 import { useNotificationActions } from './useNotificationActions';
 import { useNotificationLifecycle } from './useNotificationLifecycle';
 import { useNotificationStore } from '../store/notification-store';
-import type { MyPageResponse, MyPageTabKey, SessionUser } from '../types';
+import type { MyPageTabKey } from '../types/core';
+import type { SessionUser } from '../types/auth';
+import type { MyPageResponse } from '../types/my-page';
 
 interface UseGlobalNotificationsParams {
   sessionUser: SessionUser | null;

--- a/src/hooks/useNotificationActions.ts
+++ b/src/hooks/useNotificationActions.ts
@@ -1,5 +1,6 @@
 import { useCallback } from 'react';
-import type { MyPageTabKey, UserNotification } from '../types';
+import type { MyPageTabKey } from '../types/core';
+import type { UserNotification } from '../types/my-page';
 
 interface UseNotificationActionsParams {
   markNotificationReadInStore: (notificationId: string) => Promise<void>;

--- a/src/hooks/useNotificationLifecycle.ts
+++ b/src/hooks/useNotificationLifecycle.ts
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
-import type { MyPageResponse, SessionUser } from '../types';
+import type { SessionUser } from '../types/auth';
+import type { MyPageResponse } from '../types/my-page';
 
 interface UseNotificationLifecycleParams {
   sessionUser: SessionUser | null;

--- a/src/hooks/useSelectedPlaceReviewSync.ts
+++ b/src/hooks/useSelectedPlaceReviewSync.ts
@@ -2,7 +2,8 @@ import { useEffect } from 'react';
 import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
 import { getReviews } from '../api/reviewsClient';
 import { toReviewSummaryList } from '../lib/reviews';
-import type { Review, Tab } from '../types';
+import type { Tab } from '../types/core';
+import type { Review } from '../types/review';
 
 interface UseSelectedPlaceReviewSyncParams {
   activeTab: Tab;

--- a/test/unit/interface-locality-source-quality.test.ts
+++ b/test/unit/interface-locality-source-quality.test.ts
@@ -57,11 +57,11 @@ describe('interface locality source quality baseline', () => {
   });
 
   it('keeps frontend root type barrel usage from growing before locality splits', () => {
-    const rootTypeImportPattern = "from '../types\\|from '../../types";
+    const rootTypeImportPattern = "from '../types';\\|from '../../types';\\|from \"../types\";\\|from \"../../types\";";
 
-    expect(gitGrepCount(rootTypeImportPattern, ['src'])).toBeLessThanOrEqual(106);
-    expect(gitGrepCount(rootTypeImportPattern, ['src/components'])).toBeLessThanOrEqual(44);
-    expect(gitGrepCount(rootTypeImportPattern, ['src/hooks'])).toBeLessThanOrEqual(43);
+    expect(gitGrepCount(rootTypeImportPattern, ['src'])).toBeLessThanOrEqual(19);
+    expect(gitGrepCount(rootTypeImportPattern, ['src/components'])).toBe(0);
+    expect(gitGrepCount(rootTypeImportPattern, ['src/hooks'])).toBe(0);
   });
 
   it('keeps wide stage prop coupling from growing before stage-local props are split', () => {


### PR DESCRIPTION
﻿## 요약

- `src/components`와 `src/hooks`에서 root `src/types.ts` barrel import를 제거하고, 타입 소유 모듈(`types/core`, `types/auth`, `types/review`, `types/my-page`, `types/admin`)을 직접 참조하도록 정리했습니다.
- public API DTO와 cross-domain model은 기존 `src/types/*`에 유지했습니다.
- source-quality gate를 exact root barrel import 기준으로 고정해 components/hooks에서는 root barrel import가 다시 생기지 않도록 했습니다.

## 범위 고정

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음

## 검증

- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`

## 근거

- Exact root barrel import: 전체 19개
- Exact root barrel import in `src/components`: 0개
- Exact root barrel import in `src/hooks`: 0개

Closes #259
