### PR TITLE
Record Worker residual boundary audit gate

### DIFF
--- a/reports/completion/TSK-004-01-worker-residual-boundary-audit.md
+++ b/reports/completion/TSK-004-01-worker-residual-boundary-audit.md
@@ -1,0 +1,80 @@
+# TSK-004-01 Worker Residual Boundary Audit
+
+Scope-ID: `TSK-004-01-WORKER-RESIDUAL-BOUNDARY-AUDIT`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/273
+PR: `TBD-TSK-004-01-WORKER-RESIDUAL-BOUNDARY-AUDIT`
+Branch: `worker-residual-boundary-audit`
+Status: `validated-local`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/273
+
+## Purpose
+
+Worker-first backend의 잔여 경계 문제를 정성 평가가 아니라 실제 코드 계측값으로 고정한다. 이 보고서는 #274~#276 구현 전에 기준선을 만들고, 후속 PR이 같은 결합을 늘리지 못하도록 source-quality gate를 추가한 근거다.
+
+## Current Decisions
+
+- 이 작업은 구현 전 audit/gate 슬라이스다.
+- 외부 REST API path, response shape, DB schema, 사용자-facing copy, Kakao/Naver OAuth 성공 경로는 변경하지 않는다.
+- `deploy/api-worker-shell/.wrangler/tmp` 생성물은 생산 source-quality gate 대상에서 제외한다.
+- 후속 child issue는 이 기준선보다 결합 수치를 줄이거나, 불가피한 예외를 명시 근거와 함께 갱신해야 한다.
+
+## Audit Method
+
+재검증 명령은 아래와 같다.
+
+```powershell
+rg -n "\bany\b|Promise<any>|env:\s*any|Map<any|any\[\]|category:\s*any" deploy/api-worker-shell --glob "*.ts"
+rg -n "supabaseRequest|export async function|export function|handleFestivals|handleBannerEvents|handleFestivalImport" deploy/api-worker-shell/services/*.ts deploy/api-worker-shell/services/*-domain/*.ts
+```
+
+추가 계측은 `Path.read_text(encoding="utf-8")` 기반의 line/char/pattern counter로 수행했다.
+
+## Inventory
+
+| File | Lines | Chars | Objective Findings |
+| --- | ---: | ---: | --- |
+| `deploy/api-worker-shell/services/festivals.ts` | 194 | 22,310 | `supabaseRequest` 9, exported handlers 3, `any` 3, `env:any` 1, `any[]` 1 |
+| `deploy/api-worker-shell/services/admin.ts` | 118 | 4,040 | `any` 6, `env:any` 5, `category:any` 1 |
+| `deploy/api-worker-shell/services/notifications.ts` | 61 | 8,420 | `supabaseRequest` 11, exported handlers 5, implicit env signatures 10 |
+| `deploy/api-worker-shell/services/stamps.ts` | 53 | 6,778 | `supabaseRequest` 10, implicit request body reader 1, implicit env signature 1 |
+| `deploy/api-worker-shell/services/auth.ts` | 257 | 8,750 | `Promise<any>` 2, exported handlers 8 |
+| `deploy/api-worker-shell/services/review-interactions.ts` | 353 | 13,779 | `Promise<any>` 1, exported handlers 8 |
+| `deploy/api-worker-shell/services/review-domain/mapper.ts` | 116 | 4,568 | `any` 24, `Map<any` 4, `any[]` 9 |
+| `deploy/api-worker-shell/services/community-domain/mapper.ts` | 45 | 1,606 | `any` 7, `Map<any` 2, `any[]` 2 |
+| `deploy/api-worker-shell/services/my-domain/mapper.ts` | 26 | 1,233 | `any` 5, `Map<any` 1, `any[]` 1 |
+
+## Issue Scope
+
+- #273: 기준선 inventory와 source-quality gate 추가
+- #274: `services/festivals.ts` 책임 분리
+- #275: review/community/my mapper row contract typing
+- #276: admin/stamp/notification/auth/review-interaction handler contract typing
+- #277: 구현 PR merge 후 문서와 release traceability 정리
+
+## PR Scope
+
+이번 PR은 아래만 포함한다.
+
+- `test/unit/worker-source-quality.test.ts`에 TSK-004 residual boundary 기준선 gate 추가
+- `reports/completion/TSK-004-01-worker-residual-boundary-audit.md` 추가
+
+## Validation Results
+
+로컬 검증 결과는 아래와 같다.
+
+- [x] `npm.cmd run check:numeric-literals` 통과
+- [x] `npm.cmd run lint` 통과
+- [x] `npm.cmd run typecheck` 통과
+- [x] `npm.cmd run test:unit` 통과
+- [x] `npm.cmd run build` 통과
+- [x] `git diff --check` 통과
+- [x] UTF-8 integrity check 통과: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
+- [ ] PR checks: PR 생성 후 기록
+
+## Remaining Follow-Up Work
+
+- #274에서 festival domain split을 수행한다.
+- #275에서 mapper row contract를 domain-local 타입으로 좁힌다.
+- #276에서 service/handler contract를 명시 타입으로 좁힌다.
+- #277에서 최종 release candidate 문서와 이슈 evidence를 갱신한다.

