### PR TITLE
Type Worker service handler contracts

### DIFF
--- a/deploy/api-worker-shell/services/admin-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/admin-domain/contracts.ts
@@ -8,6 +8,10 @@
  */
 import type { WorkerEnv } from '../../types';
 
+export interface WorkerAdminServiceDeps {
+  normalizePlaceCategory: (category: unknown, slug?: string) => string;
+}
+
 export interface WorkerAdminService {
   handleAdminSummary(request: Request, env: WorkerEnv): Promise<Response>;
   handleAdminImportPublicData(request: Request, env: WorkerEnv): Promise<Response>;

--- a/deploy/api-worker-shell/services/admin.ts
+++ b/deploy/api-worker-shell/services/admin.ts
@@ -7,11 +7,11 @@ import {
   loadPublicDataSource,
   updateAdminPlaceVisibility,
 } from './admin-domain/repository';
+import type { WorkerEnv, WorkerJsonRecord } from '../types';
+import type { WorkerAdminServiceDeps } from './admin-domain/contracts';
 
-export function createAdminService({ normalizePlaceCategory }: {
-  normalizePlaceCategory: (category: any, slug?: string) => string;
-}) {
-  async function requireAdmin(request: Request, env: any) {
+export function createAdminService({ normalizePlaceCategory }: WorkerAdminServiceDeps) {
+  async function requireAdmin(request: Request, env: WorkerEnv) {
     const sessionUser = await readSessionUser(request, env);
     if (!sessionUser || !sessionUser.isAdmin) {
       return { response: jsonResponse(403, { detail: '관리자만 접근할 수 있어요.' }, env, request) };
@@ -19,9 +19,9 @@ export function createAdminService({ normalizePlaceCategory }: {
     return { sessionUser };
   }
 
-  async function buildAdminSummary(env: any) {
+  async function buildAdminSummary(env: WorkerEnv) {
     const { userCount, placeCount, reviewCount, commentCount, stampCount, placeRows, feedRows } = await loadAdminSummaryRows(env);
-    const reviewCountByPosition = new Map();
+    const reviewCountByPosition = new Map<string, number>();
     for (const row of feedRows ?? []) {
       const key = String(row.position_id);
       reviewCountByPosition.set(key, (reviewCountByPosition.get(key) ?? 0) + 1);
@@ -46,7 +46,7 @@ export function createAdminService({ normalizePlaceCategory }: {
     };
   }
 
-  async function handleAdminSummary(request: Request, env: any) {
+  async function handleAdminSummary(request: Request, env: WorkerEnv) {
     const auth = await requireAdmin(request, env);
     if (auth.response) {
       return auth.response;
@@ -54,14 +54,14 @@ export function createAdminService({ normalizePlaceCategory }: {
     return jsonResponse(200, await buildAdminSummary(env), env, request);
   }
 
-  async function handleAdminPlaceVisibility(request: Request, env: any, placeId: string) {
+  async function handleAdminPlaceVisibility(request: Request, env: WorkerEnv, placeId: string) {
     const auth = await requireAdmin(request, env);
     if (auth.response) {
       return auth.response;
     }
 
-    const payload = await request.json().catch(() => null);
-    const body: Record<string, unknown> = {};
+    const payload = await request.json().catch(() => null) as WorkerJsonRecord | null;
+    const body: WorkerJsonRecord = {};
     if (typeof payload?.isActive === 'boolean') {
       body.is_active = payload.isActive;
     }
@@ -93,7 +93,7 @@ export function createAdminService({ normalizePlaceCategory }: {
     );
   }
 
-  async function handleAdminImportPublicData(request: Request, env: any) {
+  async function handleAdminImportPublicData(request: Request, env: WorkerEnv) {
     const auth = await requireAdmin(request, env);
     if (auth.response) {
       return auth.response;

--- a/deploy/api-worker-shell/services/auth.ts
+++ b/deploy/api-worker-shell/services/auth.ts
@@ -1,6 +1,6 @@
 import { jsonResponse, redirectResponse } from '../lib/http';
 import { supabaseRequest } from '../lib/supabase';
-import type { AuthProviderKey, WorkerEnv, WorkerSessionUser } from '../types';
+import type { AuthProviderKey, WorkerEnv, WorkerJsonRecord, WorkerSessionUser } from '../types';
 import { buildKakaoLoginUrl, exchangeKakaoCode, fetchKakaoProfile } from './auth/kakao-provider';
 import { buildNaverLoginUrl, exchangeNaverCode, fetchNaverProfile } from './auth/naver-provider';
 import { buildAuthProviders, kakaoConfigured, naverConfigured } from './auth/provider-config';
@@ -45,9 +45,9 @@ export function createAuthResponse(sessionUser: WorkerSessionUser | null, env: W
   };
 }
 
-async function readJsonBody(request: Request): Promise<any> {
+async function readJsonBody(request: Request): Promise<WorkerJsonRecord> {
   try {
-    return await request.json();
+    return await request.json() as WorkerJsonRecord;
   } catch {
     throw new Error('요청 형식이 올바르지 않아요.');
   }
@@ -76,7 +76,7 @@ export async function handleUpdateProfile(request: Request, env: WorkerEnv) {
   const payload = await readJsonBody(request);
   let nickname;
   try {
-    nickname = await ensureUniqueNickname(env, payload.nickname, sessionResult.sessionUser.id);
+    nickname = await ensureUniqueNickname(env, String(payload.nickname ?? ''), sessionResult.sessionUser.id);
   } catch (error) {
     const profileError = error as { status?: number };
     return jsonResponse(
@@ -177,13 +177,21 @@ function buildCallbackContext(request: Request, env: WorkerEnv, statePayload: { 
   };
 }
 
+interface SocialLoginProfile {
+  email?: string | null;
+  id: string;
+  name?: string | null;
+  nickname?: string | null;
+  profile_image?: string | null;
+}
+
 interface FinishSocialLoginOptions {
   request: Request;
   env: WorkerEnv;
   url: URL;
   provider: AuthProviderKey;
   exchangeCode: (env: WorkerEnv, code: string, state?: string) => Promise<{ access_token: string }>;
-  fetchProfile: (accessToken: string) => Promise<any>;
+  fetchProfile: (accessToken: string) => Promise<SocialLoginProfile>;
 }
 
 async function finishSocialLogin({ request, env, url, provider, exchangeCode, fetchProfile }: FinishSocialLoginOptions) {

--- a/deploy/api-worker-shell/services/auth/naver-provider.ts
+++ b/deploy/api-worker-shell/services/auth/naver-provider.ts
@@ -17,6 +17,14 @@ interface NaverProfilePayload {
   resultcode?: string;
 }
 
+interface NaverProfileResponse {
+  email?: string | null;
+  id: string;
+  name?: string | null;
+  nickname?: string | null;
+  profile_image?: string | null;
+}
+
 function buildNaverLoginUrl(env: WorkerEnv, state: string) {
   const query = new URLSearchParams({
     response_type: 'code',
@@ -56,7 +64,13 @@ async function fetchNaverProfile(accessToken: string) {
   if (!response.ok || payload.resultcode !== '00' || !payload.response) {
     throw new Error(payload.message || '네이버 사용자 정보를 가져오지 못했어요.');
   }
-  return payload.response;
+  return {
+    id: String(payload.response.id ?? ''),
+    email: typeof payload.response.email === 'string' ? payload.response.email : null,
+    name: typeof payload.response.name === 'string' ? payload.response.name : null,
+    nickname: typeof payload.response.nickname === 'string' ? payload.response.nickname : null,
+    profile_image: typeof payload.response.profile_image === 'string' ? payload.response.profile_image : null,
+  } satisfies NaverProfileResponse;
 }
 
 export { buildNaverLoginUrl, exchangeNaverCode, fetchNaverProfile };

--- a/deploy/api-worker-shell/services/community-routes.ts
+++ b/deploy/api-worker-shell/services/community-routes.ts
@@ -134,7 +134,7 @@ export function createCommunityRouteService({ loadStaticBaseRows }: WorkerCommun
       type: 'route-published',
       title: '새로운 코스가 발행되었습니다.',
       body: title,
-      routeId,
+      routeId: routeId as string | number,
       metadata: { travelSessionId },
     });
     if (createdNotification?.notification_id) {

--- a/deploy/api-worker-shell/services/notifications.ts
+++ b/deploy/api-worker-shell/services/notifications.ts
@@ -3,37 +3,74 @@ import { jsonResponse } from '../lib/http';
 import { buildInFilter, encodeFilterValue, getSupabaseKey, supabaseRequest } from '../lib/supabase';
 import { WorkerNotificationRuntimeConfig } from '../config/runtime';
 import { getSigningSecret, readSessionUser, sha256Base64Url } from './auth';
-async function requireSessionUser(request, env) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
+import type { WorkerEnv, WorkerJsonRecord } from '../types';
+
+interface WorkerNotificationRow extends WorkerJsonRecord {
+    notification_id: string | number;
+    user_id: string;
+    actor_user_id?: string | null;
+    type: string;
+    title: string;
+    body?: string | null;
+    review_id?: string | number | null;
+    comment_id?: string | number | null;
+    route_id?: string | number | null;
+    is_read?: boolean | null;
+    created_at: string;
+}
+
+interface WorkerNotificationActorRow extends WorkerJsonRecord {
+    user_id: string;
+    nickname?: string | null;
+}
+
+interface WorkerNotificationInsertResult extends WorkerJsonRecord {
+    notification_id?: string | number | null;
+}
+
+interface WorkerNotificationCreatePayload extends WorkerJsonRecord {
+    userId: string;
+    actorUserId?: string | null;
+    type: string;
+    title: string;
+    body?: string;
+    reviewId?: string | number | null;
+    commentId?: string | number | null;
+    routeId?: string | number | null;
+    metadata?: WorkerJsonRecord;
+}
+
+async function requireSessionUser(request: Request, env: WorkerEnv) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
     return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
 } return { sessionUser }; }
-async function readNotificationRow(env, notificationId) { const rows = await supabaseRequest(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&notification_id=eq.${encodeFilterValue(notificationId)}&limit=1`); return rows?.[0] ?? null; }
-export async function createUserNotification(env, { userId, actorUserId = null, type, title, body = '', reviewId = null, commentId = null, routeId = null, metadata = {} }) { if (!userId) {
+async function readNotificationRow(env: WorkerEnv, notificationId: string | number) { const rows = await supabaseRequest<WorkerNotificationRow[]>(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&notification_id=eq.${encodeFilterValue(notificationId)}&limit=1`); return rows?.[0] ?? null; }
+export async function createUserNotification(env: WorkerEnv, { userId, actorUserId = null, type, title, body = '', reviewId = null, commentId = null, routeId = null, metadata = {} }: WorkerNotificationCreatePayload): Promise<WorkerNotificationInsertResult | null> { if (!userId) {
     return null;
-} const nowIso = new Date().toISOString(); const rows = await supabaseRequest(env, 'user_notification?select=notification_id', { method: 'POST', body: JSON.stringify({ user_id: userId, actor_user_id: actorUserId, type, title, body, review_id: reviewId ? Number(reviewId) : null, comment_id: commentId ? Number(commentId) : null, route_id: routeId ? Number(routeId) : null, metadata, is_read: false, created_at: nowIso, updated_at: nowIso, }), }); return rows?.[0] ?? null; }
-export async function loadUserNotifications(env, userId, limit = WorkerNotificationRuntimeConfig.defaultListLimit) { const rows = await supabaseRequest(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc&limit=${limit}`); const actorIdsFilter = buildInFilter((rows || []).map((row) => row.actor_user_id).filter(Boolean)); const actorRows = actorIdsFilter ? await supabaseRequest(env, `user?select=user_id,nickname&user_id=${actorIdsFilter}`) : []; const actorNameById = new Map((actorRows || []).map((row) => [row.user_id, row.nickname])); return (rows || []).map((row) => ({ id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName: row.actor_user_id ? actorNameById.get(row.actor_user_id) ?? null : null, })); }
-export async function countUnreadNotifications(env, userId) { const rows = await supabaseRequest(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`); return rows?.length ?? 0; }
-export async function loadNotificationById(env, notificationId) { const row = await readNotificationRow(env, notificationId); if (!row) {
+} const nowIso = new Date().toISOString(); const rows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, 'user_notification?select=notification_id', { method: 'POST', body: JSON.stringify({ user_id: userId, actor_user_id: actorUserId, type, title, body, review_id: reviewId ? Number(reviewId) : null, comment_id: commentId ? Number(commentId) : null, route_id: routeId ? Number(routeId) : null, metadata, is_read: false, created_at: nowIso, updated_at: nowIso, }), }); return rows?.[0] ?? null; }
+export async function loadUserNotifications(env: WorkerEnv, userId: string, limit = WorkerNotificationRuntimeConfig.defaultListLimit) { const rows = await supabaseRequest<WorkerNotificationRow[]>(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc&limit=${limit}`); const actorIdsFilter = buildInFilter((rows || []).map((row) => row.actor_user_id).filter(Boolean)); const actorRows = actorIdsFilter ? await supabaseRequest<WorkerNotificationActorRow[]>(env, `user?select=user_id,nickname&user_id=${actorIdsFilter}`) : []; const actorNameById = new Map((actorRows || []).map((row) => [row.user_id, row.nickname])); return (rows || []).map((row) => ({ id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName: row.actor_user_id ? actorNameById.get(row.actor_user_id) ?? null : null, })); }
+export async function countUnreadNotifications(env: WorkerEnv, userId: string) { const rows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`); return rows?.length ?? 0; }
+export async function loadNotificationById(env: WorkerEnv, notificationId: string | number) { const row = await readNotificationRow(env, notificationId); if (!row) {
     return null;
 } let actorName = null; if (row.actor_user_id) {
-    const actorRows = await supabaseRequest(env, `user?select=user_id,nickname&user_id=eq.${encodeFilterValue(row.actor_user_id)}&limit=1`);
+    const actorRows = await supabaseRequest<WorkerNotificationActorRow[]>(env, `user?select=user_id,nickname&user_id=eq.${encodeFilterValue(row.actor_user_id)}&limit=1`);
     actorName = actorRows?.[0]?.nickname ?? null;
 } return { id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName, }; }
-async function buildNotificationRealtimeTopic(env, userId) { const secret = getSigningSecret(env); if (!secret) {
+async function buildNotificationRealtimeTopic(env: WorkerEnv, userId: string) { const secret = getSigningSecret(env); if (!secret) {
     throw new Error('Notification realtime secret is missing.');
 } const signature = await sha256Base64Url(`${userId}:${secret}:notifications`); return `user-notifications:${userId}:${signature}`; }
-async function sendRealtimeBroadcast(env, topic, event, payload) { if (!env.APP_SUPABASE_URL) {
+async function sendRealtimeBroadcast(env: WorkerEnv, topic: string, event: string, payload: WorkerJsonRecord) { if (!env.APP_SUPABASE_URL) {
     return;
 } const apiKey = getSupabaseKey(env); if (!apiKey) {
     return;
 } await fetch(`${env.APP_SUPABASE_URL}/realtime/v1/api/broadcast`, { method: 'POST', headers: { apikey: apiKey, Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json', }, body: JSON.stringify({ messages: [{ topic, event, payload, private: false, },], }), }); }
-export async function publishNotificationEvent(env, userId, event, payload) { const topic = await buildNotificationRealtimeTopic(env, userId); await sendRealtimeBroadcast(env, topic, event, payload); }
-export async function handleMyNotifications(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export async function publishNotificationEvent(env: WorkerEnv, userId: string, event: string, payload: WorkerJsonRecord) { const topic = await buildNotificationRealtimeTopic(env, userId); await sendRealtimeBroadcast(env, topic, event, payload); }
+export async function handleMyNotifications(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const notifications = await loadUserNotifications(env, sessionResult.sessionUser.id, WorkerNotificationRuntimeConfig.myNotificationsListLimit); return jsonResponse(200, notifications, env, request); }
-export async function handleNotificationRealtimeChannel(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export async function handleNotificationRealtimeChannel(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const topic = await buildNotificationRealtimeTopic(env, sessionResult.sessionUser.id); return jsonResponse(200, { topic }, env, request); }
-export async function handleMarkNotificationRead(request, env, notificationId) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export async function handleMarkNotificationRead(request: Request, env: WorkerEnv, notificationId: string) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const notificationRow = await readNotificationRow(env, notificationId); if (!notificationRow) {
     return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);
@@ -44,14 +81,14 @@ export async function handleMarkNotificationRead(request, env, notificationId) {
     await supabaseRequest(env, `user_notification?notification_id=eq.${encodeFilterValue(notificationId)}`, { method: 'PATCH', body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso, }), });
     await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.read', { notificationId: String(notificationId), unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id), });
 } return jsonResponse(200, { notificationId: String(notificationId), read: true }, env, request); }
-export async function handleMarkAllNotificationsRead(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export async function handleMarkAllNotificationsRead(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
-} const unreadRows = await supabaseRequest(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&is_read=eq.false`); const updated = unreadRows?.length ?? 0; if (updated > 0) {
+} const unreadRows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&is_read=eq.false`); const updated = unreadRows?.length ?? 0; if (updated > 0) {
     const nowIso = new Date().toISOString();
     await supabaseRequest(env, `user_notification?user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&is_read=eq.false`, { method: 'PATCH', body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso, }), });
     await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.all-read', { updated, unreadCount: 0, });
 } return jsonResponse(200, { updated }, env, request); }
-export async function handleDeleteNotification(request, env, notificationId) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export async function handleDeleteNotification(request: Request, env: WorkerEnv, notificationId: string) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const notificationRow = await readNotificationRow(env, notificationId); if (!notificationRow) {
     return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);

--- a/deploy/api-worker-shell/services/review-interactions.ts
+++ b/deploy/api-worker-shell/services/review-interactions.ts
@@ -58,9 +58,9 @@ async function uploadReviewFile(env: WorkerEnv, sessionUser: WorkerSessionUser, 
   return { url: buildPublicStorageUrl(env, objectPath), fileName: safeFileName, contentType: file.type || 'application/octet-stream' };
 }
 
-async function readJsonBody(request: Request): Promise<any> {
+async function readJsonBody(request: Request): Promise<WorkerJsonRecord> {
   try {
-    return await request.json();
+    return await request.json() as WorkerJsonRecord;
   } catch {
     throw new Error('요청 형식이 올바르지 않아요.');
   }

--- a/deploy/api-worker-shell/services/stamp-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/stamp-domain/contracts.ts
@@ -7,6 +7,11 @@
  * Dependencies: Worker environment primitives.
  */
 import type { WorkerEnv } from '../../types';
+import type { WorkerBaseData } from '../../runtime/base-data-contracts';
+
+export interface WorkerStampServiceDeps {
+  loadBaseData(env: WorkerEnv, sessionUserId?: string | null): Promise<WorkerBaseData>;
+}
 
 export interface WorkerStampService {
   handleToggleStamp(request: Request, env: WorkerEnv): Promise<Response>;

--- a/deploy/api-worker-shell/services/stamps.ts
+++ b/deploy/api-worker-shell/services/stamps.ts
@@ -3,24 +3,26 @@ import { jsonResponse } from '../lib/http';
 import { encodeFilterValue, supabaseRequest } from '../lib/supabase';
 import { WorkerStampRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
-function getStampUnlockRadius(env) { const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters); return Number.isFinite(parsed) && parsed > 0 ? parsed : WorkerStampRuntimeConfig.defaultUnlockRadiusMeters; }
-function calculateDistanceMeters(startLatitude, startLongitude, endLatitude, endLongitude) { const latitudeDelta = (endLatitude - startLatitude) * WorkerStampRuntimeConfig.radiansPerDegree; const longitudeDelta = (endLongitude - startLongitude) * WorkerStampRuntimeConfig.radiansPerDegree; const startLatitudeRadians = startLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const endLatitudeRadians = endLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const haversine = Math.sin(latitudeDelta / 2) ** 2 + Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2; return WorkerStampRuntimeConfig.earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine))); }
-function formatDistanceMeters(distanceMeters) { if (!Number.isFinite(distanceMeters)) {
+import type { WorkerEnv, WorkerJsonRecord } from '../types';
+import type { WorkerStampServiceDeps } from './stamp-domain/contracts';
+function getStampUnlockRadius(env: WorkerEnv) { const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters); return Number.isFinite(parsed) && parsed > 0 ? parsed : WorkerStampRuntimeConfig.defaultUnlockRadiusMeters; }
+function calculateDistanceMeters(startLatitude: number, startLongitude: number, endLatitude: number, endLongitude: number) { const latitudeDelta = (endLatitude - startLatitude) * WorkerStampRuntimeConfig.radiansPerDegree; const longitudeDelta = (endLongitude - startLongitude) * WorkerStampRuntimeConfig.radiansPerDegree; const startLatitudeRadians = startLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const endLatitudeRadians = endLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const haversine = Math.sin(latitudeDelta / 2) ** 2 + Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2; return WorkerStampRuntimeConfig.earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine))); }
+function formatDistanceMeters(distanceMeters: number) { if (!Number.isFinite(distanceMeters)) {
     return '알 수 없음';
 } if (distanceMeters >= WorkerStampRuntimeConfig.metersPerKilometer) {
     return `${(distanceMeters / WorkerStampRuntimeConfig.metersPerKilometer).toFixed(1)}km`;
 } return `${Math.round(distanceMeters)}m`; }
-function buildNearPlaceMessage(placeName, distanceMeters, unlockRadius) { return `${placeName}까지 ${formatDistanceMeters(distanceMeters)} 남아있어요. 반경 ${unlockRadius}m 안에 들어오면 열려요.`; }
-async function requireSessionUser(request, env) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
+function buildNearPlaceMessage(placeName: string, distanceMeters: number, unlockRadius: number) { return `${placeName}까지 ${formatDistanceMeters(distanceMeters)} 남아있어요. 반경 ${unlockRadius}m 안에 들어오면 열려요.`; }
+async function requireSessionUser(request: Request, env: WorkerEnv) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
     return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
 } return { sessionUser }; }
-async function readJsonBody(request) { try {
-    return await request.json();
+async function readJsonBody(request: Request): Promise<WorkerJsonRecord> { try {
+    return await request.json() as WorkerJsonRecord;
 }
 catch {
     throw new Error('요청 형식이 올바르지 않아요.');
 } }
-export function createStampService({ loadBaseData }) { async function handleToggleStamp(request, env) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
+export function createStampService({ loadBaseData }: WorkerStampServiceDeps) { async function handleToggleStamp(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
     return sessionResult.response;
 } const payload = await readJsonBody(request); const placeId = String(payload.placeId ?? '').trim(); const latitude = Number(payload.latitude); const longitude = Number(payload.longitude); if (!placeId || !Number.isFinite(latitude) || !Number.isFinite(longitude)) {
     return jsonResponse(400, { detail: '장소와 현재 좌표가 필요해요.' }, env, request);

--- a/reports/completion/TSK-004-04-worker-service-handler-contracts.md
+++ b/reports/completion/TSK-004-04-worker-service-handler-contracts.md
@@ -1,0 +1,78 @@
+# TSK-004-04 Worker Service Handler Contracts
+
+Scope-ID: `TSK-004-04-WORKER-SERVICE-HANDLER-CONTRACTS`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/276
+PR: `TBD-TSK-004-04-WORKER-SERVICE-HANDLER-CONTRACTS`
+Branch: `worker-service-handler-contracts`
+Status: `validated-local`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/276
+
+## Purpose
+
+Worker admin/stamp/notification/auth/review-interaction handler의 `env`, JSON body, dependency contract를 명시 타입으로 좁혔다. 외부 REST endpoint, response shape, DB schema, 사용자-facing copy, Kakao/Naver OAuth 성공 경로는 변경하지 않았다.
+
+## Current Decisions
+
+- admin dependency contract는 `services/admin-domain/contracts.ts`가 소유한다.
+- stamp dependency contract는 `services/stamp-domain/contracts.ts`가 소유한다.
+- notification row/create payload 계약은 notification service 내부에 둔다.
+- auth/review-interaction JSON body는 `WorkerJsonRecord`로 좁힌다.
+- Naver profile response는 upsert social user 계약에 맞게 명시 shape로 변환한다.
+- global Worker type barrel인 `deploy/api-worker-shell/types.ts`에는 domain handler 타입을 추가하지 않았다.
+
+## Before And After Inventory
+
+| File | Metric | Before | After |
+| --- | --- | ---: | ---: |
+| `deploy/api-worker-shell/services/admin.ts` | `any` | 6 | 0 |
+| `deploy/api-worker-shell/services/admin.ts` | `env:any` | 5 | 0 |
+| `deploy/api-worker-shell/services/admin.ts` | `category:any` | 1 | 0 |
+| `deploy/api-worker-shell/services/auth.ts` | `Promise<any>` | 2 | 0 |
+| `deploy/api-worker-shell/services/review-interactions.ts` | `Promise<any>` | 1 | 0 |
+| `deploy/api-worker-shell/services/notifications.ts` | implicit env handler signatures | 10 | 0 |
+| `deploy/api-worker-shell/services/stamps.ts` | implicit env handler signatures | 1 | 0 |
+| `deploy/api-worker-shell/services/stamps.ts` | implicit `readJsonBody(request)` | 1 | 0 |
+
+## Issue Scope
+
+- #276: Worker service handler contract typing
+- #273~#275: 완료된 선행 child issue
+- #277: 문서와 release traceability 후속 작업
+
+## PR Scope
+
+이번 PR은 아래만 포함한다.
+
+- admin service deps/env/body 타입 명시
+- auth profile update JSON body와 social profile callback 타입 명시
+- review interaction JSON command body 타입 명시
+- stamp service deps/env/body 타입 명시
+- notification env/id/payload/row 타입 명시
+- source-quality gate를 handler contract `any` 회귀 차단 기준으로 강화
+
+## Validation Results
+
+로컬 검증 결과는 아래와 같다.
+
+- [x] targeted Vitest: `worker-source-quality`, `worker-review-domain`, `worker-account-community-admin-boundaries`, `worker-auth-security` 통과
+- [x] `npm.cmd run check:numeric-literals` 통과
+- [x] `npm.cmd run lint` 통과
+- [x] `npm.cmd run typecheck` 통과
+- [x] `npm.cmd run test:unit` 통과
+- [x] `npm.cmd run build` 통과
+- [x] `git diff --check` 통과
+- [x] `git diff --cached --check` 통과
+- [x] UTF-8 integrity check 통과: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`
+- [ ] PR checks: PR 생성 후 기록
+- [ ] main merge SHA: PR merge 후 기록
+- [ ] main CI/production-smoke/CodeQL: PR merge 후 기록
+- [ ] Dependabot/code scanning open alert 0건: PR merge 후 기록
+
+## Validation Note
+
+`npm.cmd run test:unit`는 sandbox cwd에서 `D:/JamIssue/test/setup.ts`를 못 찾는 경로 문제로 한 번 실패했다. 동일 명령을 실제 workspace `D:\JamIssue`에서 재실행해 통과했으며, 코드 실패는 아니었다.
+
+## Remaining Follow-Up Work
+
+- #277에서 TSK-004 전체 Wiki, roadmap, release candidate, parent/child evidence를 정리한다.

--- a/reports/completion/TSK-004-04-worker-service-handler-contracts.md
+++ b/reports/completion/TSK-004-04-worker-service-handler-contracts.md
@@ -2,7 +2,7 @@
 
 Scope-ID: `TSK-004-04-WORKER-SERVICE-HANDLER-CONTRACTS`
 Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/276
-PR: `TBD-TSK-004-04-WORKER-SERVICE-HANDLER-CONTRACTS`
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/282
 Branch: `worker-service-handler-contracts`
 Status: `validated-local`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -59,9 +59,9 @@ describe('worker source quality gates', () => {
       {
         file: 'deploy/api-worker-shell/services/admin.ts',
         limits: {
-          any: 6,
-          envAny: 5,
-          categoryAny: 1,
+          any: 0,
+          envAny: 0,
+          categoryAny: 0,
         },
       },
       {
@@ -69,28 +69,28 @@ describe('worker source quality gates', () => {
         limits: {
           supabaseRequest: 11,
           exportedHandlers: 5,
-          implicitEnvSignatures: 10,
+          implicitEnvSignatures: 0,
         },
       },
       {
         file: 'deploy/api-worker-shell/services/stamps.ts',
         limits: {
           supabaseRequest: 10,
-          implicitRequestBodyReaders: 1,
-          implicitEnvSignatures: 1,
+          implicitRequestBodyReaders: 0,
+          implicitEnvSignatures: 0,
         },
       },
       {
         file: 'deploy/api-worker-shell/services/auth.ts',
         limits: {
-          promiseAny: 2,
+          promiseAny: 0,
           exportedHandlers: 8,
         },
       },
       {
         file: 'deploy/api-worker-shell/services/review-interactions.ts',
         limits: {
-          promiseAny: 1,
+          promiseAny: 0,
           exportedHandlers: 8,
         },
       },


### PR DESCRIPTION
## Summary

- #276 Worker service handler contract typing 리팩터링입니다.
- admin/stamp/notification/auth/review-interaction handler의 `env`, JSON body, dependency contract를 명시 타입으로 좁혔습니다.
- 외부 REST endpoint, response shape, DB schema, 사용자-facing copy, Kakao/Naver OAuth 성공 경로는 변경하지 않았습니다.

## Scope

- Refs #276
- Parent: #272
- Branch: `worker-service-handler-contracts`
- Release candidate: `1.2.10`

## Evidence

- `admin.ts`: `any` 6 -> 0, `env:any` 5 -> 0, `category:any` 1 -> 0
- `auth.ts`: `Promise<any>` 2 -> 0
- `review-interactions.ts`: `Promise<any>` 1 -> 0
- `notifications.ts`: implicit env handler signatures 10 -> 0
- `stamps.ts`: implicit env handler signatures 1 -> 0, implicit `readJsonBody(request)` 1 -> 0
- Source-quality gate now blocks these handler contract regressions.

## Validation

- [x] targeted Vitest: `worker-source-quality`, `worker-review-domain`, `worker-account-community-admin-boundaries`, `worker-auth-security`
- [x] `npm.cmd run check:numeric-literals`
- [x] `npm.cmd run lint`
- [x] `npm.cmd run typecheck`
- [x] `npm.cmd run test:unit`
- [x] `npm.cmd run build`
- [x] `git diff --check`
- [x] `git diff --cached --check`
- [x] UTF-8 integrity check: `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`

## Note

`npm.cmd run test:unit` once failed inside the sandbox copy because Vitest could not resolve `D:/JamIssue/test/setup.ts`. The same command passed from the real workspace path `D:\JamIssue`; this was an execution-path issue, not a code failure.
