### PR TITLE
Split Worker festival service boundary

### DIFF
--- a/deploy/api-worker-shell/services/festival-domain/cache.ts
+++ b/deploy/api-worker-shell/services/festival-domain/cache.ts
@@ -1,0 +1,42 @@
+/*
+ * File: cache.ts
+ * Purpose: Own the Worker festival in-memory cache state.
+ * Primary Responsibility: Coordinate cache hit, pending-load sharing, and cache invalidation for festival cards.
+ * Design Intent: Keep mutable cache state out of the HTTP handler and away from persistence code.
+ * Non-Goals: This file does not query Supabase, normalize rows, or build banner/import responses.
+ * Dependencies: Worker runtime config, pending-request helper, and festival card contract.
+ */
+import { WorkerFestivalRuntimeConfig } from '../../config/runtime';
+import { rememberPending } from '../../lib/supabase';
+import type { FestivalCacheState, FestivalCard } from './contracts';
+
+const FESTIVALS_CACHE_TTL_MS = WorkerFestivalRuntimeConfig.cacheTtlMs;
+
+let festivalsCache: FestivalCacheState = { expiresAt: 0, syncAt: 0, value: null, pending: null };
+
+/**
+ * Returns cached festival cards or shares a pending load for concurrent requests.
+ */
+export async function loadCachedFestivalCards(now: number, loader: () => Promise<FestivalCard[]>) {
+  if (festivalsCache.value && festivalsCache.expiresAt > now) {
+    return festivalsCache.value;
+  }
+
+  return rememberPending(festivalsCache, async () => {
+    const value = await loader();
+    festivalsCache = {
+      ...festivalsCache,
+      value,
+      expiresAt: Date.now() + FESTIVALS_CACHE_TTL_MS,
+      pending: null,
+    };
+    return value;
+  });
+}
+
+/**
+ * Invalidates cards after an import so the next read reflects fresh source rows.
+ */
+export function clearFestivalCache(syncAt = Date.now()) {
+  festivalsCache = { expiresAt: 0, syncAt, value: null, pending: null };
+}

--- a/deploy/api-worker-shell/services/festival-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/festival-domain/contracts.ts
@@ -1,0 +1,116 @@
+/*
+ * File: contracts.ts
+ * Purpose: Define Worker festival domain-local contracts.
+ * Primary Responsibility: Keep festival row, DTO, import, and cache shapes near their owning domain.
+ * Design Intent: Prevent festival implementation details from leaking into the global Worker type barrel.
+ * Non-Goals: This file does not perform Supabase I/O, response mapping, or request handling.
+ * Dependencies: Worker JSON primitives from the local Worker runtime contract.
+ */
+import type { WorkerJsonRecord } from '../../types';
+
+export interface FestivalEventRow {
+  public_event_id: string | number;
+  title: string;
+  venue_name?: string | null;
+  district?: string | null;
+  address?: string | null;
+  road_address?: string | null;
+  starts_at: string;
+  ends_at: string;
+  summary?: string | null;
+  source_page_url?: string | null;
+  latitude?: unknown;
+  longitude?: unknown;
+}
+
+export interface FestivalSourceRow {
+  source_id: string | number;
+  source_key?: string | null;
+  name?: string | null;
+  last_imported_at?: string | null;
+}
+
+export interface FestivalExistingEventRow {
+  public_event_id: string | number;
+  external_id?: string | null;
+}
+
+export interface NormalizedFestivalItem {
+  externalId: string;
+  title: string;
+  venueName: string | null;
+  district: string;
+  address: string | null;
+  roadAddress: string | null;
+  startsAt: string;
+  endsAt: string;
+  homepageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  summary: string;
+  rawPayload: unknown;
+  sourceUpdatedAt: string | null;
+}
+
+export interface FestivalImportOptions {
+  sourceName?: unknown;
+  sourceUrl?: unknown;
+  importedAt?: unknown;
+}
+
+export interface FestivalUpsertRow {
+  source_id: string | number;
+  external_id: string;
+  title: string;
+  venue_name: string | null;
+  district: string;
+  address: string | null;
+  road_address: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  starts_at: string;
+  ends_at: string;
+  summary: string;
+  description: string;
+  source_page_url: string | null;
+  source_updated_at: string | null;
+  sync_status: 'imported';
+  raw_payload: unknown;
+  normalized_payload: WorkerJsonRecord;
+  updated_at: string;
+  created_at: string;
+}
+
+export interface FestivalCard {
+  id: string;
+  title: string;
+  venueName: string | null;
+  startDate: string;
+  endDate: string;
+  homepageUrl: string | null;
+  roadAddress: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  isOngoing: boolean;
+}
+
+export interface FestivalBannerItem {
+  id: string;
+  title: string;
+  venueName: string | null;
+  district: string;
+  startDate: string;
+  endDate: string;
+  dateLabel: string;
+  summary: string;
+  sourcePageUrl: string | null;
+  linkedPlaceName: null;
+  isOngoing: boolean;
+}
+
+export interface FestivalCacheState {
+  expiresAt: number;
+  syncAt: number;
+  value: FestivalCard[] | null;
+  pending: Promise<FestivalCard[]> | null;
+}

--- a/deploy/api-worker-shell/services/festival-domain/import-service.ts
+++ b/deploy/api-worker-shell/services/festival-domain/import-service.ts
@@ -1,0 +1,55 @@
+/*
+ * File: import-service.ts
+ * Purpose: Orchestrate public festival import normalization and persistence.
+ * Primary Responsibility: Convert import payloads into repository operations without exposing Supabase details to handlers.
+ * Design Intent: Keep the HTTP handler as a thin boundary while retaining one place for import sequencing.
+ * Non-Goals: This file does not parse HTTP authorization, build response DTOs, or manage response cache state directly.
+ * Dependencies: Festival mapper, repository functions, Worker runtime config, and Worker environment contract.
+ */
+import { WorkerFestivalRuntimeConfig } from '../../config/runtime';
+import type { WorkerEnv } from '../../types';
+import type { FestivalImportOptions } from './contracts';
+import { buildFestivalUpsertRows, getTargetFestivalCityKeyword, normalizeImportedFestivalItems, parseFestivalDate } from './mapper';
+import {
+  deleteStaleFestivalRows,
+  ensureImportedFestivalSource,
+  loadExistingFestivalRows,
+  updateFestivalSourceMetadata,
+  upsertFestivalRows,
+} from './repository';
+
+const INTERNAL_FESTIVAL_SOURCE_NAME = WorkerFestivalRuntimeConfig.internalSourceName;
+const INTERNAL_FESTIVAL_SOURCE_URL = WorkerFestivalRuntimeConfig.internalSourceUrl;
+
+/**
+ * Imports public festival rows while preserving source metadata and stale-row cleanup semantics.
+ */
+export async function upsertImportedFestivalItems(env: WorkerEnv, items: unknown[], options: FestivalImportOptions = {}) {
+  const cityKeyword = getTargetFestivalCityKeyword(env);
+  const normalizedItems = normalizeImportedFestivalItems(items || [], cityKeyword);
+  if (normalizedItems.length === 0) {
+    throw new Error('No valid festival items were provided for import.');
+  }
+
+  const sourceName = String(options.sourceName || INTERNAL_FESTIVAL_SOURCE_NAME).trim() || INTERNAL_FESTIVAL_SOURCE_NAME;
+  const requestUrl = String(options.sourceUrl || INTERNAL_FESTIVAL_SOURCE_URL).trim() || INTERNAL_FESTIVAL_SOURCE_URL;
+  const importedAt = parseFestivalDate(options.importedAt)?.toISOString() || new Date().toISOString();
+  const source = await ensureImportedFestivalSource(env, requestUrl, sourceName);
+  const sourceId = source.source_id;
+  const existingRows = await loadExistingFestivalRows(env, sourceId);
+  const seenExternalIds = new Set<string>();
+  const nowIso = new Date().toISOString();
+
+  for (const item of normalizedItems) {
+    seenExternalIds.add(item.externalId);
+  }
+
+  await upsertFestivalRows(env, buildFestivalUpsertRows(sourceId, normalizedItems, nowIso));
+
+  const staleIds = (existingRows || [])
+    .filter((row) => !seenExternalIds.has(String(row.external_id)))
+    .map((row) => row.public_event_id);
+  await deleteStaleFestivalRows(env, staleIds);
+  await updateFestivalSourceMetadata(env, sourceId, sourceName, requestUrl, importedAt, nowIso);
+  return normalizedItems;
+}