--- a/reports/completion/TSK-004-01-worker-residual-boundary-audit.md
+++ b/reports/completion/TSK-004-01-worker-residual-boundary-audit.md
@@ -2,7 +2,7 @@
 
 Scope-ID: `TSK-004-01-WORKER-RESIDUAL-BOUNDARY-AUDIT`
 Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/273
-PR: `TBD-TSK-004-01-WORKER-RESIDUAL-BOUNDARY-AUDIT`
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/279
 Branch: `worker-residual-boundary-audit`
 Status: `validated-local`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -7,6 +7,11 @@ import { describe, expect, it } from 'vitest';
 const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const maxWorkerLineLength = 3_500;
 
+function countSourceMatches(file: string, pattern: RegExp): number {
+  const source = readFileSync(join(workspaceRoot, file), 'utf8');
+  return [...source.matchAll(pattern)].length;
+}
+
 function collectTrackedWorkerTsFiles(): string[] {
   const output = execFileSync(
     'git',
@@ -36,6 +41,112 @@ describe('worker source quality gates', () => {
         expect(lines.length, `${relativePath} should stay reviewable`).toBeGreaterThan(1);
       }
       expect(longestLine, `${relativePath} has a suspiciously long line`).toBeLessThanOrEqual(maxWorkerLineLength);
+    }
+  });
+
+  it('keeps the TSK-004 residual Worker boundary audit from worsening before child splits', () => {
+    const residualBoundaryBaseline = [
+      {
+        file: 'deploy/api-worker-shell/services/festivals.ts',
+        limits: {
+          any: 3,
+          envAny: 1,
+          anyArray: 1,
+          supabaseRequest: 9,
+          exportedHandlers: 3,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/admin.ts',
+        limits: {
+          any: 6,
+          envAny: 5,
+          categoryAny: 1,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/notifications.ts',
+        limits: {
+          supabaseRequest: 11,
+          exportedHandlers: 5,
+          implicitEnvSignatures: 10,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/stamps.ts',
+        limits: {
+          supabaseRequest: 10,
+          implicitRequestBodyReaders: 1,
+          implicitEnvSignatures: 1,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/auth.ts',
+        limits: {
+          promiseAny: 2,
+          exportedHandlers: 8,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/review-interactions.ts',
+        limits: {
+          promiseAny: 1,
+          exportedHandlers: 8,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/review-domain/mapper.ts',
+        limits: {
+          any: 24,
+          mapAny: 4,
+          anyArray: 9,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/community-domain/mapper.ts',
+        limits: {
+          any: 7,
+          mapAny: 2,
+          anyArray: 2,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/my-domain/mapper.ts',
+        limits: {
+          any: 5,
+          mapAny: 1,
+          anyArray: 1,
+        },
+      },
+    ];
+
+    for (const { file, limits } of residualBoundaryBaseline) {
+      const expectLimit = (key: keyof typeof limits, pattern: RegExp, label: string) => {
+        const limit = limits[key];
+        if (limit === undefined) {
+          return;
+        }
+        expect(countSourceMatches(file, pattern), `${file} ${label}`).toBeLessThanOrEqual(limit);
+      };
+
+      expectLimit('any', /\bany\b/g, 'any count');
+      expectLimit('envAny', /env:\s*any/g, 'env:any count');
+      expectLimit('categoryAny', /category:\s*any/g, 'category:any count');
+      expectLimit('promiseAny', /Promise<any>/g, 'Promise<any> count');
+      expectLimit('mapAny', /Map<any/g, 'Map<any count');
+      expectLimit('anyArray', /any\[\]/g, 'any[] count');
+      expectLimit('supabaseRequest', /\bsupabaseRequest\b/g, 'supabaseRequest count');
+      expectLimit('exportedHandlers', /^export\s+async\s+function\s+handle/gm, 'exported handler count');
+      expectLimit(
+        'implicitEnvSignatures',
+        /export\s+async\s+function\s+\w+\([^)]*\benv\b(?!\s*:)/g,
+        'implicit env signature count',
+      );
+      expectLimit(
+        'implicitRequestBodyReaders',
+        /async\s+function\s+readJsonBody\(request\)/g,
+        'implicit request body reader count',
+      );
     }
   });
 


### PR DESCRIPTION
## Summary

Refs #273

Parent issue: #272
Scope-ID: `TSK-004-01-WORKER-RESIDUAL-BOUNDARY-AUDIT`
Branch: `worker-residual-boundary-audit`

This PR records the Worker residual boundary audit baseline and adds a source-quality gate so later TSK-004 child issues cannot worsen the measured coupling categories before they split the boundaries.

## Changes

- Added a TSK-004 residual boundary baseline gate to `test/unit/worker-source-quality.test.ts`.
- Added `reports/completion/TSK-004-01-worker-residual-boundary-audit.md` with measured inventory and validation evidence.
- Preserved public REST paths, response shapes, DB schema, user-facing copy, and Kakao/Naver OAuth success paths.

## Measured Baseline

| File | Baseline |
| --- | --- |
| `deploy/api-worker-shell/services/festivals.ts` | 194 lines, 22,310 chars, `supabaseRequest` 9, exported handlers 3, `any` 3 |
| `deploy/api-worker-shell/services/admin.ts` | `any` 6, `env:any` 5, `category:any` 1 |
| `deploy/api-worker-shell/services/notifications.ts` | `supabaseRequest` 11, exported handlers 5, implicit env signatures 10 |
| `deploy/api-worker-shell/services/stamps.ts` | `supabaseRequest` 10, implicit body reader 1, implicit env signature 1 |
| `deploy/api-worker-shell/services/auth.ts` | `Promise<any>` 2, exported handlers 8 |
| `deploy/api-worker-shell/services/review-interactions.ts` | `Promise<any>` 1, exported handlers 8 |
| `deploy/api-worker-shell/services/review-domain/mapper.ts` | `any` 24, `Map<any` 4, `any[]` 9 |
| `deploy/api-worker-shell/services/community-domain/mapper.ts` | `any` 7, `Map<any` 2, `any[]` 2 |
| `deploy/api-worker-shell/services/my-domain/mapper.ts` | `any` 5, `Map<any` 1, `any[]` 1 |

## Validation

- [x] `npm.cmd run check:numeric-literals`
- [x] `npm.cmd run lint`
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run test:unit`
- [x] `npm.cmd run build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
