### PR TITLE
Document 1.2.9 interface locality traceability

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Docs Guide
 
-문서 기준은 아래 2개입니다.
+JamIssue 문서는 아래 기준으로 관리합니다.
 
 ## 1. 제품 기준 문서
 
@@ -13,12 +13,12 @@
 - [growgardens-deploy-runbook.md](growgardens-deploy-runbook.md)
   - `main` 배포 기준
   - GitHub Actions 배포 방식
-  - GitHub / Cloudflare / Naver에 넣어야 할 키 위치
+  - GitHub / Cloudflare / Naver / Kakao에 넣어야 할 키 위치
 - [data-operations-runbook.md](data-operations-runbook.md)
-  - 장소/이미지/공공데이터 운영 수정 절차
+  - 장소, 이미지, 공공데이터 운영 수정 절차
   - 전체 리셋 및 재적재 절차
 
-## 세부 설계 문서
+## 3. 세부 설계 문서
 
 - [screen-spec.md](screen-spec.md)
 - [community-routes.md](community-routes.md)
@@ -26,6 +26,10 @@
 - [account-identity-schema.md](account-identity-schema.md)
 - [code-flow-diagrams.md](code-flow-diagrams.md)
 - [operations-refactor-roadmap.md](operations-refactor-roadmap.md)
+
+## 4. 리팩터링 추적 문서
+
 - [worker-backend-solid-traceability.md](worker-backend-solid-traceability.md)
 - [config-hardening-traceability.md](config-hardening-traceability.md)
 - [interface-locality-baseline.md](interface-locality-baseline.md)
+- [interface-locality-traceability.md](interface-locality-traceability.md)

--- a/docs/interface-locality-baseline.md
+++ b/docs/interface-locality-baseline.md
@@ -12,7 +12,7 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/255
 
 ## 목적
 
-공용 타입을 전부 없애는 것이 목표가 아닙니다. public API contract와 cross-domain model은 중앙에 유지하고, runtime/service dependency, Supabase row, mapper input, stage/view props처럼 구현 내부에 가까운 인터페이스는 소유 모듈 근처로 이동하는 것이 목표입니다.
+공용 타입을 없애는 것이 목표가 아닙니다. public API contract와 cross-domain model은 중앙에 유지하고, runtime/service dependency, Supabase row, mapper input, stage/view props처럼 구현 내부에 가까운 인터페이스는 소유 모듈 근처로 이동하는 것이 목표입니다.
 
 ## 변경 금지 범위
 
@@ -21,18 +21,18 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/255
 - DB schema 변경 없음
 - Kakao/Naver REST OAuth 성공 경로 변경 없음
 - public API DTO 제거 없음
-- compatibility facade 즉시 삭제 없음
+- compatibility facade 즉시 제거 없음
 
-## 현재 기준선
+## 초기 기준선
 
-| 영역 | 현재 수치 | 해석 | 후속 이슈 |
+| 영역 | 초기 수치 | 해석 | 후속 이슈 |
 | --- | ---: | --- | --- |
 | Worker central type exports | 28 | `WorkerEnv`, Supabase row, DTO, service contract, route runtime이 한 파일에 공존 | #256, #257 |
-| Worker runtime/service contract mentions in central types | 13 | `RouteRuntime`, `Worker*Service`, review interaction deps가 중앙 types에 있음 | #256 |
+| Worker runtime/service contract mentions in central types | 13 | `RouteRuntime`, `Worker*Service`, review interaction deps가 중앙 types에 존재 | #256 |
 | Frontend root `src/types` imports | 106 | API DTO와 presentation/hook import가 같은 barrel을 공유 | #259 |
 | Frontend component root type imports | 44 | presentation component가 root barrel을 직접 참조 | #259 |
-| Frontend hook root type imports | 43 | coordinator/hook 계층이 root barrel에 넓게 의존 | #259 |
-| Wide `AppPageStageProps` coupling references | 11 | feed/course/my view가 큰 stage props에서 `Pick`으로 일부만 사용 | #258 |
+| Frontend hook root type imports | 43 | coordinator/hook 계층도 root barrel에 넓게 의존 | #259 |
+| Wide `AppPageStageProps` coupling references | 11 | feed/course/my view가 넓은 stage props에서 `Pick`으로 일부만 사용 | #258 |
 | FastAPI `.models` facade imports | 5 | active backend 일부가 compatibility facade를 직접 import | #260 |
 
 ## 후속 작업 매핑
