### PR TITLE
Type Worker domain mapper row contracts

### DIFF
--- a/deploy/api-worker-shell/runtime/base-data-repository.ts
+++ b/deploy/api-worker-shell/runtime/base-data-repository.ts
@@ -5,19 +5,24 @@ import type {
   SupabaseCourseRow,
   SupabaseMapRow,
   WorkerFeedLikeRow,
-  WorkerFeedRow,
   WorkerPositionStampRow,
   WorkerStampRow,
   WorkerStaticBaseRows,
   WorkerTravelSessionRow,
   WorkerUserRouteRow,
-  WorkerUserSummaryRow,
 } from './base-data-contracts';
 import type { SupabaseCacheState } from '../lib/supabase';
 import type {
   WorkerEnv,
   WorkerJsonRecord,
 } from '../types';
+import type {
+  WorkerReviewCommentRow,
+  WorkerReviewFeedRow,
+  WorkerReviewRouteRow,
+  WorkerReviewStampRow,
+  WorkerReviewUserRow,
+} from '../services/review-domain/contracts';
 
 const STATIC_BASE_CACHE_TTL_MS = WorkerBaseDataRuntimeConfig.staticBaseCacheTtlMs;
 
@@ -31,17 +36,17 @@ let staticBaseCache: SupabaseCacheState<WorkerStaticBaseRows> & {
 
 export interface WorkerBaseDataRows {
   staticRows: WorkerStaticBaseRows;
-  feedRows: WorkerFeedRow[];
-  commentRows: WorkerJsonRecord[];
+  feedRows: WorkerReviewFeedRow[];
+  commentRows: WorkerReviewCommentRow[];
   likeRows: WorkerFeedLikeRow[];
-  reviewStampRows: WorkerStampRow[];
+  reviewStampRows: WorkerReviewStampRow[];
   userFeedLikeRows: WorkerFeedLikeRow[];
   userSessionRows: WorkerTravelSessionRow[];
   ownerRouteRows: WorkerUserRouteRow[];
   userStampRows: WorkerStampRow[];
   allPlaceStampRows: WorkerPositionStampRow[];
-  reviewRouteRows: WorkerUserRouteRow[];
-  userRows: WorkerUserSummaryRow[];
+  reviewRouteRows: WorkerReviewRouteRow[];
+  userRows: WorkerReviewUserRow[];
 }
 
 export async function loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBaseRows> {
@@ -68,7 +73,7 @@ export async function loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBa
 export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | null = null): Promise<WorkerBaseDataRows> {
   const [staticRows, feedRows] = await Promise.all([
     loadStaticBaseRows(env),
-    supabaseRequest<WorkerFeedRow[]>(
+    supabaseRequest<WorkerReviewFeedRow[]>(
       env,
       'feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&order=created_at.desc',
     ),
@@ -87,14 +92,14 @@ export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | n
     allPlaceStampRows = [],
   ] = await Promise.all([
     feedIdsFilter
-        ? supabaseRequest<WorkerStampRow[]>(
+        ? supabaseRequest<WorkerReviewCommentRow[]>(
           env,
           `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`,
         )
       : Promise.resolve([]),
     feedIdsFilter ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
     reviewStampIdsFilter
-        ? supabaseRequest<WorkerTravelSessionRow[]>(
+        ? supabaseRequest<WorkerReviewStampRow[]>(
           env,
           `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`,
         )
@@ -134,14 +139,14 @@ export async function loadBaseDataRows(env: WorkerEnv, sessionUserId: string | n
   ];
   const reviewRouteRows =
     reviewTravelSessionIds.length > 0
-      ? await supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+      ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
       : [];
   const userIdsFilter = buildInFilter([
     ...feedRows.map((row) => row.user_id),
     ...commentRows.map((row) => row.user_id),
     ...(sessionUserId ? [sessionUserId] : []),
   ]);
-  const userRows = userIdsFilter ? await supabaseRequest<WorkerUserSummaryRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+  const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
 
   return {
     staticRows,

--- a/deploy/api-worker-shell/services/community-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/community-domain/contracts.ts
@@ -9,6 +9,40 @@
 import type { WorkerEnv, WorkerJsonRecord } from '../../types';
 import type { WorkerStaticBaseRows } from '../../runtime/base-data-contracts';
 
+export interface WorkerCommunityRouteRow extends WorkerJsonRecord {
+  route_id: string | number;
+  user_id: string;
+  title: string;
+  description?: string | null;
+  mood?: string | null;
+  like_count?: number | null;
+  created_at: string;
+  is_user_generated?: boolean | null;
+  travel_session_id?: string | number | null;
+}
+
+export interface WorkerCommunityRoutePlaceRow extends WorkerJsonRecord {
+  route_id: string | number;
+  position_id: string | number;
+  stop_order: number;
+}
+
+export interface WorkerCommunityRouteLikeRow extends WorkerJsonRecord {
+  route_id: string | number;
+}
+
+export interface WorkerCommunityUserRow extends WorkerJsonRecord {
+  user_id: string;
+  nickname?: string | null;
+}
+
+export interface WorkerCommunityPlaceRef extends WorkerJsonRecord {
+  id: string;
+  name: string;
+}
+
+export type WorkerCommunityPlaceMap = Map<string, WorkerCommunityPlaceRef>;
+
 export interface WorkerCommunityRouteLoadOptions extends WorkerJsonRecord {
   ownerUserId?: string | null;
   sessionUserId?: string | null;

--- a/deploy/api-worker-shell/services/community-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/community-domain/mapper.ts
@@ -1,19 +1,33 @@
 import { formatDateTime } from '../../lib/dates';
+import type {
+  WorkerCommunityPlaceMap,
+  WorkerCommunityRoutePlaceRow,
+  WorkerCommunityRouteRow,
+  WorkerCommunityUserRow,
+} from './contracts';
+
+interface WorkerCommunityRoutePlaceRef {
+  stopOrder: number;
+  placeId: string;
+}
 
 export function mapCommunityRoutes(
-  routeRows: any[],
-  routePlaceRows: any[],
-  usersById: Map<any, any>,
-  placesByPositionId: Map<any, any>,
-  likedRouteIds = new Set<any>(),
+  routeRows: WorkerCommunityRouteRow[],
+  routePlaceRows: WorkerCommunityRoutePlaceRow[],
+  usersById: Map<string, WorkerCommunityUserRow>,
+  placesByPositionId: WorkerCommunityPlaceMap,
+  likedRouteIds = new Set<string>(),
 ) {
-  const placeRowsByRouteId = new Map();
+  const placeRowsByRouteId = new Map<string, WorkerCommunityRoutePlaceRef[]>();
   for (const row of routePlaceRows) {
     const routeId = String(row.route_id);
     if (!placeRowsByRouteId.has(routeId)) {
       placeRowsByRouteId.set(routeId, []);
     }
-    placeRowsByRouteId.get(routeId).push({ stopOrder: row.stop_order, placeId: placesByPositionId.get(String(row.position_id))?.id ?? String(row.position_id) });
+    placeRowsByRouteId.get(routeId)?.push({
+      stopOrder: row.stop_order,
+      placeId: placesByPositionId.get(String(row.position_id))?.id ?? String(row.position_id),
+    });
   }
 
   return routeRows.map((row) => {

--- a/deploy/api-worker-shell/services/community-domain/repository.ts
+++ b/deploy/api-worker-shell/services/community-domain/repository.ts
@@ -1,5 +1,11 @@
 import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
 import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+import type {
+  WorkerCommunityRouteLikeRow,
+  WorkerCommunityRoutePlaceRow,
+  WorkerCommunityRouteRow,
+  WorkerCommunityUserRow,
+} from './contracts';
 
 export async function readRouteRow(env: WorkerEnv, routeId: string) {
   const rows = await supabaseRequest<WorkerJsonRecord[]>(
@@ -14,26 +20,26 @@ export async function loadRouteRows(env: WorkerEnv, options: { sort?: string; ow
   const routeFilter = ownerUserId
     ? `user_id=eq.${encodeFilterValue(ownerUserId)}&order=created_at.desc`
     : `is_public=eq.true&order=${sort === 'popular' ? 'like_count.desc,created_at.desc' : 'created_at.desc'}`;
-  return supabaseRequest<WorkerJsonRecord[]>(
+  return supabaseRequest<WorkerCommunityRouteRow[]>(
     env,
     `user_route?select=route_id,user_id,travel_session_id,title,description,mood,like_count,created_at,is_public,is_user_generated&${routeFilter}`,
   );
 }
 
-export async function loadRouteDetailRows(env: WorkerEnv, routeRows: WorkerJsonRecord[], sessionUserId: string | null) {
-  const routeIdsFilter = buildInFilter(routeRows.map((row: any) => row.route_id));
+export async function loadRouteDetailRows(env: WorkerEnv, routeRows: WorkerCommunityRouteRow[], sessionUserId: string | null) {
+  const routeIdsFilter = buildInFilter(routeRows.map((row) => row.route_id));
   if (!routeIdsFilter) {
     return { routePlaceRows: [], userRouteLikeRows: [], userRows: [] };
   }
 
   const [routePlaceRows, userRouteLikeRows = []] = await Promise.all([
-    supabaseRequest<WorkerJsonRecord[]>(env, `user_route_place?select=route_id,position_id,stop_order&route_id=${routeIdsFilter}&order=stop_order.asc`),
+    supabaseRequest<WorkerCommunityRoutePlaceRow[]>(env, `user_route_place?select=route_id,position_id,stop_order&route_id=${routeIdsFilter}&order=stop_order.asc`),
     sessionUserId
-      ? supabaseRequest<WorkerJsonRecord[]>(env, `user_route_like?select=route_id&user_id=eq.${encodeFilterValue(sessionUserId)}&route_id=${routeIdsFilter}`)
+      ? supabaseRequest<WorkerCommunityRouteLikeRow[]>(env, `user_route_like?select=route_id&user_id=eq.${encodeFilterValue(sessionUserId)}&route_id=${routeIdsFilter}`)
       : Promise.resolve([]),
   ]);
-  const userIdsFilter = buildInFilter(routeRows.map((row: any) => row.user_id));
-  const userRows = userIdsFilter ? await supabaseRequest<WorkerJsonRecord[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+  const userIdsFilter = buildInFilter(routeRows.map((row) => row.user_id));
+  const userRows = userIdsFilter ? await supabaseRequest<WorkerCommunityUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
   return { routePlaceRows, userRouteLikeRows, userRows };
 }
 

--- a/deploy/api-worker-shell/services/my-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/my-domain/contracts.ts
@@ -6,10 +6,36 @@
  * Non-Goals: This file does not implement summaries, comments, notification reads, or persistence.
  * Dependencies: Worker environment primitives.
  */
-import type { WorkerEnv } from '../../types';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
 import type { WorkerBaseData, WorkerStaticBaseRows } from '../../runtime/base-data-contracts';
-import type { WorkerJsonRecord } from '../../types';
 import type { WorkerCommunityRouteService } from '../community-domain/contracts';
+
+export interface WorkerMyCommentRow extends WorkerJsonRecord {
+  comment_id: string | number;
+  feed_id: string | number;
+  body?: string | null;
+  parent_id?: string | number | null;
+  is_deleted?: boolean | null;
+  created_at: string;
+}
+
+export interface WorkerMyFeedRow extends WorkerJsonRecord {
+  feed_id?: string | number;
+  id?: string | number;
+  position_id?: string | number | null;
+  placeId?: string | null;
+  placeName?: string | null;
+  body?: string | null;
+}
+
+export type WorkerMyFeedInput = WorkerMyFeedRow[] | Map<string, WorkerMyFeedRow>;
+
+export interface WorkerMyPlaceRef extends WorkerJsonRecord {
+  id: string;
+  name: string;
+}
+
+export type WorkerMyPlaceMap = Map<string, WorkerMyPlaceRef>;
 
 export interface WorkerMyServiceDeps {
   communityRouteService: WorkerCommunityRouteService;

--- a/deploy/api-worker-shell/services/my-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/my-domain/mapper.ts
@@ -1,11 +1,19 @@
 import { formatDateTime } from '../../lib/dates';
+import type { WorkerMyCommentRow, WorkerMyFeedInput, WorkerMyFeedRow, WorkerMyPlaceMap } from './contracts';
 
-export function mapMyComments(commentRows: any[], feedRows: any, placesByPositionId: Map<any, any>) {
-  const isDeletedCommentRow = (row: any) => {
+export function mapMyComments(
+  commentRows: WorkerMyCommentRow[],
+  feedRows: WorkerMyFeedInput,
+  placesByPositionId: WorkerMyPlaceMap,
+) {
+  const isDeletedCommentRow = (row: WorkerMyCommentRow) => {
     const body = String(row?.body ?? '').trim();
     return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.';
   };
-  const feedById = feedRows instanceof Map ? feedRows : new Map((feedRows ?? []).map((row) => [String(row.feed_id ?? row.id), row]));
+  const feedById =
+    feedRows instanceof Map
+      ? feedRows
+      : new Map<string, WorkerMyFeedRow>((feedRows ?? []).map((row) => [String(row.feed_id ?? row.id), row]));
   return commentRows
     .filter((row) => !isDeletedCommentRow(row))
     .map((row) => {

--- a/deploy/api-worker-shell/services/my-domain/repository.ts
+++ b/deploy/api-worker-shell/services/my-domain/repository.ts
@@ -1,5 +1,6 @@
 import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
-import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+import type { WorkerEnv } from '../../types';
+import type { WorkerMyCommentRow, WorkerMyFeedRow } from './contracts';
 
 export async function loadMyCommentRows(env: WorkerEnv, userId: string, cursor: string | null, limit: number) {
   const query = [
@@ -11,19 +12,19 @@ export async function loadMyCommentRows(env: WorkerEnv, userId: string, cursor: 
   if (cursor) {
     query.push(`created_at=lt.${encodeFilterValue(cursor)}`);
   }
-  return supabaseRequest<WorkerJsonRecord[]>(env, `user_comment?${query.join('&')}`);
+  return supabaseRequest<WorkerMyCommentRow[]>(env, `user_comment?${query.join('&')}`);
 }
 
-export async function loadFeedsForCommentRows(env: WorkerEnv, commentRows: WorkerJsonRecord[]) {
-  const feedIdsFilter = buildInFilter(commentRows.map((row: any) => row.feed_id));
+export async function loadFeedsForCommentRows(env: WorkerEnv, commentRows: WorkerMyCommentRow[]) {
+  const feedIdsFilter = buildInFilter(commentRows.map((row) => row.feed_id));
   if (!feedIdsFilter) {
     return [];
   }
-  return supabaseRequest<WorkerJsonRecord[]>(env, `feed?select=feed_id,position_id,body&feed_id=${feedIdsFilter}`);
+  return supabaseRequest<WorkerMyFeedRow[]>(env, `feed?select=feed_id,position_id,body&feed_id=${feedIdsFilter}`);
 }
 
 export async function loadMySummaryCommentRows(env: WorkerEnv, userId: string) {
-  return supabaseRequest<WorkerJsonRecord[]>(
+  return supabaseRequest<WorkerMyCommentRow[]>(
     env,
     `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc`,
   );

--- a/deploy/api-worker-shell/services/review-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/review-domain/contracts.ts
@@ -10,6 +10,48 @@ import type { SupabaseMapRow, WorkerBaseData, WorkerPlace, WorkerStaticBaseRows 
 import type { WorkerEnv, WorkerJsonRecord, WorkerSessionUser } from '../../types';
 import type { WorkerReview } from './read-model';
 
+export interface WorkerReviewFeedRow extends WorkerJsonRecord {
+  feed_id: string | number;
+  user_id: string;
+  position_id: string | number;
+  body: string;
+  mood?: string | null;
+  badge?: string | null;
+  created_at: string;
+  image_url?: string | null;
+  stamp_id?: string | number | null;
+}
+
+export interface WorkerReviewCommentRow extends WorkerJsonRecord {
+  comment_id: string | number;
+  feed_id: string | number;
+  user_id: string;
+  body?: string | null;
+  parent_id?: string | number | null;
+  is_deleted?: boolean | null;
+  created_at: string;
+}
+
+export interface WorkerReviewLikeRow extends WorkerJsonRecord {
+  feed_id: string | number;
+}
+
+export interface WorkerReviewUserRow extends WorkerJsonRecord {
+  user_id: string;
+  nickname?: string | null;
+}
+
+export interface WorkerReviewStampRow extends WorkerJsonRecord {
+  stamp_id: string | number;
+  visit_ordinal?: number | null;
+  travel_session_id?: string | number | null;
+}
+
+export interface WorkerReviewRouteRow extends WorkerJsonRecord {
+  route_id: string | number;
+  travel_session_id?: string | number | null;
+}
+
 export interface WorkerReviewReadServiceDeps {
   formatVisitLabel: (visitNumber: unknown) => string;
   loadStaticBaseRows(env: WorkerEnv): Promise<WorkerStaticBaseRows>;

--- a/deploy/api-worker-shell/services/review-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/review-domain/mapper.ts
@@ -1,7 +1,27 @@
 import { formatDateTime } from '../../lib/dates';
+import type { WorkerPlace } from '../../runtime/base-data-contracts';
+import type { WorkerReview, WorkerReviewComment } from './read-model';
+import type {
+  WorkerReviewCommentRow,
+  WorkerReviewFeedRow,
+  WorkerReviewLikeRow,
+  WorkerReviewRouteRow,
+  WorkerReviewStampRow,
+  WorkerReviewUserRow,
+} from './contracts';
+
+interface WorkerReviewCommentNode extends WorkerReviewComment {
+  userId: string;
+  author: string;
+  body: string | null;
+  parentId: string | null;
+  isDeleted: boolean;
+  createdAt: string;
+  replies: WorkerReviewCommentNode[];
+}
 
 export function createReviewMapper(formatVisitLabel: (visitNumber: unknown) => string) {
-  function countComments(comments: any[]): number {
+  function countComments(comments: WorkerReviewCommentNode[]): number {
     let total = 0;
     for (const comment of comments) {
       total += 1 + countComments(comment.replies);
@@ -9,25 +29,25 @@ export function createReviewMapper(formatVisitLabel: (visitNumber: unknown) => s
     return total;
   }
 
-  function buildCommentTree(commentRows: any[], usersById: Map<any, any>) {
-    const isDeletedCommentRow = (row: any) => {
+  function buildCommentTree(commentRows: WorkerReviewCommentRow[], usersById: Map<string, WorkerReviewUserRow>) {
+    const isDeletedCommentRow = (row: WorkerReviewCommentRow) => {
       const body = String(row?.body ?? '').trim();
       return Boolean(row?.is_deleted) || body === '[deleted]' || body === '삭제된 댓글입니다.';
     };
-    const commentsById = new Map<string, any>();
-    const rowsById = new Map<string, any>(commentRows.map((row) => [String(row.comment_id), row]));
-    const roots: any[] = [];
+    const commentsById = new Map<string, WorkerReviewCommentNode>();
+    const rowsById = new Map<string, WorkerReviewCommentRow>(commentRows.map((row) => [String(row.comment_id), row]));
+    const roots: WorkerReviewCommentNode[] = [];
     for (const row of commentRows) {
       const comment = {
         id: String(row.comment_id),
         userId: row.user_id,
         author: usersById.get(row.user_id)?.nickname ?? '이름 없음',
-        body: isDeletedCommentRow(row) ? '삭제된 댓글입니다.' : row.body,
+        body: isDeletedCommentRow(row) ? '삭제된 댓글입니다.' : (row.body ?? null),
         parentId: row.parent_id ? String(row.parent_id) : null,
         isDeleted: isDeletedCommentRow(row),
         createdAt: formatDateTime(row.created_at),
         replies: [],
-      };
+      } satisfies WorkerReviewCommentNode;
       commentsById.set(comment.id, comment);
     }
     for (const comment of commentsById.values()) {
@@ -40,9 +60,10 @@ export function createReviewMapper(formatVisitLabel: (visitNumber: unknown) => s
       }
     }
 
-    const hasLiveDescendant = (node: any): boolean => node.replies.some((reply: any) => !reply.isDeleted || hasLiveDescendant(reply));
-    const collapseDeletedNodes = (nodes: any[]) =>
-      nodes.reduce((acc: any[], node: any) => {
+    const hasLiveDescendant = (node: WorkerReviewCommentNode): boolean =>
+      node.replies.some((reply) => !reply.isDeleted || hasLiveDescendant(reply));
+    const collapseDeletedNodes = (nodes: WorkerReviewCommentNode[]) =>
+      nodes.reduce<WorkerReviewCommentNode[]>((acc, node) => {
         const nextNode = { ...node, replies: collapseDeletedNodes(node.replies) };
         if (nextNode.isDeleted) {
           if (hasLiveDescendant(nextNode)) {
@@ -57,24 +78,24 @@ export function createReviewMapper(formatVisitLabel: (visitNumber: unknown) => s
   }
 
   function mapReviewRows(
-    feedRows: any[],
-    commentRows: any[],
-    likeRows: any[],
-    usersById: Map<any, any>,
-    placesByPositionId: Map<any, any>,
-    stampRowsById: Map<any, any>,
-    routeRows: any[] = [],
-    likedFeedIds = new Set<any>(),
-  ) {
-    const commentsByFeedId = new Map();
+    feedRows: WorkerReviewFeedRow[],
+    commentRows: WorkerReviewCommentRow[],
+    likeRows: WorkerReviewLikeRow[],
+    usersById: Map<string, WorkerReviewUserRow>,
+    placesByPositionId: Map<string, WorkerPlace>,
+    stampRowsById: Map<string, WorkerReviewStampRow>,
+    routeRows: WorkerReviewRouteRow[] = [],
+    likedFeedIds = new Set<string>(),
+  ): WorkerReview[] {
+    const commentsByFeedId = new Map<string, WorkerReviewCommentRow[]>();
     for (const row of commentRows) {
       const feedId = String(row.feed_id);
       if (!commentsByFeedId.has(feedId)) {
         commentsByFeedId.set(feedId, []);
       }
-      commentsByFeedId.get(feedId).push(row);
+      commentsByFeedId.get(feedId)?.push(row);
     }
-    const likesByFeedId = new Map();
+    const likesByFeedId = new Map<string, number>();
     for (const row of likeRows) {
       const feedId = String(row.feed_id);
       likesByFeedId.set(feedId, (likesByFeedId.get(feedId) ?? 0) + 1);

--- a/deploy/api-worker-shell/services/reviews.ts
+++ b/deploy/api-worker-shell/services/reviews.ts
@@ -3,15 +3,19 @@ import { buildInFilter, encodeFilterValue, parseListLimit, supabaseRequest } fro
 import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
 import { createReviewMapper } from './review-domain/mapper';
+import type { SupabaseMapRow } from '../runtime/base-data-contracts';
+import type { WorkerEnv } from '../types';
 import type {
-  WorkerFeedLikeRow,
-  WorkerFeedRow,
-  WorkerStampRow,
-  WorkerUserRouteRow,
-  WorkerUserSummaryRow,
-} from '../runtime/base-data-contracts';
-import type { WorkerEnv, WorkerJsonRecord } from '../types';
-import type { WorkerReviewDataFilters, WorkerReviewPageOptions, WorkerReviewReadServiceDeps } from './review-domain/contracts';
+  WorkerReviewCommentRow,
+  WorkerReviewDataFilters,
+  WorkerReviewFeedRow,
+  WorkerReviewLikeRow,
+  WorkerReviewPageOptions,
+  WorkerReviewReadServiceDeps,
+  WorkerReviewRouteRow,
+  WorkerReviewStampRow,
+  WorkerReviewUserRow,
+} from './review-domain/contracts';
 
 export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, mapPlace }: WorkerReviewReadServiceDeps) {
   const { buildCommentTree, countComments, mapReviewRows } = createReviewMapper(formatVisitLabel);
@@ -33,19 +37,19 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
       reviewQuery.push(`user_id=eq.${encodeFilterValue(filters.userId)}`);
     }
 
-    const feedRows = await supabaseRequest<WorkerFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
+    const feedRows = await supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
     const feedIdsFilter = buildInFilter(feedRows.map((row) => row.feed_id));
     const reviewStampIdsFilter = buildInFilter(feedRows.map((row) => row.stamp_id).filter(Boolean));
     const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
       feedIdsFilter
-        ? supabaseRequest<WorkerJsonRecord[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
+        ? supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
         : Promise.resolve([]),
-      feedIdsFilter ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
+      feedIdsFilter ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
       reviewStampIdsFilter
-        ? supabaseRequest<WorkerStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
+        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
         : Promise.resolve([]),
       sessionUserId && feedIdsFilter
-        ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
+        ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
         : Promise.resolve([]),
     ]);
     const reviewTravelSessionIds = [
@@ -58,10 +62,10 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     ];
     const reviewRouteRows =
       reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
         : [];
     const userIdsFilter = buildInFilter([...feedRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerUserSummaryRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
     const usersById = new Map(userRows.map((row) => [row.user_id, row]));
     const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
     const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
@@ -78,21 +82,21 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
       reviewQuery.push(`created_at=lt.${encodeFilterValue(cursor)}`);
     }
 
-    const feedRows = await supabaseRequest<WorkerFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
+    const feedRows = await supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
     const nextCursor = feedRows.length > limit ? String(feedRows[limit].created_at) : null;
     const pageRows = feedRows.slice(0, limit);
     const feedIdsFilter = buildInFilter(pageRows.map((row) => row.feed_id));
     const reviewStampIdsFilter = buildInFilter(pageRows.map((row) => row.stamp_id).filter(Boolean));
     const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
       feedIdsFilter
-        ? supabaseRequest<WorkerJsonRecord[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
+        ? supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
         : Promise.resolve([]),
-      feedIdsFilter ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
+      feedIdsFilter ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
       reviewStampIdsFilter
-        ? supabaseRequest<WorkerStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
+        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
         : Promise.resolve([]),
       sessionUserId && feedIdsFilter
-        ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
+        ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
         : Promise.resolve([]),
     ]);
     const reviewTravelSessionIds = [
@@ -105,10 +109,10 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     ];
     const reviewRouteRows =
       reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
         : [];
     const userIdsFilter = buildInFilter([...pageRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerUserSummaryRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
     const usersById = new Map(userRows.map((row) => [row.user_id, row]));
     const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
     const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
@@ -116,7 +120,7 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
   }
 
   async function loadSingleReview(env: WorkerEnv, reviewId: string, sessionUserId: string | null = null) {
-    const reviewRows = await supabaseRequest<WorkerFeedRow[]>(
+    const reviewRows = await supabaseRequest<WorkerReviewFeedRow[]>(
       env,
       `feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`,
     );
@@ -125,16 +129,16 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
       return null;
     }
     const [commentRows, likeRows, placeRows, stampRows, userFeedLikeRows = []] = await Promise.all([
-      supabaseRequest<WorkerJsonRecord[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&order=created_at.asc`),
-      supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}`),
-      supabaseRequest(
+      supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&order=created_at.asc`),
+      supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}`),
+      supabaseRequest<SupabaseMapRow[]>(
         env,
         `map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&position_id=eq.${encodeFilterValue(reviewRow.position_id)}&limit=1`,
       ),
       reviewRow.stamp_id
-        ? supabaseRequest<WorkerStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=eq.${encodeFilterValue(reviewRow.stamp_id)}&limit=1`)
+        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=eq.${encodeFilterValue(reviewRow.stamp_id)}&limit=1`)
         : Promise.resolve([]),
-      sessionUserId ? supabaseRequest<WorkerFeedLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`) : Promise.resolve([]),
+      sessionUserId ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`) : Promise.resolve([]),
     ]);
     const reviewTravelSessionIds = [
       ...new Set(
@@ -146,10 +150,10 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     ];
     const reviewRouteRows =
       reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerUserRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
+        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
         : [];
     const userIdsFilter = buildInFilter([reviewRow.user_id, ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerUserSummaryRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
     const places = placeRows.map(mapPlace);
     const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
     const usersById = new Map(userRows.map((row) => [row.user_id, row]));

--- a/reports/completion/TSK-004-03-worker-domain-mapper-contracts.md
+++ b/reports/completion/TSK-004-03-worker-domain-mapper-contracts.md
@@ -2,7 +2,7 @@
 
 Scope-ID: `TSK-004-03-WORKER-DOMAIN-MAPPER-CONTRACTS`
 Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/275
-PR: `TBD-TSK-004-03-WORKER-DOMAIN-MAPPER-CONTRACTS`
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/281
 Branch: `worker-domain-mapper-contracts`
 Status: `validated-local`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272

--- a/reports/completion/TSK-004-03-worker-domain-mapper-contracts.md
+++ b/reports/completion/TSK-004-03-worker-domain-mapper-contracts.md
@@ -1,0 +1,79 @@
+# TSK-004-03 Worker Domain Mapper Contracts
+
+Scope-ID: `TSK-004-03-WORKER-DOMAIN-MAPPER-CONTRACTS`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/275
+PR: `TBD-TSK-004-03-WORKER-DOMAIN-MAPPER-CONTRACTS`
+Branch: `worker-domain-mapper-contracts`
+Status: `validated-local`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/275
+
+## Purpose
+
+Worker review/community/my domain mapper가 `any[]`, `Map<any, any>`에 의존하던 잔여 계약을 domain-local row/read-model 타입으로 대체했다. 외부 REST endpoint, response shape, DB schema, 사용자-facing copy, Kakao/Naver OAuth 성공 경로는 변경하지 않았다.
+
+## Current Decisions
+
+- review mapper row 계약은 `services/review-domain/contracts.ts`가 소유한다.
+- community route mapper row 계약은 `services/community-domain/contracts.ts`가 소유한다.
+- my-page comment mapper row 계약은 `services/my-domain/contracts.ts`가 소유한다.
+- repository가 mapper에 넘기는 row도 같은 domain-local 타입으로 좁혔다.
+- global Worker type barrel인 `deploy/api-worker-shell/types.ts`에는 domain row/mapper 타입을 추가하지 않았다.
+- `scripts/numeric-literal-baseline.json`은 최신 main의 festival-domain split 파일을 포함하도록 재생성했다. 이는 #275 변경으로 생긴 수치가 아니라 공통 게이트 복구용 보정이다.
+
+## Before And After Inventory
+
+| File | Metric | Before | After |
+| --- | --- | ---: | ---: |
+| `deploy/api-worker-shell/services/review-domain/mapper.ts` | `any` | 24 | 0 |
+| `deploy/api-worker-shell/services/review-domain/mapper.ts` | `Map<any` | 4 | 0 |
+| `deploy/api-worker-shell/services/review-domain/mapper.ts` | `any[]` | 9 | 0 |
+| `deploy/api-worker-shell/services/community-domain/mapper.ts` | `any` | 7 | 0 |
+| `deploy/api-worker-shell/services/community-domain/mapper.ts` | `Map<any` | 2 | 0 |
+| `deploy/api-worker-shell/services/community-domain/mapper.ts` | `any[]` | 2 | 0 |
+| `deploy/api-worker-shell/services/my-domain/mapper.ts` | `any` | 5 | 0 |
+| `deploy/api-worker-shell/services/my-domain/mapper.ts` | `Map<any` | 1 | 0 |
+| `deploy/api-worker-shell/services/my-domain/mapper.ts` | `any[]` | 1 | 0 |
+| `deploy/api-worker-shell/services/community-domain/repository.ts` | `row: any` | 2 | 0 |
+| `deploy/api-worker-shell/services/my-domain/repository.ts` | `row: any` | 1 | 0 |
+
+## Issue Scope
+
+- #275: Worker domain mapper row contracts
+- #273: baseline gate completed by PR #279
+- #274: festival boundary split completed by PR #280
+- #276~#277: handler contract/docs 작업은 후속 child issue 범위
+
+## PR Scope
+
+이번 PR은 아래만 포함한다.
+
+- review/community/my domain-local row/read-model 타입 추가
+- mapper 입력 타입을 `any`에서 명시 타입으로 변경
+- repository가 mapper에 넘기는 row 타입 정리
+- base-data repository와 review read service의 review row 타입 연결
+- source-quality gate를 mapper/repository `any` 회귀 차단 기준으로 강화
+- numeric literal baseline을 최신 main tracked production files 기준으로 갱신
+
+## Validation Results
+
+로컬 검증 결과는 아래와 같다.
+
+- [x] targeted Vitest: `worker-source-quality`, `worker-bootstrap-shape`, `worker-account-community-admin-boundaries`, `worker-review-domain`, `worker-routing-runtime` 통과
+- [x] `npm.cmd run check:numeric-literals` 통과
+- [x] `npm.cmd run lint` 통과
+- [x] `npm.cmd run typecheck` 통과
+- [x] `npm.cmd run test:unit` 통과
+- [x] `npm.cmd run build` 통과
+- [x] `git diff --check` 통과
+- [x] `git diff --cached --check` 통과
+- [x] UTF-8 integrity check 통과: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
+- [ ] PR checks: PR 생성 후 기록
+- [ ] main merge SHA: PR merge 후 기록
+- [ ] main CI/production-smoke/CodeQL: PR merge 후 기록
+- [ ] Dependabot/code scanning open alert 0건: PR merge 후 기록
+
+## Remaining Follow-Up Work
+
+- #276에서 admin/stamp/notification/auth/review-interaction handler contract를 명시 타입으로 좁힌다.
+- #277에서 TSK-004 전체 Wiki, release candidate, parent/child evidence를 정리한다.

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "5fddc64d0f8b8a1f94f3505d2fb911958aa49a35",
+  "generatedFrom": "cb04022cd5fd091ddf0c61d56726f8eb1f818975",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -1328,12 +1328,12 @@
       "examples": [
         {
           "value": "0",
-          "line": 27,
+          "line": 32,
           "column": 14
         },
         {
           "value": "0",
-          "line": 136,
+          "line": 141,
           "column": 37
         }
       ]
@@ -1678,7 +1678,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 29,
+          "line": 43,
           "column": 36
         }
       ]
@@ -1693,32 +1693,32 @@
       "examples": [
         {
           "value": "1",
-          "line": 7,
+          "line": 13,
           "column": 100
         },
         {
           "value": "0",
-          "line": 9,
+          "line": 15,
           "column": 17
         },
         {
           "value": "1",
-          "line": 43,
+          "line": 49,
           "column": 159
         },
         {
           "value": "0",
-          "line": 45,
+          "line": 51,
           "column": 17
         },
         {
           "value": "1",
-          "line": 51,
+          "line": 57,
           "column": 138
         },
         {
           "value": "0",
-          "line": 53,
+          "line": 59,
           "column": 17
         }
       ]
@@ -1759,6 +1759,161 @@
         {
           "value": "400",
           "line": 84,
+          "column": 27
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festival-domain/cache.ts",
+      "count": 3,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 15,
+          "column": 55
+        },
+        {
+          "value": "0",
+          "line": 15,
+          "column": 66
+        },
+        {
+          "value": "0",
+          "line": 41,
+          "column": 33
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festival-domain/import-service.ts",
+      "count": 1,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 30,
+          "column": 34
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festival-domain/mapper.ts",
+      "count": 32,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 37,
+          "column": 51
+        },
+        {
+          "value": "2",
+          "line": 55,
+          "column": 18
+        },
+        {
+          "value": "00",
+          "line": 68,
+          "column": 34
+        },
+        {
+          "value": "00",
+          "line": 68,
+          "column": 37
+        },
+        {
+          "value": "09",
+          "line": 68,
+          "column": 40
+        },
+        {
+          "value": "00",
+          "line": 68,
+          "column": 43
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festival-domain/read-service.ts",
+      "count": 5,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "0",
+          "line": 34,
+          "column": 12
+        },
+        {
+          "value": "0",
+          "line": 46,
+          "column": 29
+        },
+        {
+          "value": "0",
+          "line": 48,
+          "column": 24
+        },
+        {
+          "value": "0",
+          "line": 49,
+          "column": 25
+        },
+        {
+          "value": "0",
+          "line": 52,
+          "column": 33
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/festival-domain/repository.ts",
+      "count": 7,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 22,
+          "column": 124
+        },
+        {
+          "value": "0",
+          "line": 24,
+          "column": 14
+        },
+        {
+          "value": "0",
+          "line": 25,
+          "column": 17
+        },
+        {
+          "value": "0",
+          "line": 37,
+          "column": 43
+        },
+        {
+          "value": "0",
+          "line": 54,
+          "column": 23
+        },
+        {
+          "value": "0",
+          "line": 68,
           "column": 27
         }
       ]
@@ -1813,7 +1968,7 @@
       "examples": [
         {
           "value": "1",
-          "line": 9,
+          "line": 10,
           "column": 22
         }
       ]
@@ -1908,32 +2063,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 5,
+          "line": 25,
           "column": 17
         },
         {
           "value": "1",
-          "line": 7,
+          "line": 27,
           "column": 16
         },
         {
           "value": "0",
-          "line": 80,
+          "line": 101,
           "column": 63
         },
         {
           "value": "1",
-          "line": 80,
+          "line": 101,
           "column": 68
         },
         {
           "value": "1",
-          "line": 89,
+          "line": 110,
           "column": 51
         },
         {
           "value": "0",
-          "line": 103,
+          "line": 124,
           "column": 62
         }
       ]
@@ -2028,32 +2183,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 60,
+          "line": 64,
           "column": 39
         },
         {
           "value": "1",
-          "line": 76,
+          "line": 80,
           "column": 152
         },
         {
           "value": "0",
-          "line": 83,
+          "line": 87,
           "column": 37
         },
         {
           "value": "0",
-          "line": 107,
+          "line": 111,
           "column": 39
         },
         {
           "value": "1",
-          "line": 121,
+          "line": 125,
           "column": 142
         },
         {
           "value": "0",
-          "line": 123,
+          "line": 127,
           "column": 36
         }
       ]

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -97,25 +97,41 @@ describe('worker source quality gates', () => {
       {
         file: 'deploy/api-worker-shell/services/review-domain/mapper.ts',
         limits: {
-          any: 24,
-          mapAny: 4,
-          anyArray: 9,
+          any: 0,
+          mapAny: 0,
+          anyArray: 0,
         },
       },
       {
         file: 'deploy/api-worker-shell/services/community-domain/mapper.ts',
         limits: {
-          any: 7,
-          mapAny: 2,
-          anyArray: 2,
+          any: 0,
+          mapAny: 0,
+          anyArray: 0,
         },
       },
       {
         file: 'deploy/api-worker-shell/services/my-domain/mapper.ts',
         limits: {
-          any: 5,
-          mapAny: 1,
-          anyArray: 1,
+          any: 0,
+          mapAny: 0,
+          anyArray: 0,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/community-domain/repository.ts',
+        limits: {
+          any: 0,
+          mapAny: 0,
+          anyArray: 0,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/my-domain/repository.ts',
+        limits: {
+          any: 0,
+          mapAny: 0,
+          anyArray: 0,
         },
       },
     ];


### PR DESCRIPTION
## Summary

- #275 Worker domain mapper row contract 리팩터링입니다.
- review/community/my mapper의 `any[]`, `Map<any, any>`, repository `row: any` 잔여 계약을 domain-local row/read-model 타입으로 대체했습니다.
- global Worker type barrel에는 domain row/mapper 타입을 추가하지 않았습니다.
- 외부 REST endpoint, response shape, DB schema, 사용자-facing copy, Kakao/Naver OAuth 성공 경로는 변경하지 않았습니다.

## Scope

- Refs #275
- Parent: #272
- Branch: `worker-domain-mapper-contracts`
- Release candidate: `1.2.10`

## Evidence

- `review-domain/mapper.ts`: `any` 24 -> 0, `Map<any` 4 -> 0, `any[]` 9 -> 0
- `community-domain/mapper.ts`: `any` 7 -> 0, `Map<any` 2 -> 0, `any[]` 2 -> 0
- `my-domain/mapper.ts`: `any` 5 -> 0, `Map<any` 1 -> 0, `any[]` 1 -> 0
- `community-domain/repository.ts`: `row: any` 2 -> 0
- `my-domain/repository.ts`: `row: any` 1 -> 0
- Source-quality gate now blocks mapper/repository `any` regression for this child scope.

## Validation

- [x] targeted Vitest: `worker-source-quality`, `worker-bootstrap-shape`, `worker-account-community-admin-boundaries`, `worker-review-domain`, `worker-routing-runtime`
- [x] `npm.cmd run check:numeric-literals`
- [x] `npm.cmd run lint`
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run test:unit`
- [x] `npm.cmd run build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] UTF-8 integrity check: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
