### PR TITLE
test: guard architecture regression baselines

### DIFF
--- a/test/unit/interface-locality-source-quality.test.ts
+++ b/test/unit/interface-locality-source-quality.test.ts
@@ -39,6 +39,22 @@ function countSourceMatches(file: string, pattern: RegExp) {
   return [...source.matchAll(pattern)].length;
 }
 
+function collectTrackedFiles(paths: string[]) {
+  const output = execFileSync('git', ['ls-files', ...paths], {
+    cwd: workspaceRoot,
+    encoding: 'utf8',
+  });
+
+  return output.split(/\r?\n/).filter(Boolean);
+}
+
+function countTrackedSourceMatches(paths: string[], pattern: RegExp) {
+  return collectTrackedFiles(paths).reduce((count, file) => {
+    const source = readFileSync(join(workspaceRoot, file), 'utf8');
+    return count + [...source.matchAll(pattern)].length;
+  }, 0);
+}
+
 describe('interface locality source quality baseline', () => {
   it('keeps Worker central type surface from growing before locality splits', () => {
     expect(countSourceMatches('deploy/api-worker-shell/types.ts', /^export (type|interface) /gm)).toBeLessThanOrEqual(4);
@@ -62,6 +78,16 @@ describe('interface locality source quality baseline', () => {
     expect(gitGrepCount(rootTypeImportPattern, ['src'])).toBeLessThanOrEqual(19);
     expect(gitGrepCount(rootTypeImportPattern, ['src/components'])).toBe(0);
     expect(gitGrepCount(rootTypeImportPattern, ['src/hooks'])).toBe(0);
+  });
+
+  it('keeps frontend public type contracts from importing API clients', () => {
+    expect(countTrackedSourceMatches(['src/types'], /from\s+['"][^'"]*\/api(?:\/|['"])/g)).toBe(0);
+  });
+
+  it('keeps the Naver map SDK any baseline from growing before local contracts are added', () => {
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /\bany\b/g)).toBeLessThanOrEqual(14);
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /Promise<any>/g)).toBeLessThanOrEqual(1);
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /Map<string,\s*any>/g)).toBeLessThanOrEqual(2);
   });
 
   it('keeps wide stage prop coupling from growing before stage-local props are split', () => {

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from 'vitest';
 
 const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
 const maxWorkerLineLength = 3_500;
+const maxWorkerSemicolonsPerLine = 6;
 
 function countSourceMatches(file: string, pattern: RegExp): number {
   const source = readFileSync(join(workspaceRoot, file), 'utf8');
@@ -34,6 +35,7 @@ describe('worker source quality gates', () => {
       const source = readFileSync(file, 'utf8');
       const lines = source.split(/\r?\n/);
       const longestLine = Math.max(...lines.map((line) => line.length));
+      const mostSemicolonsOnLine = Math.max(...lines.map((line) => [...line.matchAll(/;/g)].length));
       const relativePath = relative(workspaceRoot, file);
 
       expect(relativePath, 'worker quality gate must inspect tracked source only').not.toContain('.wrangler');
@@ -41,6 +43,9 @@ describe('worker source quality gates', () => {
         expect(lines.length, `${relativePath} should stay reviewable`).toBeGreaterThan(1);
       }
       expect(longestLine, `${relativePath} has a suspiciously long line`).toBeLessThanOrEqual(maxWorkerLineLength);
+      expect(mostSemicolonsOnLine, `${relativePath} has too many statements on one line`).toBeLessThanOrEqual(
+        maxWorkerSemicolonsPerLine,
+      );
     }
   });
 
@@ -62,6 +67,12 @@ describe('worker source quality gates', () => {
           any: 0,
           envAny: 0,
           categoryAny: 0,
+        },
+      },
+      {
+        file: 'deploy/api-worker-shell/services/reviews.ts',
+        limits: {
+          supabaseRequest: 23,
         },
       },
       {


### PR DESCRIPTION
## Scope

- Scope-ID: TSK-005-01
- Parent Issue: #286
- Child Issue: #287
- Branch: architecture-regression-audit-gates
- Target release candidate: 1.2.11

## Summary

Adds source-quality gates that prevent architecture and interface-locality regression before the next child issue splits implementation details.

## Changes

- Blocks `src/types/**` from importing `src/api/**`, preventing the PR #285 reverse-dependency pattern from returning.
- Freezes the current Naver map SDK `any` baseline before local contracts are introduced.
- Freezes the current Worker review/stamp/notification direct `supabaseRequest` baseline before boundary splits.
- Adds a Worker semicolon-density gate so compressed multi-statement lines cannot get worse.

## Validation

- `npx.cmd vitest run test/unit/worker-source-quality.test.ts test/unit/interface-locality-source-quality.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`

## Non-Goals

- No API path, response shape, DB schema, user-facing copy, or OAuth flow changes.

Refs #287.