--- a/deploy/api-worker-shell/services/festival-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/festival-domain/mapper.ts
@@ -1,0 +1,488 @@
+/*
+ * File: mapper.ts
+ * Purpose: Normalize festival import payloads and map stored festival rows to Worker response DTOs.
+ * Primary Responsibility: Own festival parsing, grouping, deduplication, and DTO assembly rules.
+ * Design Intent: Keep transformation policy out of HTTP handlers and Supabase repository functions.
+ * Non-Goals: This file does not read requests, write responses, or call Supabase.
+ * Dependencies: Worker runtime config and date formatting helpers.
+ */
+import { WorkerFestivalRuntimeConfig } from '../../config/runtime';
+import { formatDate, toSeoulDateKey } from '../../lib/dates';
+import type {
+  FestivalBannerItem,
+  FestivalCard,
+  FestivalEventRow,
+  FestivalUpsertRow,
+  NormalizedFestivalItem,
+} from './contracts';
+
+const textEncoder = new TextEncoder();
+
+function base64UrlEncode(bytes: Uint8Array) {
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, '');
+}
+
+function createFestivalExternalId(
+  title: string,
+  startDate: Date,
+  venueName: string | null,
+  roadAddress: string | null,
+) {
+  const seed = `${title}|${startDate.toISOString()}|${venueName || ''}|${roadAddress || ''}`;
+  const bytes = textEncoder.encode(seed);
+  return `festival-${base64UrlEncode(bytes).slice(0, WorkerFestivalRuntimeConfig.externalIdTokenLength)}`;
+}
+
+function isFestivalOngoingInSeoul(startsAt: string, endsAt: string, nowValue = Date.now()) {
+  if (!startsAt || !endsAt) {
+    return false;
+  }
+  const startDateKey = toSeoulDateKey(startsAt);
+  const endDateKey = toSeoulDateKey(endsAt);
+  const nowDateKey = toSeoulDateKey(nowValue);
+  return startDateKey <= nowDateKey && endDateKey >= nowDateKey;
+}
+
+function normalizeFestivalSeriesKeyPart(value: unknown) {
+  return String(value || '')
+    .replace(/\[[^\]]*\]/g, ' ')
+    .replace(/\([^)]*\)/g, ' ')
+    .replace(/[&_·/|]+/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim()
+    .toLowerCase();
+}
+
+function buildFestivalSeriesKey(row: FestivalEventRow) {
+  return [
+    normalizeFestivalSeriesKeyPart(row.title),
+    normalizeFestivalSeriesKeyPart(row.venue_name ?? row.road_address ?? row.address ?? ''),
+  ].join('|');
+}
+
+function parseSeoulDateKey(dateKey: string) {
+  return new Date(`${dateKey}T00:00:00+09:00`);
+}
+
+function areFestivalSeriesDatesAdjacent(leftEnd: string, rightStart: string) {
+  const leftKey = toSeoulDateKey(leftEnd);
+  const rightKey = toSeoulDateKey(rightStart);
+  if (!leftKey || !rightKey) {
+    return false;
+  }
+  const nextDate = parseSeoulDateKey(leftKey);
+  nextDate.setDate(nextDate.getDate() + 1);
+  return parseSeoulDateKey(rightKey).getTime() <= nextDate.getTime();
+}
+
+function areFestivalSeriesPeriodsMergeable(leftRow: FestivalEventRow, rightRow: FestivalEventRow) {
+  const leftStartTime = new Date(leftRow.starts_at).getTime();
+  const leftEndTime = new Date(leftRow.ends_at).getTime();
+  const rightStartTime = new Date(rightRow.starts_at).getTime();
+  const rightEndTime = new Date(rightRow.ends_at).getTime();
+  if (
+    !Number.isFinite(leftStartTime) ||
+    !Number.isFinite(leftEndTime) ||
+    !Number.isFinite(rightStartTime) ||
+    !Number.isFinite(rightEndTime)
+  ) {
+    return false;
+  }
+  if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
+    return true;
+  }
+  return areFestivalSeriesDatesAdjacent(leftRow.ends_at, rightRow.starts_at);
+}
+
+function buildImportedFestivalSeriesKey(item: NormalizedFestivalItem) {
+  return [
+    normalizeFestivalSeriesKeyPart(item.title),
+    normalizeFestivalSeriesKeyPart(item.venueName ?? item.roadAddress ?? item.address ?? ''),
+  ].join('|');
+}
+
+function areImportedFestivalSeriesPeriodsMergeable(
+  leftItem: NormalizedFestivalItem,
+  rightItem: NormalizedFestivalItem,
+) {
+  const leftStartTime = new Date(leftItem.startsAt).getTime();
+  const leftEndTime = new Date(leftItem.endsAt).getTime();
+  const rightStartTime = new Date(rightItem.startsAt).getTime();
+  const rightEndTime = new Date(rightItem.endsAt).getTime();
+  if (
+    !Number.isFinite(leftStartTime) ||
+    !Number.isFinite(leftEndTime) ||
+    !Number.isFinite(rightStartTime) ||
+    !Number.isFinite(rightEndTime)
+  ) {
+    return false;
+  }
+  if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
+    return true;
+  }
+  return areFestivalSeriesDatesAdjacent(leftItem.endsAt, rightItem.startsAt);
+}
+
+function mergeImportedFestivalItems(items: NormalizedFestivalItem[]) {
+  const sortedItems = [...items].sort((left, right) => {
+    const keyOrder = buildImportedFestivalSeriesKey(left).localeCompare(buildImportedFestivalSeriesKey(right));
+    if (keyOrder !== 0) {
+      return keyOrder;
+    }
+    return new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime();
+  });
+  const mergedItems: NormalizedFestivalItem[] = [];
+  for (const item of sortedItems) {
+    const previous = mergedItems[mergedItems.length - 1];
+    if (
+      previous &&
+      buildImportedFestivalSeriesKey(previous) === buildImportedFestivalSeriesKey(item) &&
+      areImportedFestivalSeriesPeriodsMergeable(previous, item)
+    ) {
+      mergeImportedFestivalItem(previous, item);
+      continue;
+    }
+    mergedItems.push({
+      ...item,
+      externalId: createFestivalExternalId(item.title, new Date(item.startsAt), item.venueName, item.roadAddress),
+      rawPayload: {
+        ...readObjectPayload(item.rawPayload),
+        mergedExternalIds: [item.externalId].filter(Boolean),
+      },
+    });
+  }
+  return mergedItems;
+}
+
+function mergeImportedFestivalItem(target: NormalizedFestivalItem, source: NormalizedFestivalItem) {
+  if (new Date(source.startsAt).getTime() < new Date(target.startsAt).getTime()) {
+    target.startsAt = source.startsAt;
+  }
+  if (new Date(source.endsAt).getTime() > new Date(target.endsAt).getTime()) {
+    target.endsAt = source.endsAt;
+  }
+  if (!target.summary && source.summary) {
+    target.summary = source.summary;
+  }
+  if (!target.homepageUrl && source.homepageUrl) {
+    target.homepageUrl = source.homepageUrl;
+  }
+  if (!target.roadAddress && source.roadAddress) {
+    target.roadAddress = source.roadAddress;
+  }
+  if (!target.address && source.address) {
+    target.address = source.address;
+  }
+  if (
+    (!Number.isFinite(Number(target.latitude)) || !Number.isFinite(Number(target.longitude))) &&
+    Number.isFinite(Number(source.latitude)) &&
+    Number.isFinite(Number(source.longitude))
+  ) {
+    target.latitude = source.latitude;
+    target.longitude = source.longitude;
+  }
+  target.rawPayload = {
+    ...readObjectPayload(target.rawPayload),
+    mergedExternalIds: [
+      ...new Set([
+        ...readMergedExternalIds(target.rawPayload),
+        ...readMergedExternalIds(source.rawPayload),
+        source.externalId,
+      ].filter(Boolean)),
+    ],
+  };
+  target.externalId = createFestivalExternalId(target.title, new Date(target.startsAt), target.venueName, target.roadAddress);
+}
+
+function deduplicateImportedFestivalItemsByExternalId(items: NormalizedFestivalItem[]) {
+  const grouped = new Map<string, NormalizedFestivalItem>();
+  for (const item of items) {
+    const key = String(item.externalId || '');
+    const existing = grouped.get(key);
+    if (!existing) {
+      grouped.set(key, { ...item });
+      continue;
+    }
+    mergeImportedFestivalItem(existing, item);
+  }
+  return [...grouped.values()];
+}
+
+function readObjectPayload(payload: unknown) {
+  return payload && typeof payload === 'object' ? (payload as Record<string, unknown>) : {};
+}
+
+function readMergedExternalIds(payload: unknown) {
+  const mergedExternalIds = readObjectPayload(payload).mergedExternalIds;
+  return Array.isArray(mergedExternalIds) ? mergedExternalIds : [];
+}
+
+function readFestivalText(payload: object | null | undefined, keys: string[]) {
+  const record = (payload ?? {}) as Record<string, unknown>;
+  for (const key of keys) {
+    const value = record[key];
+    if (value !== undefined && value !== null && String(value).trim() !== '') {
+      return String(value).trim();
+    }
+  }
+  return null;
+}
+
+export function parseFestivalDate(value: unknown, endOfDay = false) {
+  if (!value) {
+    return null;
+  }
+  const text = String(value).trim();
+  if (!text) {
+    return null;
+  }
+  if (/^\d{8}$/.test(text)) {
+    const year = Number(text.slice(0, 4));
+    const month = Number(text.slice(4, 6));
+    const day = Number(text.slice(6, 8));
+    const date = new Date(Date.UTC(year, month - 1, day, endOfDay ? 23 : 0, endOfDay ? 59 : 0, endOfDay ? 59 : 0));
+    return Number.isNaN(date.getTime()) ? null : date;
+  }
+  const parsed = new Date(text);
+  if (Number.isNaN(parsed.getTime())) {
+    return null;
+  }
+  if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(text)) {
+    parsed.setUTCHours(23, 59, 59, 0);
+  }
+  return parsed;
+}
+
+export function getFestivalWindowEnd(now: number) {
+  return new Date(now + WorkerFestivalRuntimeConfig.windowMs);
+}
+
+export function getTargetFestivalCityKeyword(env: { APP_PUBLIC_EVENT_CITY_KEYWORD?: unknown }) {
+  const cityKeyword = String(env.APP_PUBLIC_EVENT_CITY_KEYWORD || '대전').trim();
+  return cityKeyword || '대전';
+}
+
+function getTargetFestivalAreaKeywords(cityKeyword: string) {
+  const normalized = String(cityKeyword || '').trim();
+  const keywords = new Set(normalized ? [normalized] : []);
+  if (normalized.includes('대전')) {
+    ['대전광역시', '동구', '중구', '서구', '유성구', '대덕구'].forEach((keyword) => keywords.add(keyword));
+  }
+  return [...keywords];
+}
+
+function isFestivalRowInTargetArea(payload: object, cityKeyword: string) {
+  const haystack = [
+    readFestivalText(payload, ['district', 'signguNm']),
+    readFestivalText(payload, ['title', 'eventTitle', 'fstvlNm', 'eventNm']),
+    readFestivalText(payload, ['venueName', 'venue_name', 'fstvlCo', 'opar']),
+    readFestivalText(payload, ['roadAddress', 'road_address', 'rdnmadr']),
+    readFestivalText(payload, ['address', 'lnmadr']),
+  ]
+    .filter(Boolean)
+    .join(' ');
+  return getTargetFestivalAreaKeywords(cityKeyword).some((keyword) => haystack.includes(keyword));
+}
+
+function deriveImportedFestivalDistrict(payload: object, cityKeyword: string) {
+  const explicit = readFestivalText(payload, ['district', 'signguNm']);
+  if (explicit) {
+    return explicit;
+  }
+  const combined = [
+    readFestivalText(payload, ['roadAddress', 'road_address', 'rdnmadr']),
+    readFestivalText(payload, ['address', 'lnmadr']),
+    readFestivalText(payload, ['venueName', 'venue_name', 'fstvlCo', 'opar']),
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const districtMatch = combined.match(/([가-힣]+구)/);
+  return districtMatch?.[1] || cityKeyword;
+}
+
+function parseFestivalCoordinate(value: unknown) {
+  if (value === undefined || value === null || String(value).trim() === '') {
+    return null;
+  }
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function normalizeFestivalImportItem(payload: unknown, cityKeyword: string): NormalizedFestivalItem | null {
+  if (!payload || typeof payload !== 'object') {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  const title = readFestivalText(record, ['title', 'eventTitle', 'name']);
+  const venueName = readFestivalText(record, ['venueName', 'venue_name', 'placeName', 'location']);
+  const roadAddress = readFestivalText(record, ['roadAddress', 'road_address', 'address']);
+  const startsAt = parseFestivalDate(readFestivalText(record, ['startsAt', 'starts_at', 'startDate']));
+  const endsAt = parseFestivalDate(readFestivalText(record, ['endsAt', 'ends_at', 'endDate']), true);
+  const homepageUrl = readFestivalText(record, ['homepageUrl', 'homepage_url', 'sourcePageUrl', 'source_page_url']);
+  const district = deriveImportedFestivalDistrict(
+    {
+      district: readFestivalText(record, ['district']),
+      signguNm: readFestivalText(record, ['signguNm']),
+      roadAddress,
+      address: readFestivalText(record, ['address']),
+      venueName,
+      title,
+    },
+    cityKeyword,
+  );
+  const latitude = parseFestivalCoordinate(readFestivalText(record, ['latitude', 'lat']));
+  const longitude = parseFestivalCoordinate(readFestivalText(record, ['longitude', 'lng']));
+  const sourceUpdatedAt = parseFestivalDate(readFestivalText(record, ['sourceUpdatedAt', 'source_updated_at']));
+  const areaProbe = {
+    district,
+    venueName,
+    roadAddress,
+    address: readFestivalText(record, ['address']),
+    title,
+  };
+  if (!title || !startsAt || !endsAt || !isFestivalRowInTargetArea(areaProbe, cityKeyword)) {
+    return null;
+  }
+  return {
+    externalId:
+      readFestivalText(record, ['externalId', 'external_id', 'eventSeq', 'id']) ||
+      createFestivalExternalId(title, startsAt, venueName, roadAddress),
+    title,
+    venueName,
+    district,
+    address: readFestivalText(record, ['address']),
+    roadAddress,
+    startsAt: startsAt.toISOString(),
+    endsAt: endsAt.toISOString(),
+    homepageUrl,
+    latitude,
+    longitude,
+    summary:
+      readFestivalText(record, ['summary', 'description']) ||
+      (venueName ? `${venueName}에서 열리는 ${cityKeyword} 행사예요.` : `${cityKeyword}에서 열리는 행사예요.`),
+    rawPayload: record.rawPayload && typeof record.rawPayload === 'object' ? record.rawPayload : record,
+    sourceUpdatedAt: sourceUpdatedAt ? sourceUpdatedAt.toISOString() : null,
+  };
+}
+
+export function normalizeImportedFestivalItems(items: unknown[], cityKeyword: string) {
+  return deduplicateImportedFestivalItemsByExternalId(
+    mergeImportedFestivalItems(items.map((item) => normalizeFestivalImportItem(item, cityKeyword)).filter(Boolean)),
+  );
+}
+
+export function groupFestivalRowsBySeries(rows: FestivalEventRow[]) {
+  return rows.reduce<FestivalEventRow[]>((acc, row) => {
+    const previous = acc[acc.length - 1];
+    if (
+      previous &&
+      buildFestivalSeriesKey(previous) === buildFestivalSeriesKey(row) &&
+      areFestivalSeriesPeriodsMergeable(previous, row)
+    ) {
+      if (new Date(row.ends_at).getTime() > new Date(previous.ends_at).getTime()) {
+        previous.ends_at = row.ends_at;
+      }
+      if (!previous.summary && row.summary) {
+        previous.summary = row.summary;
+      }
+      if (!previous.source_page_url && row.source_page_url) {
+        previous.source_page_url = row.source_page_url;
+      }
+      if (!previous.road_address && row.road_address) {
+        previous.road_address = row.road_address;
+      }
+      if (!previous.address && row.address) {
+        previous.address = row.address;
+      }
+      if (
+        (!Number.isFinite(Number(previous.latitude)) || !Number.isFinite(Number(previous.longitude))) &&
+        Number.isFinite(Number(row.latitude)) &&
+        Number.isFinite(Number(row.longitude))
+      ) {
+        previous.latitude = row.latitude;
+        previous.longitude = row.longitude;
+      }
+      return acc;
+    }
+    acc.push({ ...row });
+    return acc;
+  }, []);
+}
+
+export function isFestivalRowInConfiguredArea(row: FestivalEventRow, cityKeyword: string) {
+  return isFestivalRowInTargetArea(row, cityKeyword);
+}
+
+export function buildFestivalCard(row: FestivalEventRow, now: number): FestivalCard {
+  return {
+    id: String(row.public_event_id),
+    title: row.title,
+    venueName: row.venue_name ?? null,
+    startDate: row.starts_at ? toSeoulDateKey(row.starts_at) : '',
+    endDate: row.ends_at ? toSeoulDateKey(row.ends_at) : '',
+    homepageUrl: row.source_page_url ?? null,
+    roadAddress: row.road_address ?? row.address ?? null,
+    latitude: parseFestivalCoordinate(row.latitude),
+    longitude: parseFestivalCoordinate(row.longitude),
+    isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now),
+  };
+}
+
+export function buildBannerItem(row: FestivalEventRow, now: number, emptyDateLabel = ''): FestivalBannerItem {
+  return {
+    id: String(row.public_event_id),
+    title: row.title,
+    venueName: row.venue_name ?? null,
+    district: row.district ?? '',
+    startDate: row.starts_at,
+    endDate: row.ends_at,
+    dateLabel: row.starts_at && row.ends_at ? `${formatDate(row.starts_at)} - ${formatDate(row.ends_at)}` : emptyDateLabel,
+    summary: row.summary ?? '',
+    sourcePageUrl: row.source_page_url ?? null,
+    linkedPlaceName: null,
+    isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now),
+  };
+}
+
+export function buildFestivalUpsertRows(
+  sourceId: string | number,
+  normalizedItems: NormalizedFestivalItem[],
+  nowIso: string,
+): FestivalUpsertRow[] {
+  return normalizedItems.map((item) => ({
+    source_id: sourceId,
+    external_id: item.externalId,
+    title: item.title,
+    venue_name: item.venueName,
+    district: item.district,
+    address: item.address,
+    road_address: item.roadAddress,
+    latitude: item.latitude,
+    longitude: item.longitude,
+    starts_at: item.startsAt,
+    ends_at: item.endsAt,
+    summary: item.summary,
+    description: item.summary,
+    source_page_url: item.homepageUrl,
+    source_updated_at: item.sourceUpdatedAt,
+    sync_status: 'imported',
+    raw_payload: item.rawPayload,
+    normalized_payload: {
+      title: item.title,
+      venue_name: item.venueName,
+      address: item.address,
+      road_address: item.roadAddress,
+      starts_at: item.startsAt,
+      ends_at: item.endsAt,
+      homepage_url: item.homepageUrl,
+      latitude: item.latitude,
+      longitude: item.longitude,
+    },
+    updated_at: nowIso,
+    created_at: nowIso,
+  }));
+}

--- a/deploy/api-worker-shell/services/festival-domain/read-service.ts
+++ b/deploy/api-worker-shell/services/festival-domain/read-service.ts
@@ -1,0 +1,57 @@
+/*
+ * File: read-service.ts
+ * Purpose: Assemble festival read models for public Worker endpoints.
+ * Primary Responsibility: Coordinate repository reads, configured-area filtering, grouping, and mapper output.
+ * Design Intent: Keep HTTP handlers thin while keeping Supabase access and DTO mapping behind festival-domain APIs.
+ * Non-Goals: This file does not parse import payloads, authorize requests, or mutate festival data.
+ * Dependencies: Worker environment contract, festival repository, mapper, and runtime config.
+ */
+import { WorkerFestivalRuntimeConfig } from '../../config/runtime';
+import type { WorkerEnv } from '../../types';
+import { buildBannerItem, buildFestivalCard, getFestivalWindowEnd, getTargetFestivalCityKeyword, groupFestivalRowsBySeries, isFestivalRowInConfiguredArea } from './mapper';
+import { loadFestivalRows, loadFestivalSourceMetadata } from './repository';
+
+async function loadConfiguredFestivalRows(env: WorkerEnv, now: number, limit: number) {
+  const nowIso = new Date(now).toISOString();
+  const windowEndIso = getFestivalWindowEnd(now).toISOString();
+  const cityKeyword = getTargetFestivalCityKeyword(env);
+  const rows = await loadFestivalRows(env, nowIso, windowEndIso, limit);
+  return groupFestivalRowsBySeries((rows || []).filter((row) => isFestivalRowInConfiguredArea(row, cityKeyword)));
+}
+
+/**
+ * Loads festival cards for `/api/festivals`.
+ */
+export async function loadFestivalCards(env: WorkerEnv, now: number) {
+  const rows = await loadConfiguredFestivalRows(env, now, WorkerFestivalRuntimeConfig.dbQueryLimit);
+  const windowEndTime = getFestivalWindowEnd(now).getTime();
+  return rows
+    .filter((row) => {
+      const startTime = new Date(row.starts_at).getTime();
+      const endTime = new Date(row.ends_at).getTime();
+      return Number.isFinite(startTime) && Number.isFinite(endTime) && endTime >= now && startTime <= windowEndTime;
+    })
+    .slice(0, WorkerFestivalRuntimeConfig.cardDisplayLimit)
+    .map((row) => buildFestivalCard(row, now));
+}
+
+/**
+ * Loads banner event response fields for `/api/banner/events`.
+ */
+export async function loadBannerEvents(now: number, env: WorkerEnv) {
+  const [eventRows, sourceRows] = await Promise.all([
+    loadConfiguredFestivalRows(env, now, WorkerFestivalRuntimeConfig.bannerQueryLimit),
+    loadFestivalSourceMetadata(env),
+  ]);
+  const source = sourceRows[0] ?? null;
+  const items =
+    eventRows.length > 0
+      ? eventRows.slice(0, WorkerFestivalRuntimeConfig.bannerDisplayLimit).map((row) => buildBannerItem(row, now))
+      : [];
+  return {
+    sourceReady: items.length > 0 || Boolean(source?.last_imported_at),
+    sourceName: source?.name ?? null,
+    importedAt: source?.last_imported_at ?? null,
+    items,
+  };
+}

--- a/deploy/api-worker-shell/services/festival-domain/repository.ts
+++ b/deploy/api-worker-shell/services/festival-domain/repository.ts
@@ -1,0 +1,114 @@
+/*
+ * File: repository.ts
+ * Purpose: Encapsulate Supabase REST access for the Worker festival domain.
+ * Primary Responsibility: Own festival source/event queries, upserts, stale deletes, and source metadata updates.
+ * Design Intent: Keep persistence mechanics behind a domain repository so handlers and mappers stay I/O-free.
+ * Non-Goals: This file does not normalize import payloads, build HTTP responses, or manage in-memory cache state.
+ * Dependencies: Worker Supabase REST helper and festival domain contracts.
+ */
+import type { WorkerEnv } from '../../types';
+import { encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import { WorkerFestivalRuntimeConfig } from '../../config/runtime';
+import type { FestivalEventRow, FestivalExistingEventRow, FestivalSourceRow, FestivalUpsertRow } from './contracts';
+
+const INTERNAL_FESTIVAL_SOURCE_KEY = WorkerFestivalRuntimeConfig.internalSourceKey;
+
+/**
+ * Loads or creates the configured public-event source row.
+ */
+export async function ensureImportedFestivalSource(env: WorkerEnv, requestUrl: string, sourceName: string) {
+  const rows = await supabaseRequest<FestivalSourceRow[]>(
+    env,
+    `public_data_source?select=source_id,source_key&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`,
+  );
+  if (rows?.[0]) {
+    return rows[0];
+  }
+  const created = await supabaseRequest<FestivalSourceRow[]>(env, 'public_data_source', {
+    method: 'POST',
+    body: JSON.stringify({
+      source_key: INTERNAL_FESTIVAL_SOURCE_KEY,
+      provider: 'public-event',
+      name: sourceName,
+      source_url: requestUrl,
+      updated_at: new Date().toISOString(),
+    }),
+  });
+  return Array.isArray(created) ? created[0] : created;
+}
+
+/**
+ * Loads imported festival external IDs so the import service can remove stale rows.
+ */
+export function loadExistingFestivalRows(env: WorkerEnv, sourceId: string | number) {
+  return supabaseRequest<FestivalExistingEventRow[]>(
+    env,
+    `public_event?select=public_event_id,external_id&source_id=eq.${encodeFilterValue(sourceId)}`,
+  );
+}
+
+/**
+ * Upserts normalized festival event rows by source and external ID.
+ */
+export async function upsertFestivalRows(env: WorkerEnv, rows: FestivalUpsertRow[]) {
+  if (rows.length === 0) {
+    return;
+  }
+  await supabaseRequest(env, 'public_event?on_conflict=source_id,external_id', {
+    method: 'POST',
+    headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
+    body: JSON.stringify(rows),
+  });
+}
+
+/**
+ * Deletes imported festival rows that are no longer present in the latest import payload.
+ */
+export async function deleteStaleFestivalRows(env: WorkerEnv, staleIds: Array<string | number>) {
+  if (staleIds.length === 0) {
+    return;
+  }
+  await supabaseRequest(env, `public_event?public_event_id=in.(${staleIds.join(',')})`, { method: 'DELETE' });
+}
+
+/**
+ * Records the latest source display metadata after a successful import.
+ */
+export function updateFestivalSourceMetadata(
+  env: WorkerEnv,
+  sourceId: string | number,
+  sourceName: string,
+  requestUrl: string,
+  importedAt: string,
+  nowIso: string,
+) {
+  return supabaseRequest(env, `public_data_source?source_id=eq.${encodeFilterValue(sourceId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({
+      name: sourceName,
+      source_url: requestUrl,
+      last_imported_at: importedAt,
+      updated_at: nowIso,
+    }),
+  });
+}
+
+/**
+ * Loads upcoming public event rows for festival card and banner responses.
+ */
+export function loadFestivalRows(env: WorkerEnv, nowIso: string, windowEndIso: string, limit: number) {
+  return supabaseRequest<FestivalEventRow[]>(
+    env,
+    `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`,
+  );
+}
+
+/**
+ * Loads source metadata for the banner response readiness fields.
+ */
+export function loadFestivalSourceMetadata(env: WorkerEnv) {
+  return supabaseRequest<Array<Pick<FestivalSourceRow, 'name' | 'last_imported_at'>>>(
+    env,
+    `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`,
+  );
+}

--- a/deploy/api-worker-shell/services/festivals.ts
+++ b/deploy/api-worker-shell/services/festivals.ts
@@ -1,194 +1,92 @@
-import { formatDate, toSeoulDateKey } from '../lib/dates';
-import { jsonResponse } from '../lib/http';
-import { encodeFilterValue, rememberPending, supabaseRequest } from '../lib/supabase';
+/*
+ * File: festivals.ts
+ * Purpose: Expose public festival Worker HTTP handlers.
+ * Primary Responsibility: Validate HTTP inputs and delegate festival read/import work to festival-domain modules.
+ * Design Intent: Keep the public handler surface stable while hiding cache, mapper, import, and repository details.
+ * Non-Goals: This file does not own Supabase queries, payload normalization, cache state, or festival DTO mapping.
+ * Dependencies: Worker HTTP helpers, runtime config, and festival-domain services.
+ */
 import { WorkerFestivalRuntimeConfig } from '../config/runtime';
-const textEncoder = new TextEncoder();
-const FESTIVALS_CACHE_TTL_MS = WorkerFestivalRuntimeConfig.cacheTtlMs;
-const INTERNAL_FESTIVAL_SOURCE_KEY = WorkerFestivalRuntimeConfig.internalSourceKey;
+import { jsonResponse } from '../lib/http';
+import type { WorkerEnv, WorkerJsonRecord } from '../types';
+import { clearFestivalCache, loadCachedFestivalCards } from './festival-domain/cache';
+import { upsertImportedFestivalItems } from './festival-domain/import-service';
+import { parseFestivalDate } from './festival-domain/mapper';
+import { loadBannerEvents, loadFestivalCards } from './festival-domain/read-service';
+
 const INTERNAL_FESTIVAL_SOURCE_NAME = WorkerFestivalRuntimeConfig.internalSourceName;
-const INTERNAL_FESTIVAL_SOURCE_URL = WorkerFestivalRuntimeConfig.internalSourceUrl;
-let festivalsCache = { expiresAt: 0, syncAt: 0, value: null, pending: null };
-function base64UrlEncode(bytes) { let binary = ''; for (const byte of bytes) {
-    binary += String.fromCharCode(byte);
-} return btoa(binary).replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/g, ''); }
-function createFestivalExternalId(title, startDate, venueName, roadAddress) { const seed = `${title}|${startDate.toISOString()}|${venueName || ''}|${roadAddress || ''}`; const bytes = textEncoder.encode(seed); return `festival-${base64UrlEncode(bytes).slice(0, WorkerFestivalRuntimeConfig.externalIdTokenLength)}`; }
-function isFestivalOngoingInSeoul(startsAt, endsAt, nowValue = Date.now()) { if (!startsAt || !endsAt) {
-    return false;
-} const startDateKey = toSeoulDateKey(startsAt); const endDateKey = toSeoulDateKey(endsAt); const nowDateKey = toSeoulDateKey(nowValue); return startDateKey <= nowDateKey && endDateKey >= nowDateKey; }
-function normalizeFestivalSeriesKeyPart(value) { return String(value || '').replace(/\[[^\]]*\]/g, ' ').replace(/\([^)]*\)/g, ' ').replace(/[&_·/|]+/g, ' ').replace(/\s{2,}/g, ' ').trim().toLowerCase(); }
-function buildFestivalSeriesKey(row) { return [normalizeFestivalSeriesKeyPart(row.title), normalizeFestivalSeriesKeyPart(row.venue_name ?? row.road_address ?? row.address ?? ''),].join('|'); }
-function parseSeoulDateKey(dateKey) { return new Date(`${dateKey}T00:00:00+09:00`); }
-function areFestivalSeriesDatesAdjacent(leftEnd, rightStart) { const leftKey = toSeoulDateKey(leftEnd); const rightKey = toSeoulDateKey(rightStart); if (!leftKey || !rightKey) {
-    return false;
-} const nextDate = parseSeoulDateKey(leftKey); nextDate.setDate(nextDate.getDate() + 1); return parseSeoulDateKey(rightKey).getTime() <= nextDate.getTime(); }
-function areFestivalSeriesPeriodsMergeable(leftRow, rightRow) { const leftStartTime = new Date(leftRow.starts_at).getTime(); const leftEndTime = new Date(leftRow.ends_at).getTime(); const rightStartTime = new Date(rightRow.starts_at).getTime(); const rightEndTime = new Date(rightRow.ends_at).getTime(); if (!Number.isFinite(leftStartTime) || !Number.isFinite(leftEndTime) || !Number.isFinite(rightStartTime) || !Number.isFinite(rightEndTime)) {
-    return false;
-} if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
-    return true;
-} return areFestivalSeriesDatesAdjacent(leftRow.ends_at, rightRow.starts_at); }
-function buildImportedFestivalSeriesKey(item) { return [normalizeFestivalSeriesKeyPart(item.title), normalizeFestivalSeriesKeyPart(item.venueName ?? item.roadAddress ?? item.address ?? ''),].join('|'); }
-function areImportedFestivalSeriesPeriodsMergeable(leftItem, rightItem) { const leftStartTime = new Date(leftItem.startsAt).getTime(); const leftEndTime = new Date(leftItem.endsAt).getTime(); const rightStartTime = new Date(rightItem.startsAt).getTime(); const rightEndTime = new Date(rightItem.endsAt).getTime(); if (!Number.isFinite(leftStartTime) || !Number.isFinite(leftEndTime) || !Number.isFinite(rightStartTime) || !Number.isFinite(rightEndTime)) {
-    return false;
-} if (rightStartTime <= leftEndTime && rightEndTime >= leftStartTime) {
-    return true;
-} return areFestivalSeriesDatesAdjacent(leftItem.endsAt, rightItem.startsAt); }
-function mergeImportedFestivalItems(items) { const sortedItems = [...items].sort((left, right) => { const keyOrder = buildImportedFestivalSeriesKey(left).localeCompare(buildImportedFestivalSeriesKey(right)); if (keyOrder !== 0) {
-    return keyOrder;
-} return new Date(left.startsAt).getTime() - new Date(right.startsAt).getTime(); }); const mergedItems = []; for (const item of sortedItems) {
-    const previous = mergedItems[mergedItems.length - 1];
-    if (previous && buildImportedFestivalSeriesKey(previous) === buildImportedFestivalSeriesKey(item) && areImportedFestivalSeriesPeriodsMergeable(previous, item)) {
-        if (new Date(item.startsAt).getTime() < new Date(previous.startsAt).getTime()) {
-            previous.startsAt = item.startsAt;
-        }
-        if (new Date(item.endsAt).getTime() > new Date(previous.endsAt).getTime()) {
-            previous.endsAt = item.endsAt;
-        }
-        if (!previous.summary && item.summary) {
-            previous.summary = item.summary;
-        }
-        if (!previous.homepageUrl && item.homepageUrl) {
-            previous.homepageUrl = item.homepageUrl;
-        }
-        if (!previous.roadAddress && item.roadAddress) {
-            previous.roadAddress = item.roadAddress;
-        }
-        if (!previous.address && item.address) {
-            previous.address = item.address;
-        }
-        if ((!Number.isFinite(Number(previous.latitude)) || !Number.isFinite(Number(previous.longitude))) && Number.isFinite(Number(item.latitude)) && Number.isFinite(Number(item.longitude))) {
-            previous.latitude = item.latitude;
-            previous.longitude = item.longitude;
-        }
-        previous.rawPayload = { ...(previous.rawPayload || {}), mergedExternalIds: [...new Set([...(previous.rawPayload?.mergedExternalIds || []), ...(item.rawPayload?.mergedExternalIds || []), item.externalId,].filter(Boolean)),], };
-        previous.externalId = createFestivalExternalId(previous.title, new Date(previous.startsAt), previous.venueName, previous.roadAddress);
-        continue;
-    }
-    mergedItems.push({ ...item, externalId: createFestivalExternalId(item.title, new Date(item.startsAt), item.venueName, item.roadAddress), rawPayload: { ...(item.rawPayload || {}), mergedExternalIds: [item.externalId].filter(Boolean), }, });
-} return mergedItems; }
-function deduplicateImportedFestivalItemsByExternalId(items) { const grouped = new Map(); for (const item of items) {
-    const key = String(item.externalId || '');
-    const existing = grouped.get(key);
-    if (!existing) {
-        grouped.set(key, { ...item });
-        continue;
-    }
-    if (new Date(item.startsAt).getTime() < new Date(existing.startsAt).getTime()) {
-        existing.startsAt = item.startsAt;
-    }
-    if (new Date(item.endsAt).getTime() > new Date(existing.endsAt).getTime()) {
-        existing.endsAt = item.endsAt;
-    }
-    if (!existing.summary && item.summary) {
-        existing.summary = item.summary;
-    }
-    if (!existing.homepageUrl && item.homepageUrl) {
-        existing.homepageUrl = item.homepageUrl;
-    }
-    if (!existing.roadAddress && item.roadAddress) {
-        existing.roadAddress = item.roadAddress;
-    }
-    if (!existing.address && item.address) {
-        existing.address = item.address;
-    }
-    if ((!Number.isFinite(Number(existing.latitude)) || !Number.isFinite(Number(existing.longitude))) && Number.isFinite(Number(item.latitude)) && Number.isFinite(Number(item.longitude))) {
-        existing.latitude = item.latitude;
-        existing.longitude = item.longitude;
-    }
-    existing.rawPayload = { ...(existing.rawPayload || {}), mergedExternalIds: [...new Set([...(existing.rawPayload?.mergedExternalIds || []), ...(item.rawPayload?.mergedExternalIds || []), item.externalId,].filter(Boolean)),], };
-} return [...grouped.values()]; }
-function groupFestivalRowsBySeries(rows) { return rows.reduce((acc, row) => { const previous = acc[acc.length - 1]; if (previous && buildFestivalSeriesKey(previous) === buildFestivalSeriesKey(row) && areFestivalSeriesPeriodsMergeable(previous, row)) {
-    if (new Date(row.ends_at).getTime() > new Date(previous.ends_at).getTime()) {
-        previous.ends_at = row.ends_at;
-    }
-    if (!previous.summary && row.summary) {
-        previous.summary = row.summary;
-    }
-    if (!previous.source_page_url && row.source_page_url) {
-        previous.source_page_url = row.source_page_url;
-    }
-    if (!previous.road_address && row.road_address) {
-        previous.road_address = row.road_address;
-    }
-    if (!previous.address && row.address) {
-        previous.address = row.address;
-    }
-    if ((!Number.isFinite(Number(previous.latitude)) || !Number.isFinite(Number(previous.longitude))) && Number.isFinite(Number(row.latitude)) && Number.isFinite(Number(row.longitude))) {
-        previous.latitude = row.latitude;
-        previous.longitude = row.longitude;
-    }
-    return acc;
-} acc.push({ ...row }); return acc; }, []); }
-function readFestivalText(payload, keys) { for (const key of keys) {
-    const value = payload?.[key];
-    if (value !== undefined && value !== null && String(value).trim() !== '') {
-        return String(value).trim();
-    }
-} return null; }
-function parseFestivalDate(value, endOfDay = false) { if (!value) {
-    return null;
-} const text = String(value).trim(); if (!text) {
-    return null;
-} if (/^\d{8}$/.test(text)) {
-    const year = Number(text.slice(0, 4));
-    const month = Number(text.slice(4, 6));
-    const day = Number(text.slice(6, 8));
-    const date = new Date(Date.UTC(year, month - 1, day, endOfDay ? 23 : 0, endOfDay ? 59 : 0, endOfDay ? 59 : 0));
-    return Number.isNaN(date.getTime()) ? null : date;
-} const parsed = new Date(text); if (Number.isNaN(parsed.getTime())) {
-    return null;
-} if (endOfDay && /^\d{4}-\d{2}-\d{2}$/.test(text)) {
-    parsed.setUTCHours(23, 59, 59, 0);
-} return parsed; }
-function getFestivalWindowEnd(now) { return new Date(now + WorkerFestivalRuntimeConfig.windowMs); }
-function getTargetFestivalCityKeyword(env) { const cityKeyword = String(env.APP_PUBLIC_EVENT_CITY_KEYWORD || '대전').trim(); return cityKeyword || '대전'; }
-function getTargetFestivalAreaKeywords(cityKeyword) { const normalized = String(cityKeyword || '').trim(); const keywords = new Set(normalized ? [normalized] : []); if (normalized.includes('대전')) {
-    ['대전광역시', '동구', '중구', '서구', '유성구', '대덕구'].forEach((keyword) => keywords.add(keyword));
-} return [...keywords]; }
-function isFestivalRowInTargetArea(payload, cityKeyword) { const haystack = [readFestivalText(payload, ['district', 'signguNm']), readFestivalText(payload, ['title', 'eventTitle', 'fstvlNm', 'eventNm']), readFestivalText(payload, ['venueName', 'venue_name', 'fstvlCo', 'opar']), readFestivalText(payload, ['roadAddress', 'road_address', 'rdnmadr']), readFestivalText(payload, ['address', 'lnmadr']),].filter(Boolean).join(' '); return getTargetFestivalAreaKeywords(cityKeyword).some((keyword) => haystack.includes(keyword)); }
-function deriveImportedFestivalDistrict(payload, cityKeyword) { const explicit = readFestivalText(payload, ['district', 'signguNm']); if (explicit) {
-    return explicit;
-} const combined = [readFestivalText(payload, ['roadAddress', 'road_address', 'rdnmadr']), readFestivalText(payload, ['address', 'lnmadr']), readFestivalText(payload, ['venueName', 'venue_name', 'fstvlCo', 'opar']),].filter(Boolean).join(' '); const districtMatch = combined.match(/([가-힣]+구)/); return districtMatch?.[1] || cityKeyword; }
-function parseFestivalCoordinate(value) { if (value === undefined || value === null || String(value).trim() === '') {
-    return null;
-} const numeric = Number(value); return Number.isFinite(numeric) ? numeric : null; }
-function readFestivalImportToken(env) { return String(env.APP_EVENT_IMPORT_TOKEN || '').trim(); }
-function readBearerToken(request) { const authorization = request.headers.get('authorization') || ''; const match = authorization.match(/^Bearer\s+(.+)$/i); return match ? match[1].trim() : ''; }
-function normalizeFestivalImportItem(payload, cityKeyword) { if (!payload || typeof payload !== 'object') {
-    return null;
-} const title = readFestivalText(payload, ['title', 'eventTitle', 'name']); const venueName = readFestivalText(payload, ['venueName', 'venue_name', 'placeName', 'location']); const roadAddress = readFestivalText(payload, ['roadAddress', 'road_address', 'address']); const startsAt = parseFestivalDate(readFestivalText(payload, ['startsAt', 'starts_at', 'startDate'])); const endsAt = parseFestivalDate(readFestivalText(payload, ['endsAt', 'ends_at', 'endDate']), true); const homepageUrl = readFestivalText(payload, ['homepageUrl', 'homepage_url', 'sourcePageUrl', 'source_page_url']); const district = deriveImportedFestivalDistrict({ district: readFestivalText(payload, ['district']), signguNm: readFestivalText(payload, ['signguNm']), roadAddress, address: readFestivalText(payload, ['address']), venueName, title, }, cityKeyword); const latitude = parseFestivalCoordinate(readFestivalText(payload, ['latitude', 'lat'])); const longitude = parseFestivalCoordinate(readFestivalText(payload, ['longitude', 'lng'])); const sourceUpdatedAt = parseFestivalDate(readFestivalText(payload, ['sourceUpdatedAt', 'source_updated_at'])); const areaProbe = { district, venueName, roadAddress, address: readFestivalText(payload, ['address']), title, }; if (!title || !startsAt || !endsAt || !isFestivalRowInTargetArea(areaProbe, cityKeyword)) {
-    return null;
-} return { externalId: readFestivalText(payload, ['externalId', 'external_id', 'eventSeq', 'id']) || createFestivalExternalId(title, startsAt, venueName, roadAddress), title, venueName, district, address: readFestivalText(payload, ['address']), roadAddress, startsAt: startsAt.toISOString(), endsAt: endsAt.toISOString(), homepageUrl, latitude, longitude, summary: readFestivalText(payload, ['summary', 'description']) || (venueName ? `${venueName}에서 열리는 ${cityKeyword} 행사예요.` : `${cityKeyword}에서 열리는 행사예요.`), rawPayload: payload.rawPayload && typeof payload.rawPayload === 'object' ? payload.rawPayload : payload, sourceUpdatedAt: sourceUpdatedAt ? sourceUpdatedAt.toISOString() : null, }; }
-async function ensureImportedFestivalSource(env, requestUrl, sourceName) { const rows = await supabaseRequest(env, `public_data_source?select=source_id,source_key&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`); if (rows?.[0]) {
-    return rows[0];
-} const created = await supabaseRequest(env, 'public_data_source', { method: 'POST', body: JSON.stringify({ source_key: INTERNAL_FESTIVAL_SOURCE_KEY, provider: 'public-event', name: sourceName, source_url: requestUrl, updated_at: new Date().toISOString(), }), }); return Array.isArray(created) ? created[0] : created; }
-async function upsertImportedFestivalItems(env: any, items: any[], options: any = {}) { const cityKeyword = getTargetFestivalCityKeyword(env); const normalizedItems = deduplicateImportedFestivalItemsByExternalId(mergeImportedFestivalItems((items || []).map((item) => normalizeFestivalImportItem(item, cityKeyword)).filter(Boolean))); if (normalizedItems.length === 0) {
-    throw new Error('No valid festival items were provided for import.');
-} const sourceName = String(options.sourceName || INTERNAL_FESTIVAL_SOURCE_NAME).trim() || INTERNAL_FESTIVAL_SOURCE_NAME; const requestUrl = String(options.sourceUrl || INTERNAL_FESTIVAL_SOURCE_URL).trim() || INTERNAL_FESTIVAL_SOURCE_URL; const importedAt = parseFestivalDate(options.importedAt)?.toISOString() || new Date().toISOString(); const source = await ensureImportedFestivalSource(env, requestUrl, sourceName); const sourceId = source.source_id; const existingRows = await supabaseRequest(env, `public_event?select=public_event_id,external_id&source_id=eq.${encodeFilterValue(sourceId)}`); const seenExternalIds = new Set(); const nowIso = new Date().toISOString(); const upsertRows = []; for (const item of normalizedItems) {
-    seenExternalIds.add(item.externalId);
-    upsertRows.push({ source_id: sourceId, external_id: item.externalId, title: item.title, venue_name: item.venueName, district: item.district, address: item.address, road_address: item.roadAddress, latitude: item.latitude, longitude: item.longitude, starts_at: item.startsAt, ends_at: item.endsAt, summary: item.summary, description: item.summary, source_page_url: item.homepageUrl, source_updated_at: item.sourceUpdatedAt, sync_status: 'imported', raw_payload: item.rawPayload, normalized_payload: { title: item.title, venue_name: item.venueName, address: item.address, road_address: item.roadAddress, starts_at: item.startsAt, ends_at: item.endsAt, homepage_url: item.homepageUrl, latitude: item.latitude, longitude: item.longitude, }, updated_at: nowIso, created_at: nowIso, });
-} if (upsertRows.length > 0) {
-    await supabaseRequest(env, 'public_event?on_conflict=source_id,external_id', { method: 'POST', headers: { Prefer: 'resolution=merge-duplicates,return=minimal' }, body: JSON.stringify(upsertRows), });
-} const staleIds = (existingRows || []).filter((row) => !seenExternalIds.has(String(row.external_id))).map((row) => row.public_event_id); if (staleIds.length > 0) {
-    await supabaseRequest(env, `public_event?public_event_id=in.(${staleIds.join(',')})`, { method: 'DELETE', });
-} await supabaseRequest(env, `public_data_source?source_id=eq.${encodeFilterValue(sourceId)}`, { method: 'PATCH', body: JSON.stringify({ name: sourceName, source_url: requestUrl, last_imported_at: importedAt, updated_at: nowIso, }), }); return normalizedItems; }
-async function loadFestivalRowsFromDb(env, nowIso, windowEndIso, limit = WorkerFestivalRuntimeConfig.dbQueryLimit) { const rows = await supabaseRequest(env, `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`); const cityKeyword = getTargetFestivalCityKeyword(env); return groupFestivalRowsBySeries((rows || []).filter((row) => isFestivalRowInTargetArea(row, cityKeyword))); }
-function buildFestivalCard(row, now) { return { id: String(row.public_event_id), title: row.title, venueName: row.venue_name ?? null, startDate: row.starts_at ? toSeoulDateKey(row.starts_at) : '', endDate: row.ends_at ? toSeoulDateKey(row.ends_at) : '', homepageUrl: row.source_page_url ?? null, roadAddress: row.road_address ?? row.address ?? null, latitude: parseFestivalCoordinate(row.latitude), longitude: parseFestivalCoordinate(row.longitude), isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now), }; }
-function buildBannerItem(row, now, emptyDateLabel = '') { return { id: String(row.public_event_id), title: row.title, venueName: row.venue_name ?? null, district: row.district ?? '', startDate: row.starts_at, endDate: row.ends_at, dateLabel: row.starts_at && row.ends_at ? `${formatDate(row.starts_at)} - ${formatDate(row.ends_at)}` : emptyDateLabel, summary: row.summary ?? '', sourcePageUrl: row.source_page_url ?? null, linkedPlaceName: null, isOngoing: isFestivalOngoingInSeoul(row.starts_at, row.ends_at, now), }; }
-export async function handleFestivals(request, env) { const now = Date.now(); if (festivalsCache.value && festivalsCache.expiresAt > now) {
-    return jsonResponse(200, festivalsCache.value, env, request);
-} const festivals = await rememberPending(festivalsCache, async () => { const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const rows = await loadFestivalRowsFromDb(env, nowIso, windowEndIso, WorkerFestivalRuntimeConfig.dbQueryLimit); const windowEndTime = getFestivalWindowEnd(now).getTime(); const value = rows.filter((row) => { const startTime = new Date(row.starts_at).getTime(); const endTime = new Date(row.ends_at).getTime(); return Number.isFinite(startTime) && Number.isFinite(endTime) && endTime >= now && startTime <= windowEndTime; }).slice(0, WorkerFestivalRuntimeConfig.cardDisplayLimit).map((row) => buildFestivalCard(row, now)); festivalsCache = { ...festivalsCache, value, expiresAt: Date.now() + FESTIVALS_CACHE_TTL_MS, pending: null, }; return value; }); return jsonResponse(200, festivals, env, request); }
-export async function handleBannerEvents(request, env) { const now = Date.now(); const nowIso = new Date(now).toISOString(); const windowEndIso = getFestivalWindowEnd(now).toISOString(); const [eventRows, sourceRows] = await Promise.all([loadFestivalRowsFromDb(env, nowIso, windowEndIso, WorkerFestivalRuntimeConfig.bannerQueryLimit), supabaseRequest(env, `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`),]); const source = sourceRows[0] ?? null; const items = eventRows.length > 0 ? eventRows.slice(0, WorkerFestivalRuntimeConfig.bannerDisplayLimit).map((row) => buildBannerItem(row, now)) : []; return jsonResponse(200, { sourceReady: items.length > 0 || Boolean(source?.last_imported_at), sourceName: source?.name ?? null, importedAt: source?.last_imported_at ?? null, items, }, env, request); }
-export async function handleFestivalImport(request, env) { const configuredToken = readFestivalImportToken(env); if (!configuredToken) {
-    return jsonResponse(503, { detail: 'APP_EVENT_IMPORT_TOKEN is empty.' }, env, request);
-} const bearerToken = readBearerToken(request); if (!bearerToken || bearerToken !== configuredToken) {
-    return jsonResponse(401, { detail: '공공 행사 import 토큰이 올바르지 않아요.' }, env, request);
-} const payload = await request.json().catch(() => null); if (!payload || !Array.isArray(payload.items)) {
-    return jsonResponse(400, { detail: 'items 배열이 필요해요.' }, env, request);
-} let importedItems; try {
-    importedItems = await upsertImportedFestivalItems(env, payload.items, { sourceName: payload.sourceName, sourceUrl: payload.sourceUrl, importedAt: payload.importedAt, });
+
+function readFestivalImportToken(env: WorkerEnv) {
+  return String(env.APP_EVENT_IMPORT_TOKEN || '').trim();
 }
-catch (error) {
+
+function readBearerToken(request: Request) {
+  const authorization = request.headers.get('authorization') || '';
+  const match = authorization.match(/^Bearer\s+(.+)$/i);
+  return match ? match[1].trim() : '';
+}
+
+async function readFestivalImportPayload(request: Request) {
+  const payload = await request.json().catch(() => null);
+  return payload && typeof payload === 'object' ? (payload as WorkerJsonRecord) : null;
+}
+
+/**
+ * Handles `/api/festivals` without exposing cache or repository internals to routing.
+ */
+export async function handleFestivals(request: Request, env: WorkerEnv) {
+  const now = Date.now();
+  const festivals = await loadCachedFestivalCards(now, () => loadFestivalCards(env, now));
+  return jsonResponse(200, festivals, env, request);
+}
+
+/**
+ * Handles `/api/banner/events` using the festival read model service.
+ */
+export async function handleBannerEvents(request: Request, env: WorkerEnv) {
+  return jsonResponse(200, await loadBannerEvents(Date.now(), env), env, request);
+}
+
+/**
+ * Handles `/api/internal/public-events/import` while preserving token and response semantics.
+ */
+export async function handleFestivalImport(request: Request, env: WorkerEnv) {
+  const configuredToken = readFestivalImportToken(env);
+  if (!configuredToken) {
+    return jsonResponse(503, { detail: 'APP_EVENT_IMPORT_TOKEN is empty.' }, env, request);
+  }
+
+  const bearerToken = readBearerToken(request);
+  if (!bearerToken || bearerToken !== configuredToken) {
+    return jsonResponse(401, { detail: '공공 행사 import 토큰이 올바르지 않아요.' }, env, request);
+  }
+
+  const payload = await readFestivalImportPayload(request);
+  if (!payload || !Array.isArray(payload.items)) {
+    return jsonResponse(400, { detail: 'items 배열이 필요해요.' }, env, request);
+  }
+
+  let importedItems;
+  try {
+    importedItems = await upsertImportedFestivalItems(env, payload.items, {
+      sourceName: payload.sourceName,
+      sourceUrl: payload.sourceUrl,
+      importedAt: payload.importedAt,
+    });
+  } catch (error) {
     console.error('[worker] festival import failed', error);
     return jsonResponse(422, { detail: '공공 행사 데이터를 정리할 수 없어요.' }, env, request);
-} festivalsCache = { expiresAt: 0, syncAt: Date.now(), value: null, pending: null, }; return jsonResponse(200, { importedEvents: importedItems.length, sourceName: String(payload.sourceName || INTERNAL_FESTIVAL_SOURCE_NAME), importedAt: parseFestivalDate(payload.importedAt)?.toISOString() || new Date().toISOString(), }, env, request); }
+  }
 
+  clearFestivalCache();
+  return jsonResponse(
+    200,
+    {
+      importedEvents: importedItems.length,
+      sourceName: String(payload.sourceName || INTERNAL_FESTIVAL_SOURCE_NAME),
+      importedAt: parseFestivalDate(payload.importedAt)?.toISOString() || new Date().toISOString(),
+    },
+    env,
+    request,
+  );
+}

--- a/reports/completion/TSK-004-02-worker-festival-boundary-split.md
+++ b/reports/completion/TSK-004-02-worker-festival-boundary-split.md
@@ -2,7 +2,7 @@
 
 Scope-ID: `TSK-004-02-WORKER-FESTIVAL-BOUNDARY-SPLIT`
 Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/274
-PR: `TBD-TSK-004-02-WORKER-FESTIVAL-BOUNDARY-SPLIT`
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/280
 Branch: `worker-festival-boundary-split`
 Status: `validated-local`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272

--- a/reports/completion/TSK-004-02-worker-festival-boundary-split.md
+++ b/reports/completion/TSK-004-02-worker-festival-boundary-split.md
@@ -1,0 +1,69 @@
+# TSK-004-02 Worker Festival Boundary Split
+
+Scope-ID: `TSK-004-02-WORKER-FESTIVAL-BOUNDARY-SPLIT`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/274
+PR: `TBD-TSK-004-02-WORKER-FESTIVAL-BOUNDARY-SPLIT`
+Branch: `worker-festival-boundary-split`
+Status: `validated-local`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/274
+
+## Purpose
+
+`deploy/api-worker-shell/services/festivals.ts`에 섞여 있던 public handler, cache, Supabase repository, import orchestration, mapper 책임을 `festival-domain` 내부 모듈로 분리한다. 외부 REST endpoint와 응답 shape는 유지한다.
+
+## Current Decisions
+
+- public handler entry point는 `handleFestivals`, `handleBannerEvents`, `handleFestivalImport` 그대로 유지한다.
+- Supabase 호출은 `services/festival-domain/repository.ts`로 이동한다.
+- normalize, merge, deduplicate, card/banner mapping은 `services/festival-domain/mapper.ts`로 이동한다.
+- import sequence는 `services/festival-domain/import-service.ts`로 이동한다.
+- in-memory festival cache는 `services/festival-domain/cache.ts`로 이동한다.
+- festival read model assembly는 `services/festival-domain/read-service.ts`로 이동한다.
+- 사용자-facing copy, REST path, response shape, DB schema, OAuth 흐름은 변경하지 않는다.
+
+## Before And After Inventory
+
+| File | Before | After |
+| --- | ---: | ---: |
+| `deploy/api-worker-shell/services/festivals.ts` lines | 194 | 92 |
+| `deploy/api-worker-shell/services/festivals.ts` chars | 22,310 | 3,670 |
+| `deploy/api-worker-shell/services/festivals.ts` `supabaseRequest` | 9 | 0 |
+| `deploy/api-worker-shell/services/festivals.ts` `any` | 3 | 0 |
+| `deploy/api-worker-shell/services/festival-domain/repository.ts` `supabaseRequest` | 해당 없음 | 9 |
+| `deploy/api-worker-shell/services/festival-domain/mapper.ts` `any` | 해당 없음 | 0 |
+
+## Issue Scope
+
+- #274: festival service boundary split
+- #273: baseline gate completed by PR #279
+- #275~#277: 후속 mapper/handler/docs 작업
+
+## PR Scope
+
+이번 PR은 아래만 포함한다.
+
+- `services/festival-domain/*` 모듈 추가
+- `services/festivals.ts` thin handler화
+- festival read/import/cache/mapper 회귀 테스트 추가
+- numeric literal baseline 갱신
+
+## Validation Results
+
+로컬 검증 결과는 아래와 같다.
+
+- [x] targeted Vitest: `worker-festival-domain`, `worker-auth-security`, `worker-source-quality`, `numeric-literal-audit` 통과
+- [x] `npm.cmd run check:numeric-literals` 통과
+- [x] `npm.cmd run lint` 통과
+- [x] `npm.cmd run typecheck` 통과
+- [x] `npm.cmd run test:unit` 통과
+- [x] `npm.cmd run build` 통과
+- [x] `git diff --check` 통과
+- [x] UTF-8 integrity check 통과: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
+- [ ] PR checks: PR 생성 후 기록
+
+## Remaining Follow-Up Work
+
+- #275에서 review/community/my mapper row contract를 좁힌다.
+- #276에서 admin/stamp/notification/auth/review-interaction handler contract를 좁힌다.
+- #277에서 release candidate와 parent/child evidence를 정리한다.

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "3bcbbc4fd9e28d3b70f4899461e95dafbb7eb9e4",
+  "generatedFrom": "5fddc64d0f8b8a1f94f3505d2fb911958aa49a35",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -858,7 +858,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 10,
+          "line": 12,
           "column": 60
         }
       ]
@@ -1063,32 +1063,32 @@
       "examples": [
         {
           "value": "2",
-          "line": 23,
+          "line": 24,
           "column": 37
         },
         {
           "value": "6",
-          "line": 25,
+          "line": 26,
           "column": 37
         },
         {
           "value": "2",
-          "line": 104,
+          "line": 105,
           "column": 21
         },
         {
           "value": "8",
-          "line": 106,
+          "line": 107,
           "column": 27
         },
         {
           "value": "0",
-          "line": 134,
+          "line": 135,
           "column": 20
         },
         {
           "value": "1",
-          "line": 141,
+          "line": 142,
           "column": 60
         }
       ]
@@ -1168,7 +1168,7 @@
       "examples": [
         {
           "value": "500",
-          "line": 83,
+          "line": 82,
           "column": 27
         }
       ]
@@ -1248,12 +1248,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 65,
+          "line": 75,
           "column": 39
         },
         {
           "value": "0",
-          "line": 77,
+          "line": 87,
           "column": 25
         }
       ]
@@ -1268,12 +1268,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 33,
+          "line": 42,
           "column": 130
         },
         {
           "value": "0",
-          "line": 42,
+          "line": 51,
           "column": 108
         }
       ]
@@ -1288,32 +1288,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 22,
+          "line": 26,
           "column": 89
         },
         {
           "value": "1",
-          "line": 22,
+          "line": 26,
           "column": 115
         },
         {
           "value": "0",
-          "line": 29,
+          "line": 33,
           "column": 27
         },
         {
           "value": "0",
-          "line": 31,
+          "line": 35,
           "column": 19
         },
         {
           "value": "0",
-          "line": 32,
+          "line": 36,
           "column": 50
         },
         {
           "value": "1",
-          "line": 34,
+          "line": 38,
           "column": 37
         }
       ]
@@ -1328,12 +1328,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 18,
+          "line": 27,
           "column": 14
         },
         {
           "value": "0",
-          "line": 127,
+          "line": 136,
           "column": 37
         }
       ]
@@ -1363,32 +1363,32 @@
       "examples": [
         {
           "value": "200",
-          "line": 14,
+          "line": 16,
           "column": 5
         },
         {
           "value": "200",
-          "line": 45,
+          "line": 47,
           "column": 5
         },
         {
           "value": "0",
-          "line": 54,
+          "line": 56,
           "column": 44
         },
         {
           "value": "200",
-          "line": 65,
+          "line": 64,
           "column": 23
         },
         {
           "value": "200",
-          "line": 72,
+          "line": 71,
           "column": 5
         },
         {
           "value": "0",
-          "line": 83,
+          "line": 82,
           "column": 45
         }
       ]
@@ -1403,32 +1403,32 @@
       "examples": [
         {
           "value": "1",
-          "line": 74,
+          "line": 75,
           "column": 116
         },
         {
           "value": "1",
-          "line": 75,
+          "line": 76,
           "column": 92
         },
         {
           "value": "1",
-          "line": 76,
+          "line": 77,
           "column": 93
         },
         {
           "value": "1",
-          "line": 82,
+          "line": 83,
           "column": 87
         },
         {
           "value": "200",
-          "line": 83,
+          "line": 84,
           "column": 29
         },
         {
           "value": "1",
-          "line": 86,
+          "line": 87,
           "column": 102
         }
       ]
@@ -1638,32 +1638,32 @@
       "examples": [
         {
           "value": "1",
-          "line": 18,
+          "line": 19,
           "column": 71
         },
         {
           "value": "0",
-          "line": 20,
+          "line": 21,
           "column": 17
         },
         {
           "value": "1",
-          "line": 26,
+          "line": 27,
           "column": 117
         },
         {
           "value": "0",
-          "line": 28,
+          "line": 29,
           "column": 17
         },
         {
           "value": "2",
-          "line": 50,
+          "line": 51,
           "column": 27
         },
         {
           "value": "400",
-          "line": 52,
+          "line": 53,
           "column": 20
         }
       ]
@@ -1765,41 +1765,41 @@
     },
     {
       "path": "deploy/api-worker-shell/services/festivals.ts",
-      "count": 57,
+      "count": 8,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
       "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
       "examples": [
         {
-          "value": "0",
-          "line": 10,
-          "column": 35
+          "value": "1",
+          "line": 26,
+          "column": 24
         },
         {
-          "value": "0",
-          "line": 10,
-          "column": 46
+          "value": "200",
+          "line": 40,
+          "column": 23
         },
         {
-          "value": "0",
-          "line": 14,
-          "column": 259
+          "value": "200",
+          "line": 47,
+          "column": 23
         },
         {
-          "value": "2",
-          "line": 18,
-          "column": 170
+          "value": "503",
+          "line": 56,
+          "column": 25
         },
         {
-          "value": "00",
-          "line": 20,
-          "column": 70
+          "value": "401",
+          "line": 61,
+          "column": 25
         },
         {
-          "value": "00",
-          "line": 20,
-          "column": 73
+          "value": "400",
+          "line": 66,
+          "column": 25
         }
       ]
     },
@@ -1828,32 +1828,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 13,
+          "line": 20,
           "column": 40
         },
         {
           "value": "0",
-          "line": 15,
+          "line": 22,
           "column": 29
         },
         {
           "value": "401",
-          "line": 27,
+          "line": 34,
           "column": 27
         },
         {
           "value": "200",
-          "line": 33,
+          "line": 40,
           "column": 25
         },
         {
           "value": "401",
-          "line": 39,
+          "line": 46,
           "column": 27
         },
         {
           "value": "200",
-          "line": 54,
+          "line": 61,
           "column": 7
         }
       ]
@@ -1988,32 +1988,32 @@
       "examples": [
         {
           "value": "9",
-          "line": 22,
+          "line": 23,
           "column": 62
         },
         {
           "value": "9_",
-          "line": 40,
+          "line": 41,
           "column": 67
         },
         {
           "value": "401",
-          "line": 71,
+          "line": 72,
           "column": 37
         },
         {
           "value": "400",
-          "line": 85,
+          "line": 86,
           "column": 25
         },
         {
           "value": "400",
-          "line": 88,
+          "line": 89,
           "column": 25
         },
         {
           "value": "5242880",
-          "line": 90,
+          "line": 91,
           "column": 66
         }
       ]
@@ -2028,32 +2028,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 51,
+          "line": 60,
           "column": 39
         },
         {
           "value": "1",
-          "line": 67,
+          "line": 76,
           "column": 152
         },
         {
           "value": "0",
-          "line": 74,
+          "line": 83,
           "column": 37
         },
         {
           "value": "0",
-          "line": 98,
+          "line": 107,
           "column": 39
         },
         {
           "value": "1",
-          "line": 112,
+          "line": 121,
           "column": 142
         },
         {
           "value": "0",
-          "line": 114,
+          "line": 123,
           "column": 36
         }
       ]
@@ -3033,7 +3033,7 @@
       "examples": [
         {
           "value": "1",
-          "line": 61,
+          "line": 62,
           "column": 22
         }
       ]
@@ -3103,7 +3103,7 @@
       "examples": [
         {
           "value": "72",
-          "line": 54,
+          "line": 55,
           "column": 17
         }
       ]
@@ -3423,12 +3423,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 44,
+          "line": 45,
           "column": 26
         },
         {
           "value": "0",
-          "line": 68,
+          "line": 69,
           "column": 41
         }
       ]
@@ -3528,17 +3528,17 @@
       "examples": [
         {
           "value": "0",
-          "line": 25,
+          "line": 26,
           "column": 45
         },
         {
           "value": "1",
-          "line": 26,
+          "line": 27,
           "column": 72
         },
         {
           "value": "24",
-          "line": 29,
+          "line": 30,
           "column": 57
         }
       ]
@@ -4143,12 +4143,12 @@
       "examples": [
         {
           "value": "1",
-          "line": 55,
+          "line": 56,
           "column": 34
         },
         {
           "value": "1",
-          "line": 111,
+          "line": 112,
           "column": 66
         }
       ]
@@ -4163,7 +4163,7 @@
       "examples": [
         {
           "value": "1",
-          "line": 73,
+          "line": 76,
           "column": 93
         }
       ]
@@ -4208,17 +4208,17 @@
       "examples": [
         {
           "value": "1",
-          "line": 52,
+          "line": 54,
           "column": 55
         },
         {
           "value": "0",
-          "line": 81,
+          "line": 83,
           "column": 66
         },
         {
           "value": "1",
-          "line": 81,
+          "line": 83,
           "column": 71
         }
       ]
@@ -4283,7 +4283,7 @@
       "examples": [
         {
           "value": "1",
-          "line": 60,
+          "line": 61,
           "column": 63
         }
       ]
@@ -4313,7 +4313,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 78,
+          "line": 71,
           "column": 56
         }
       ]

--- a/test/unit/worker-festival-domain.test.ts
+++ b/test/unit/worker-festival-domain.test.ts
@@ -1,0 +1,190 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { clearFestivalCache } from '../../deploy/api-worker-shell/services/festival-domain/cache';
+import { normalizeImportedFestivalItems } from '../../deploy/api-worker-shell/services/festival-domain/mapper';
+import { handleBannerEvents, handleFestivalImport, handleFestivals } from '../../deploy/api-worker-shell/services/festivals';
+import type { WorkerEnv } from '../../deploy/api-worker-shell/types';
+
+const apiUrl = 'https://api.daejeon.jamissue.com';
+
+function buildEnv(overrides: WorkerEnv = {}): WorkerEnv {
+  return {
+    APP_SUPABASE_URL: 'https://supabase.example.test',
+    APP_SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    APP_EVENT_IMPORT_TOKEN: 'expected-token',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function sampleFestivalRow() {
+  return {
+    public_event_id: 11,
+    title: '대전 봄 축제',
+    venue_name: '대전시청 광장',
+    district: '서구',
+    address: '대전 서구 둔산동',
+    road_address: '대전광역시 서구 둔산로 100',
+    starts_at: '2026-05-10T00:00:00+09:00',
+    ends_at: '2026-06-20T23:59:59+09:00',
+    summary: '봄 행사',
+    source_page_url: 'https://example.test/event',
+    latitude: '36.3504',
+    longitude: '127.3845',
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.useRealTimers();
+  clearFestivalCache(0);
+});
+
+describe('worker festival domain boundary', () => {
+  it('keeps /api/festivals response shape and cache hit semantics', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00+09:00'));
+    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([sampleFestivalRow()]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const request = new Request(`${apiUrl}/api/festivals`);
+    const first = await handleFestivals(request, buildEnv());
+    const second = await handleFestivals(request, buildEnv());
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(200);
+    expect(await first.json()).toEqual([
+      {
+        id: '11',
+        title: '대전 봄 축제',
+        venueName: '대전시청 광장',
+        startDate: '2026-05-10',
+        endDate: '2026-06-20',
+        homepageUrl: 'https://example.test/event',
+        roadAddress: '대전광역시 서구 둔산로 100',
+        latitude: 36.3504,
+        longitude: 127.3845,
+        isOngoing: true,
+      },
+    ]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps /api/banner/events source and item response shape', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00+09:00'));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([sampleFestivalRow()]))
+      .mockResolvedValueOnce(jsonResponse([{ name: 'Daejeon Official Event Search', last_imported_at: '2026-05-11T00:00:00.000Z' }]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handleBannerEvents(new Request(`${apiUrl}/api/banner/events`), buildEnv());
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      sourceReady: true,
+      sourceName: 'Daejeon Official Event Search',
+      importedAt: '2026-05-11T00:00:00.000Z',
+      items: [
+        {
+          id: '11',
+          title: '대전 봄 축제',
+          venueName: '대전시청 광장',
+          district: '서구',
+          startDate: '2026-05-10T00:00:00+09:00',
+          endDate: '2026-06-20T23:59:59+09:00',
+          dateLabel: '05. 10. - 06. 20.',
+          summary: '봄 행사',
+          sourcePageUrl: 'https://example.test/event',
+          linkedPlaceName: null,
+          isOngoing: true,
+        },
+      ],
+    });
+  });
+
+  it('keeps festival import token and valid path semantics', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-11T00:00:00+09:00'));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([{ source_id: 7, source_key: 'jamissue-public-event-feed' }]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handleFestivalImport(
+      new Request(`${apiUrl}/api/internal/public-events/import`, {
+        method: 'POST',
+        headers: { authorization: 'Bearer expected-token' },
+        body: JSON.stringify({
+          sourceName: 'Official',
+          importedAt: '2026-05-11',
+          items: [
+            {
+              externalId: 'event-1',
+              title: '대전 봄 축제',
+              venueName: '대전시청 광장',
+              roadAddress: '대전광역시 서구 둔산로 100',
+              startsAt: '2026-05-10',
+              endsAt: '2026-05-12',
+            },
+          ],
+        }),
+      }),
+      buildEnv(),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      importedEvents: 1,
+      sourceName: 'Official',
+      importedAt: '2026-05-11T00:00:00.000Z',
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(5);
+    expect(String(fetchMock.mock.calls[3][0])).toContain('public_event?on_conflict=source_id,external_id');
+  });
+
+  it('keeps festival import merge and deduplicate behavior in the mapper layer', () => {
+    const items = normalizeImportedFestivalItems(
+      [
+        {
+          externalId: 'event-1',
+          title: '대전 봄 축제',
+          venueName: '대전시청 광장',
+          roadAddress: '대전광역시 서구 둔산로 100',
+          startsAt: '2026-05-10',
+          endsAt: '2026-05-11',
+          summary: '',
+        },
+        {
+          externalId: 'event-2',
+          title: '대전 봄 축제',
+          venueName: '대전시청 광장',
+          roadAddress: '대전광역시 서구 둔산로 100',
+          startsAt: '2026-05-12',
+          endsAt: '2026-05-13',
+          summary: '상세 행사',
+        },
+      ],
+      '대전',
+    );
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      title: '대전 봄 축제',
+      startsAt: '2026-05-10T00:00:00.000Z',
+      endsAt: '2026-05-13T23:59:59.000Z',
+      summary: '대전시청 광장에서 열리는 대전 행사예요.',
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Refs #274

Parent issue: #272
Scope-ID: `TSK-004-02-WORKER-FESTIVAL-BOUNDARY-SPLIT`
Branch: `worker-festival-boundary-split`

This PR splits the Worker festival service into domain-owned repository, mapper, import, cache, and read-service boundaries while preserving public endpoints and response shapes.

## Changes

- Kept public handlers stable: `handleFestivals`, `handleBannerEvents`, `handleFestivalImport`.
- Moved Supabase access to `services/festival-domain/repository.ts`.
- Moved normalize/merge/deduplicate/card/banner mapping to `services/festival-domain/mapper.ts`.
- Moved import orchestration to `services/festival-domain/import-service.ts`.
- Moved in-memory festival cache state to `services/festival-domain/cache.ts`.
- Added festival response/import/cache/merge regression tests.
- Updated numeric literal baseline for the refactored file split.

## Boundary Evidence

| Metric | Before | After |
| --- | ---: | ---: |
| `services/festivals.ts` lines | 194 | 92 |
| `services/festivals.ts` chars | 22,310 | 3,670 |
| `services/festivals.ts` `supabaseRequest` | 9 | 0 |
| `services/festivals.ts` `any` | 3 | 0 |
| `festival-domain/repository.ts` `supabaseRequest` | n/a | 9 |
| `festival-domain/mapper.ts` `any` | n/a | 0 |

## Validation

- [x] targeted Vitest: `worker-festival-domain`, `worker-auth-security`, `worker-source-quality`, `numeric-literal-audit`
- [x] `npm.cmd run check:numeric-literals`
- [x] `npm.cmd run lint`
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run test:unit`
- [x] `npm.cmd run build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`

## Non-Goals

- No REST path changes.
- No response shape changes.
- No DB schema changes.
- No user-facing copy changes.
- No Kakao/Naver OAuth flow changes.
