### PR TITLE
Update 1.2.9 reissue traceability

### DIFF
--- a/docs/interface-locality-traceability.md
+++ b/docs/interface-locality-traceability.md
@@ -1,18 +1,11 @@
 # Interface Locality Traceability
 
 Scope-ID: `TSK-003-00-INTERFACE-LOCALITY-HARDENING`
-Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
-PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/268
-Branch: `interface-locality-docs-traceability`
-Status: `candidate-docs`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/254
-Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/261
+Status: `release-reissue-ready`
+Release: `release-v1.2.9`
 
-이 문서는 1.2.9 refactoring candidate의 두 번째 축인 `TSK-003` interface locality hardening 결과를 repo 기준으로 추적합니다.
-
-## 목적
-
-공용 타입을 제거하는 것이 목적이 아닙니다. public API DTO와 cross-domain model은 중앙에 유지하고, 내부 구현 인터페이스는 실제 소유 모듈 근처로 이동해 변경 영향 범위를 줄이는 것이 목적입니다.
+이 문서는 `1.2.9` interface-locality 리팩터링의 실제 구현 근거를 repo 기준으로 추적합니다. 목적은 공용 타입을 없애는 것이 아니라, public API DTO와 cross-domain model은 중앙에 유지하고 내부 구현 인터페이스는 소유 모듈 근처로 이동하는 것입니다.
 
 ## 변경 금지 범위
 
@@ -27,38 +20,41 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/261
 
 | 영역 | 결정 |
 | --- | --- |
-| Worker public primitive | `deploy/api-worker-shell/types.ts`에는 `WorkerEnv`, session user, JSON primitive만 유지 |
-| Worker runtime/service contract | route runtime과 service dependency type은 runtime/service/domain 소유 위치로 이동 |
-| Worker row/read model | Supabase row, base-data row, mapper input은 repository/mapper 근처로 이동 |
-| Frontend stage props | `AppPageStageProps` 중심 `Pick` 의존을 feed/course/my stage-local props로 분리 |
-| Frontend type import | component/hook의 root `src/types.ts` barrel import를 domain type import로 전환 |
+| Worker public primitive | `deploy/api-worker-shell/types.ts`에는 `WorkerEnv`, `WorkerSessionUser`, `WorkerJsonRecord`, `AuthProviderKey`만 유지 |
+| Worker runtime/service contract | route runtime과 service dependency type은 runtime/service/domain 소유 위치에 유지 |
+| Worker row/read model | Supabase row, base-data row, mapper input은 base-data repository/mapper 근처에 유지 |
+| Frontend stage props | `AppPageStageProps`의 넓은 `Pick` 의존을 stage-local props로 축소 |
+| Frontend type import | `src/components`와 `src/hooks`의 root `src/types.ts` barrel import를 0개로 유지 |
 | FastAPI contracts | active app code는 `.models` compatibility facade 대신 `model_contracts/*`를 직접 import |
 
 ## Sub-Issue Trace
 
 | Scope-ID | Issue | Branch | PR | Main merge SHA | 완료 근거 |
 | --- | --- | --- | --- | --- | --- |
