### PR TITLE
Refactor FastAPI contract import locality

### DIFF
--- a/backend/app/api_deps.py
+++ b/backend/app/api_deps.py
@@ -2,7 +2,7 @@ from fastapi import Depends, HTTPException, Request, status
 
 from .config import Settings, get_settings
 from .jwt_auth import ACCESS_TOKEN_COOKIE, read_access_token
-from .models import SessionUser
+from .model_contracts.auth import SessionUser
 
 
 def get_session_user(request: Request, app_settings: Settings = Depends(get_settings)) -> SessionUser | None:

--- a/backend/app/jwt_auth.py
+++ b/backend/app/jwt_auth.py
@@ -9,7 +9,7 @@ import jwt
 from fastapi import Response
 
 from .config import Settings
-from .models import SessionUser
+from .model_contracts.auth import SessionUser
 
 ACCESS_TOKEN_COOKIE = "jamissue_access_token"
 logger = logging.getLogger(__name__)

--- a/backend/app/repository_support_comments.py
+++ b/backend/app/repository_support_comments.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from .db_models import UserComment
-from .models import CommentOut
+from .model_contracts.review import CommentOut
 from .repository_support_time import format_datetime
 
 

--- a/backend/app/repository_support_serializers.py
+++ b/backend/app/repository_support_serializers.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from .db_models import MapPlace, User
-from .models import AdminPlaceOut, PlaceOut, SessionUser
+from .model_contracts.admin import AdminPlaceOut
+from .model_contracts.auth import SessionUser
+from .model_contracts.content import PlaceOut
 from .repository_support_time import format_datetime
 
 

--- a/backend/app/user_routes.py
+++ b/backend/app/user_routes.py
@@ -8,7 +8,8 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session, joinedload
 
 from .db_models import MapPlace, UserRoute, UserRouteLike, UserRoutePlace, UserStamp
-from .models import RouteSort, UserRouteCreate, UserRouteLikeResponse, UserRouteOut
+from .model_contracts.core import RouteSort
+from .model_contracts.routes import UserRouteCreate, UserRouteLikeResponse, UserRouteOut
 from .repository_support import format_datetime, utcnow_naive
 from .repositories.user_data_repository import get_or_create_user
 from .runtime_config import FastApiRouteRuntimeConfig

--- a/test/unit/interface-locality-source-quality.test.ts
+++ b/test/unit/interface-locality-source-quality.test.ts
@@ -76,6 +76,6 @@ describe('interface locality source quality baseline', () => {
   });
 
   it('keeps FastAPI compatibility model facade imports from growing', () => {
-    expect(gitGrepCount('from \\.models import', ['backend/app'])).toBeLessThanOrEqual(5);
+    expect(gitGrepCount('from \\.models import', ['backend/app'])).toBe(0);
   });
 });


### PR DESCRIPTION
﻿## 요약

- FastAPI active app code의 `.models` compatibility facade import 5곳을 `model_contracts/*` 직접 import로 전환했습니다.
- `models.py` facade는 compatibility boundary로 유지했습니다.
- source-quality gate를 `backend/app`의 `.models` facade import 0개로 강화했습니다.

## 범위 고정

- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- Kakao/Naver OAuth 성공 경로 변경 없음

## 검증

- `rg -n "from \\.models import|import .*\\.models" backend\\app`: match 0개
- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts`
- `..\\.tools\\python313\\python.exe -m pytest tests` from `backend`: 95 passed, pytest cache write warning 2건
- `npm.cmd run typecheck`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\\.tools\\python313\\python.exe .tmp\\check_utf8_integrity.py --staged`

Closes #260