@@ -48,16 +48,17 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/255
 
 ## Source Quality Gate
 
-`test/unit/interface-locality-source-quality.test.ts`는 현재 기준선보다 interface locality가 후퇴하지 않도록 막습니다.
+`test/unit/interface-locality-source-quality.test.ts`는 interface locality가 후퇴하지 않도록 막습니다.
 
-현재 기준:
+현재 게이트:
 
-- 중앙 Worker type export와 runtime/service contract mention은 늘어나면 안 됩니다.
-- frontend root type barrel import는 늘어나면 안 됩니다.
-- wide stage props coupling은 늘어나면 안 됩니다.
-- FastAPI `.models` facade import는 늘어나면 안 됩니다.
+- 중앙 Worker type export와 runtime/service contract mention 증가 방지
+- Worker data row/DTO contract가 중앙 `types.ts`로 되돌아가는 것 방지
+- `src/components`와 `src/hooks`의 root `src/types.ts` barrel import 재도입 방지
+- page-stage의 `Pick<AppPageStageProps>` 재도입 방지
+- FastAPI active app code의 `.models` facade import 재도입 방지
 
-후속 PR에서 수치가 줄어들면 gate는 그대로 통과합니다. 후속 PR은 필요한 때 threshold를 더 낮춰 다음 회귀 기준으로 갱신합니다.
+후속 PR에서 수치가 줄어들면 gate threshold도 낮춰 다음 회귀 기준으로 사용합니다.
 
 ## 완료 판단
 

