### PR TITLE
Trim 1.2.10 release candidate wording

### DIFF
--- a/docs/worker-residual-boundary-traceability.md
+++ b/docs/worker-residual-boundary-traceability.md
@@ -5,7 +5,7 @@ Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/272
 Status: `implementation-complete-docs-in-progress`
 Release candidate: `1.2.10`
 
-이 문서는 1.2.9 이후 실제 Worker 코드에서 확인된 잔여 결합 지점을 어떤 PR로 제거했는지 추적합니다. 평가 문구를 맞추기 위한 문서가 아니라, `festivals.ts` 책임 과밀, mapper 계층의 `any` row 계약, handler contract 미정형화를 코드 기준으로 줄인 근거를 기록합니다.
+이 문서는 1.2.9 이후 실제 Worker 코드에서 확인된 잔여 결합 지점을 어떤 PR로 제거했는지 추적합니다. 기록 대상은 `festivals.ts` 책임 과밀, mapper 계층의 `any` row 계약, handler contract 미정형화와 이를 줄인 검증 근거입니다.
 
 ## 변경 금지 범위
 

--- a/reports/completion/TSK-004-05-worker-boundary-traceability-docs.md
+++ b/reports/completion/TSK-004-05-worker-boundary-traceability-docs.md
@@ -13,7 +13,7 @@ Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/277
 - repo 기준 traceability 문서 `docs/worker-residual-boundary-traceability.md`를 추가한다.
 - `docs/operations-refactor-roadmap.md`에 TSK-004 완료 범위와 남은 예외를 추가한다.
 - Wiki `Refactor-Roadmap`, `Release-Notes`, `Release-Notes-1.2.10`, `Home`, `_Sidebar`를 1.2.10 후보 기준으로 갱신한다.
-- 문서 표현은 `SOLID 우수` 같은 평가 문구가 아니라 제거한 결합 지점과 검증 evidence를 기준으로 기록한다.
+- 문서 표현은 제거한 결합 지점, 남은 예외, 검증 evidence를 기준으로 기록한다.
 
 ## 검증 계획
 


### PR DESCRIPTION
## 요약

- 1.2.10 후보 문서에서 내부 대화성 표현을 제거했습니다.
- repo traceability 문서에 남은 `평가 문구`/`SOLID 우수` 표현을 제거하고, 제거한 결합 지점/검증 근거 중심 문장으로 정리했습니다.
- Wiki `Release-Notes-1.2.10`은 별도 Wiki commit `45da250`으로 이미 반영했습니다.

## 논리 보정

- 1.2.10 후보 기준 commit을 #283 merge 후 최종 main SHA `a9338dc93e57dc61f008b5655b6604a30c98cde6`로 맞췄습니다.
- #277 항목의 `TBD` merge SHA를 제거했습니다.
- 검증 링크를 #283 merge 이후 main Actions로 맞췄습니다.

## 검증

- `git diff --check`: pass
- `git diff --cached --check`: pass
- UTF-8 no-BOM check: pass
- 금지 표현 검색: pass

## 금지 변경 확인

- 앱 코드 변경 없음
- 사용자-facing copy 변경 없음
- API path/response shape 변경 없음
- DB schema 변경 없음
- OAuth 성공 경로 변경 없음