-| `TSK-003-01` | [#255](https://github.com/STH-1-Class-One-Group/JamIssue/issues/255) | `interface-locality-audit` | [#262](https://github.com/STH-1-Class-One-Group/JamIssue/pull/262) | `852728bda993710c09de8adb07711be0d5cb5968` | baseline 문서와 source-quality gate 추가 |
-| `TSK-003-02` | [#256](https://github.com/STH-1-Class-One-Group/JamIssue/issues/256) | `worker-runtime-contract-locality` | [#263](https://github.com/STH-1-Class-One-Group/JamIssue/pull/263) | `5d88d6a15536c6ac04ed58bc4d26ca43d01ad8d7` | Worker runtime/service contract locality 정리 |
-| `TSK-003-03` | [#257](https://github.com/STH-1-Class-One-Group/JamIssue/issues/257) | `worker-data-contract-locality` | [#264](https://github.com/STH-1-Class-One-Group/JamIssue/pull/264), [#265](https://github.com/STH-1-Class-One-Group/JamIssue/pull/265) | `23b65010575e3f033dff44ec04f6801199b02ce8`, `3464b303004ca6409ca4c1b2d1ed96b313844cd5` | Worker data row/DTO contract locality 정리 |
+| `TSK-003-01` | [#255](https://github.com/STH-1-Class-One-Group/JamIssue/issues/255) | `interface-locality-audit` | [#262](https://github.com/STH-1-Class-One-Group/JamIssue/pull/262), [#270](https://github.com/STH-1-Class-One-Group/JamIssue/pull/270) | `852728bda993710c09de8adb07711be0d5cb5968`, `da277d7f446198912cbfed2dffb5980cffeef2ea` | source-quality gate 추가 및 실제 코드 기준 회귀 조건 보강 |
+| `TSK-003-02` | [#256](https://github.com/STH-1-Class-One-Group/JamIssue/issues/256) | `worker-runtime-contract-locality` | [#263](https://github.com/STH-1-Class-One-Group/JamIssue/pull/263), [#270](https://github.com/STH-1-Class-One-Group/JamIssue/pull/270) | `5d88d6a15536c6ac04ed58bc4d26ca43d01ad8d7`, `da277d7f446198912cbfed2dffb5980cffeef2ea` | `RouteRuntime`에서 Supabase row/mapper dependency 제거 |
+| `TSK-003-03` | [#257](https://github.com/STH-1-Class-One-Group/JamIssue/issues/257) | `worker-data-contract-locality` | [#264](https://github.com/STH-1-Class-One-Group/JamIssue/pull/264), [#265](https://github.com/STH-1-Class-One-Group/JamIssue/pull/265), [#270](https://github.com/STH-1-Class-One-Group/JamIssue/pull/270) | `23b65010575e3f033dff44ec04f6801199b02ce8`, `3464b303004ca6409ca4c1b2d1ed96b313844cd5`, `da277d7f446198912cbfed2dffb5980cffeef2ea` | base-data row/mapper contract를 route surface 밖으로 격리 |
 | `TSK-003-04` | [#258](https://github.com/STH-1-Class-One-Group/JamIssue/issues/258) | `frontend-stage-prop-locality` | [#266](https://github.com/STH-1-Class-One-Group/JamIssue/pull/266) | `b7140db222b99cbc15c88e1eaefc0d2f1fc0202e` | stage-local props 분리 |
-| `TSK-003-05` | [#259](https://github.com/STH-1-Class-One-Group/JamIssue/issues/259) | `frontend-type-import-locality` | [#267](https://github.com/STH-1-Class-One-Group/JamIssue/pull/267) | `d589761066188632a72f6adbb6b6099b61fd8a35` | component/hook root barrel import 0개로 축소 |
-| `TSK-003-06` | [#260](https://github.com/STH-1-Class-One-Group/JamIssue/issues/260) | `fastapi-contract-import-locality` | [#268](https://github.com/STH-1-Class-One-Group/JamIssue/pull/268) | `3242d0ae6fa88c617f0bbcc681b469926fd06c31` | FastAPI `.models` facade import 0개로 축소 |
-| `TSK-003-07` | [#261](https://github.com/STH-1-Class-One-Group/JamIssue/issues/261) | `interface-locality-docs-traceability` | TBD | TBD | Wiki, roadmap, release note traceability 정리 |
+| `TSK-003-05` | [#259](https://github.com/STH-1-Class-One-Group/JamIssue/issues/259) | `frontend-type-import-locality` | [#267](https://github.com/STH-1-Class-One-Group/JamIssue/pull/267) | `d589761066188632a72f6adbb6b6099b61fd8a35` | component/hook root barrel import 0개 |
+| `TSK-003-06` | [#260](https://github.com/STH-1-Class-One-Group/JamIssue/issues/260) | `fastapi-contract-import-locality` | [#268](https://github.com/STH-1-Class-One-Group/JamIssue/pull/268) | `3242d0ae6fa88c617f0bbcc681b469926fd06c31` | FastAPI `.models` facade active import 0개 |
+| `TSK-003-07` | [#261](https://github.com/STH-1-Class-One-Group/JamIssue/issues/261) | `release-129-reissue-traceability` | [#269](https://github.com/STH-1-Class-One-Group/JamIssue/pull/269), docs follow-up PR | `f765939d78558e6f1fbb9fd575f4412c49842951`, final docs merge SHA는 PR merge 후 issue/wiki에 기록 | release note, roadmap, issue evidence 갱신 |
 
 ## Source Quality Gate
 
-`test/unit/interface-locality-source-quality.test.ts`가 다음 회귀를 막습니다.
+`test/unit/interface-locality-source-quality.test.ts`와 `test/unit/worker-source-quality.test.ts`가 아래 회귀를 막습니다.
 
 - Worker central type surface가 다시 커지는 경우
 - Worker runtime/service/data contract가 central `types.ts`로 되돌아가는 경우
+- `RouteRuntime`이 Supabase row, mapper, static row loader를 다시 노출하는 경우
+- Worker test가 global Worker type barrel에서 local contract를 import하는 경우
+- Worker service constructor dependency가 `any`로 회귀하는 경우
 - `src/components` 또는 `src/hooks`에서 root `src/types.ts` barrel import가 다시 생기는 경우
 - page-stage에서 `Pick<AppPageStageProps>`가 되살아나는 경우
 - FastAPI active app code가 `.models` facade import로 되돌아가는 경우
 
 ## 검증 기준
 
-각 구현 PR에서 공통으로 확인한 기준입니다.
+최종 보정 PR #270에서 아래 검증을 통과했습니다.
 
 - `npm.cmd run check:numeric-literals`
 - `npm.cmd run lint`
@@ -67,17 +63,15 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/261
 - `npm.cmd run build`
 - `git diff --check`
 - UTF-8 integrity check
-- GitHub Actions CI
-- CodeQL
-
-FastAPI 변경 PR에서는 아래 검증을 추가했습니다.
-
 - `cd backend`
 - `..\.tools\python313\python.exe -m pytest tests`
+- main CI: https://github.com/STH-1-Class-One-Group/JamIssue/actions/runs/25645927280
+- production-smoke: https://github.com/STH-1-Class-One-Group/JamIssue/actions/runs/25645927278
+- CodeQL: https://github.com/STH-1-Class-One-Group/JamIssue/actions/runs/25645926730, https://github.com/STH-1-Class-One-Group/JamIssue/actions/runs/25645926750
+- Dependabot open alert: 0건
+- Code scanning open alert: 0건
 
-## 1.2.9 후보 범위
-
-`1.2.9`는 1.2.8 이후 refactoring candidate입니다.
+## 1.2.9 재발행 범위
 
 포함 범위:
 
@@ -86,6 +80,7 @@ FastAPI 변경 PR에서는 아래 검증을 추가했습니다.
 - numeric literal quality gate
 - interface-locality source-quality gate
 - Worker-first BFF와 FastAPI local/fallback 경계 문서화
+- 실제 코드 기준 Worker interface-locality 보정 PR #270
 
 제외 범위:
 
@@ -95,6 +90,6 @@ FastAPI 변경 PR에서는 아래 검증을 추가했습니다.
 - OAuth provider 동작 변경
 - 시각 redesign
 
-## 남은 확인
+## 최종 확인
 
-현재 GitHub CLI token에는 `security_events` scope가 없어 Dependabot/code-scanning alert endpoint가 404/401을 반환합니다. 최종 릴리즈 전에는 권한 있는 GitHub Security 경로로 open alert 상태를 재확인해야 합니다.
+`release-v1.2.9`는 docs follow-up PR merge 후 새 final main SHA를 기준으로 삭제 후 재생성합니다. 최종 tag target, Wiki commit, issue close 근거는 #254와 #261에 기록합니다.

--- a/docs/operations-refactor-roadmap.md
+++ b/docs/operations-refactor-roadmap.md
@@ -19,7 +19,7 @@
 3. FastAPI repository/service 예외 계약 정리
 4. Worker route/data/security 경계 분리
 5. `repository_normalized.py` 잔여 facade 축소
-6. 1.2.9 refactoring candidate 추적성 정리
+6. 1.2.9 refactoring release 추적성 정리
 
 ## 1. 운영 스모크 테스트 자동화
 
@@ -227,7 +227,7 @@
 
 상태: DONE
 우선순위: 높음
-성격: 1.2.9 refactoring candidate / SOLID / interface locality
+성격: 1.2.9 refactoring release / SOLID / interface locality
 
 ### 배경
 1.2.9의 config hardening 이후에도 내부 구현 인터페이스 일부가 중앙 barrel 또는 compatibility facade에 남아 있었습니다. 이 상태에서는 실제 소유 모듈과 타입 정의 위치가 멀어져 변경 영향 범위를 판단하기 어렵습니다.


### PR DESCRIPTION
## 목적

PR #270으로 실제 코드 기준 interface-locality 보정을 마친 뒤, repo 문서의 1.2.9 추적성을 재발행 흐름에 맞게 갱신합니다.

## 변경 사항

- `docs/interface-locality-traceability.md`의 후보/권한 제한 문구를 제거합니다.
- PR #270, merge SHA `da277d7f446198912cbfed2dffb5980cffeef2ea`, main Actions, Security 0건 근거를 기록합니다.
- `docs/operations-refactor-roadmap.md`의 `candidate` 표기를 정식 refactoring release로 정정합니다.

## 검증

- `git diff --check`
- UTF-8 integrity check
- 문서 내 `candidate`, `security_events`, 구 Wiki SHA 잔존 검사

## 추적

Refs #254
Refs #255
Refs #256
Refs #257
Refs #261