--- a/docs/interface-locality-traceability.md
+++ b/docs/interface-locality-traceability.md
@@ -1,0 +1,100 @@
+# Interface Locality Traceability
+
+Scope-ID: `TSK-003-00-INTERFACE-LOCALITY-HARDENING`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/268
+Branch: `interface-locality-docs-traceability`
+Status: `candidate-docs`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/261
+
+이 문서는 1.2.9 refactoring candidate의 두 번째 축인 `TSK-003` interface locality hardening 결과를 repo 기준으로 추적합니다.
+
+## 목적
+
+공용 타입을 제거하는 것이 목적이 아닙니다. public API DTO와 cross-domain model은 중앙에 유지하고, 내부 구현 인터페이스는 실제 소유 모듈 근처로 이동해 변경 영향 범위를 줄이는 것이 목적입니다.
+
+## 변경 금지 범위
+
+- 사용자-facing copy 변경 없음
+- API path/response shape 변경 없음
+- DB schema 변경 없음
+- Kakao/Naver REST OAuth 성공 경로 변경 없음
+- public API DTO 제거 없음
+- compatibility facade 즉시 제거 없음
+
+## 설계 결정
+
+| 영역 | 결정 |
+| --- | --- |
+| Worker public primitive | `deploy/api-worker-shell/types.ts`에는 `WorkerEnv`, session user, JSON primitive만 유지 |
+| Worker runtime/service contract | route runtime과 service dependency type은 runtime/service/domain 소유 위치로 이동 |
+| Worker row/read model | Supabase row, base-data row, mapper input은 repository/mapper 근처로 이동 |
+| Frontend stage props | `AppPageStageProps` 중심 `Pick` 의존을 feed/course/my stage-local props로 분리 |
+| Frontend type import | component/hook의 root `src/types.ts` barrel import를 domain type import로 전환 |
+| FastAPI contracts | active app code는 `.models` compatibility facade 대신 `model_contracts/*`를 직접 import |
+
+## Sub-Issue Trace
+
+| Scope-ID | Issue | Branch | PR | Main merge SHA | 완료 근거 |
+| --- | --- | --- | --- | --- | --- |
+| `TSK-003-01` | [#255](https://github.com/STH-1-Class-One-Group/JamIssue/issues/255) | `interface-locality-audit` | [#262](https://github.com/STH-1-Class-One-Group/JamIssue/pull/262) | `852728bda993710c09de8adb07711be0d5cb5968` | baseline 문서와 source-quality gate 추가 |
+| `TSK-003-02` | [#256](https://github.com/STH-1-Class-One-Group/JamIssue/issues/256) | `worker-runtime-contract-locality` | [#263](https://github.com/STH-1-Class-One-Group/JamIssue/pull/263) | `5d88d6a15536c6ac04ed58bc4d26ca43d01ad8d7` | Worker runtime/service contract locality 정리 |
+| `TSK-003-03` | [#257](https://github.com/STH-1-Class-One-Group/JamIssue/issues/257) | `worker-data-contract-locality` | [#264](https://github.com/STH-1-Class-One-Group/JamIssue/pull/264), [#265](https://github.com/STH-1-Class-One-Group/JamIssue/pull/265) | `23b65010575e3f033dff44ec04f6801199b02ce8`, `3464b303004ca6409ca4c1b2d1ed96b313844cd5` | Worker data row/DTO contract locality 정리 |
+| `TSK-003-04` | [#258](https://github.com/STH-1-Class-One-Group/JamIssue/issues/258) | `frontend-stage-prop-locality` | [#266](https://github.com/STH-1-Class-One-Group/JamIssue/pull/266) | `b7140db222b99cbc15c88e1eaefc0d2f1fc0202e` | stage-local props 분리 |
+| `TSK-003-05` | [#259](https://github.com/STH-1-Class-One-Group/JamIssue/issues/259) | `frontend-type-import-locality` | [#267](https://github.com/STH-1-Class-One-Group/JamIssue/pull/267) | `d589761066188632a72f6adbb6b6099b61fd8a35` | component/hook root barrel import 0개로 축소 |
+| `TSK-003-06` | [#260](https://github.com/STH-1-Class-One-Group/JamIssue/issues/260) | `fastapi-contract-import-locality` | [#268](https://github.com/STH-1-Class-One-Group/JamIssue/pull/268) | `3242d0ae6fa88c617f0bbcc681b469926fd06c31` | FastAPI `.models` facade import 0개로 축소 |
+| `TSK-003-07` | [#261](https://github.com/STH-1-Class-One-Group/JamIssue/issues/261) | `interface-locality-docs-traceability` | TBD | TBD | Wiki, roadmap, release note traceability 정리 |
+
+## Source Quality Gate
+
+`test/unit/interface-locality-source-quality.test.ts`가 다음 회귀를 막습니다.
+
+- Worker central type surface가 다시 커지는 경우
+- Worker runtime/service/data contract가 central `types.ts`로 되돌아가는 경우
+- `src/components` 또는 `src/hooks`에서 root `src/types.ts` barrel import가 다시 생기는 경우
+- page-stage에서 `Pick<AppPageStageProps>`가 되살아나는 경우
+- FastAPI active app code가 `.models` facade import로 되돌아가는 경우
+
+## 검증 기준
+
+각 구현 PR에서 공통으로 확인한 기준입니다.
+
+- `npm.cmd run check:numeric-literals`
+- `npm.cmd run lint`
+- `npm.cmd run typecheck`
+- `npm.cmd run test:unit`
+- `npm.cmd run build`
+- `git diff --check`
+- UTF-8 integrity check
+- GitHub Actions CI
+- CodeQL
+
+FastAPI 변경 PR에서는 아래 검증을 추가했습니다.
+
+- `cd backend`
+- `..\.tools\python313\python.exe -m pytest tests`
+
+## 1.2.9 후보 범위
+
+`1.2.9`는 1.2.8 이후 refactoring candidate입니다.
+
+포함 범위:
+
+- `TSK-002` repo-wide config hardening
+- `TSK-003` repo-wide interface-locality hardening
+- numeric literal quality gate
+- interface-locality source-quality gate
+- Worker-first BFF와 FastAPI local/fallback 경계 문서화
+
+제외 범위:
+
+- 신규 사용자 기능
+- API 계약 변경
+- DB migration
+- OAuth provider 동작 변경
+- 시각 redesign
+
+## 남은 확인
+
+현재 GitHub CLI token에는 `security_events` scope가 없어 Dependabot/code-scanning alert endpoint가 404/401을 반환합니다. 최종 릴리즈 전에는 권한 있는 GitHub Security 경로로 open alert 상태를 재확인해야 합니다.

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -19,6 +19,7 @@
 3. FastAPI repository/service 예외 계약 정리
 4. Worker route/data/security 경계 분리
 5. `repository_normalized.py` 잔여 facade 축소
+6. 1.2.9 refactoring candidate 추적성 정리
 
 ## 1. 운영 스모크 테스트 자동화
 
@@ -221,6 +222,41 @@
 - `repository_normalized.py`가 더 이상 프로젝트의 만능 파일이 아니다.
 - `main.py -> service -> repository` 흐름이 대부분의 경로에서 일관된다.
 - 리뷰/스탬프/프로필 변경 시 관련 파일 경계가 명확하다.
+
+## 3-1. Repo-wide interface locality hardening
+
+상태: DONE
+우선순위: 높음
+성격: 1.2.9 refactoring candidate / SOLID / interface locality
+
+### 배경
+1.2.9의 config hardening 이후에도 내부 구현 인터페이스 일부가 중앙 barrel 또는 compatibility facade에 남아 있었습니다. 이 상태에서는 실제 소유 모듈과 타입 정의 위치가 멀어져 변경 영향 범위를 판단하기 어렵습니다.
+
+### 목표
+공용 타입을 제거하지 않고, public API DTO와 cross-domain model은 중앙에 유지합니다. 대신 runtime/service dependency, Supabase row, mapper input, stage/view props처럼 구현 내부에 가까운 인터페이스는 소유 모듈 근처로 이동합니다.
+
+### 완료
+- [x] parent issue #254와 child issue #255~#261로 작업 단위를 materialize
+- [x] `docs/interface-locality-baseline.md`와 source-quality gate 추가
+- [x] Worker runtime/service contract를 runtime/service/domain 소유 위치로 이동
+- [x] Worker data row/DTO contract를 repository/mapper 근처로 이동
+- [x] `AppPageStageProps` 중심 `Pick` 의존을 stage-local props로 축소
+- [x] `src/components`와 `src/hooks`의 root `src/types.ts` barrel import를 0개로 축소
+- [x] FastAPI active app code의 `.models` facade import를 0개로 축소
+
+### 완료 근거
+| Issue | PR | Main merge SHA |
+| --- | --- | --- |
+| #255 | #262 | `852728bda993710c09de8adb07711be0d5cb5968` |
+| #256 | #263 | `5d88d6a15536c6ac04ed58bc4d26ca43d01ad8d7` |
+| #257 | #264, #265 | `23b65010575e3f033dff44ec04f6801199b02ce8`, `3464b303004ca6409ca4c1b2d1ed96b313844cd5` |
+| #258 | #266 | `b7140db222b99cbc15c88e1eaefc0d2f1fc0202e` |
+| #259 | #267 | `d589761066188632a72f6adbb6b6099b61fd8a35` |
+| #260 | #268 | `3242d0ae6fa88c617f0bbcc681b469926fd06c31` |
+
+### 남은 후속
+- [ ] #261에서 1.2.9 Wiki release note와 roadmap mirror를 final SHA 기준으로 갱신
+- [ ] 최종 릴리즈 전 Dependabot/code-scanning open alert 상태를 권한 있는 Security 경로로 재확인
 
 ## 4. Worker route/data/security 경계 분리
 


### PR DESCRIPTION
﻿## 요약

- `TSK-003` interface-locality 결과를 repo traceability 문서로 추가했습니다.
- `docs/README.md`를 한글/Repo-safe 링크 기준으로 복원했습니다.
- `docs/interface-locality-baseline.md`의 깨진 한글을 복원하고, `docs/operations-refactor-roadmap.md`에 1.2.9 interface locality 완료 근거를 추가했습니다.

## Wiki

- `.tmp-wiki/`에는 `Release-Notes-1.2.9`, `Release-Notes`, `Refactor-Roadmap`, `Home`, `_Sidebar` 갱신안이 준비되어 있습니다.
- Wiki repo는 main repo PR merge 후 최종 PR 번호와 main SHA를 반영해 별도 commit/push합니다.
- `.tmp-wiki/`는 main repo에 stage하지 않았습니다.

## 검증

- `npm.cmd run check:numeric-literals`
- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts`
- `git diff --check`
- `git -C .tmp-wiki diff --check`
- UTF-8 changed/staged check
- Wiki-safe link check

Refs #261
