### PR TITLE
refactor: localize naver map sdk contract

### DIFF
--- a/src/components/naver-map/mapSdk.ts
+++ b/src/components/naver-map/mapSdk.ts
@@ -1,16 +1,11 @@
 import { MapViewportConfig } from '../../config/mapConfig';
+import type { NaverMapsApi } from './naverMapTypes';
 
 export const DAEJEON_CENTER = MapViewportConfig.daejeonCenter;
 
-declare global {
-  interface Window {
-    naver?: any;
-  }
-}
+let naverScriptPromise: Promise<NaverMapsApi> | null = null;
 
-let naverScriptPromise: Promise<any> | null = null;
-
-export function loadNaverMaps(clientId: string) {
+export function loadNaverMaps(clientId: string): Promise<NaverMapsApi> {
   if (window.naver?.maps) {
     return Promise.resolve(window.naver.maps);
   }

--- a/src/components/naver-map/markerContent.ts
+++ b/src/components/naver-map/markerContent.ts
@@ -2,6 +2,11 @@ import { cssPx, UiNaverMarkerVisualConfig } from '../../config/uiTokenConfig';
 import { categoryInfo } from '../../lib/categories';
 import type { FestivalItem, Place } from '../../types/core';
 
+type FestivalWithCoordinates = FestivalItem & {
+  latitude: number;
+  longitude: number;
+};
+
 export function placeMarkerContent(place: Place, isActive: boolean) {
   const info = categoryInfo[place.category];
   const ring = isActive ? '#5f4660' : 'rgba(95, 70, 96, 0.18)';
@@ -42,7 +47,7 @@ export function festivalMarkerContent(_festival: FestivalItem, isActive: boolean
   `;
 }
 
-export function hasFestivalCoordinates(festival: FestivalItem) {
+export function hasFestivalCoordinates(festival: FestivalItem): festival is FestivalWithCoordinates {
   return typeof festival.latitude === 'number'
     && Number.isFinite(festival.latitude)
     && typeof festival.longitude === 'number'

--- a/src/components/naver-map/naverMapTypes.ts
+++ b/src/components/naver-map/naverMapTypes.ts
@@ -1,0 +1,95 @@
+/*
+ * File: naverMapTypes.ts
+ * Purpose: Keep the minimal Naver Maps SDK contract local to the map adapter.
+ * Primary Responsibility: Type only the SDK surface used by JamIssue map hooks.
+ */
+
+export type NaverLatLng = {
+  lat: () => number;
+  lng: () => number;
+};
+
+export type NaverPoint = unknown;
+
+export type NaverLatLngBounds = {
+  extend: (position: NaverLatLng) => void;
+};
+
+export type NaverMapInstance = {
+  fitBounds?: (bounds: NaverLatLngBounds, padding?: Record<string, number>) => void;
+  getCenter: () => NaverLatLng;
+  getZoom: () => number;
+  panBy?: (x: number, y: number) => void;
+  panTo?: (position: NaverLatLng) => void;
+  setCenter?: (position: NaverLatLng) => void;
+  setZoom?: (zoom: number, effect?: boolean) => void;
+};
+
+export type NaverMarkerIcon = {
+  content: string;
+  anchor: NaverPoint;
+};
+
+export type NaverMarkerInstance = {
+  setIcon: (icon: NaverMarkerIcon) => void;
+  setMap: (map: NaverMapInstance | null) => void;
+  setPosition: (position: NaverLatLng) => void;
+  setZIndex: (zIndex: number) => void;
+};
+
+export type NaverPolylineInstance = {
+  setMap: (map: NaverMapInstance | null) => void;
+};
+
+export type NaverMapEventListener = unknown;
+
+export type NaverMapsApi = {
+  Event: {
+    addListener: (
+      target: NaverMapInstance | NaverMarkerInstance,
+      eventName: string,
+      listener: () => void,
+    ) => NaverMapEventListener;
+    removeListener: (listener: NaverMapEventListener) => void;
+  };
+  LatLng: new (latitude: number, longitude: number) => NaverLatLng;
+  LatLngBounds: new () => NaverLatLngBounds;
+  Map: new (
+    element: HTMLElement,
+    options: {
+      center: NaverLatLng;
+      zoom: number;
+      minZoom: number;
+      scaleControl: boolean;
+      logoControl: boolean;
+      mapDataControl: boolean;
+      zoomControl: boolean;
+    },
+  ) => NaverMapInstance;
+  Marker: new (options: {
+    map: NaverMapInstance | null;
+    position: NaverLatLng;
+    title: string;
+    zIndex?: number;
+    icon: NaverMarkerIcon;
+  }) => NaverMarkerInstance;
+  Point: new (x: number, y: number) => NaverPoint;
+  Polyline: new (options: {
+    map: NaverMapInstance | null;
+    path: NaverLatLng[];
+    strokeColor: string;
+    strokeOpacity: number;
+    strokeWeight: number;
+    strokeLineCap: string;
+    strokeLineJoin: string;
+    zIndex: number;
+  }) => NaverPolylineInstance;
+};
+
+declare global {
+  interface Window {
+    naver?: {
+      maps?: NaverMapsApi;
+    };
+  }
+}

--- a/src/components/naver-map/useNaverCurrentLocationFocus.ts
+++ b/src/components/naver-map/useNaverCurrentLocationFocus.ts
@@ -1,14 +1,9 @@
 import { useEffect } from 'react';
-
-type NaverMapInstance = {
-  panTo?: (position: unknown) => void;
-};
-
-type MapsApi = typeof window.naver.maps;
+import type { NaverMapInstance, NaverMapsApi } from './naverMapTypes';
 
 type CurrentLocationFocusArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
+  mapsApi: NaverMapsApi | undefined;
   mapRef: React.MutableRefObject<NaverMapInstance | null>;
   currentPosition: { latitude: number; longitude: number } | null;
   focusCurrentLocationKey: number;

--- a/src/components/naver-map/useNaverCurrentLocationMarker.ts
+++ b/src/components/naver-map/useNaverCurrentLocationMarker.ts
@@ -2,13 +2,12 @@ import { useEffect, useRef } from 'react';
 import type { MutableRefObject } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
 import { currentLocationMarkerContent } from './markerContent';
-
-type MapsApi = typeof window.naver.maps;
+import type { NaverMapInstance, NaverMapsApi, NaverMarkerInstance } from './naverMapTypes';
 
 type CurrentLocationMarkerArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
-  mapRef: MutableRefObject<any>;
+  mapsApi: NaverMapsApi | undefined;
+  mapRef: MutableRefObject<NaverMapInstance | null>;
   currentPosition: { latitude: number; longitude: number } | null;
 };
 
@@ -18,7 +17,7 @@ export function useNaverCurrentLocationMarker({
   mapRef,
   currentPosition,
 }: CurrentLocationMarkerArgs) {
-  const currentMarkerRef = useRef<any | null>(null);
+  const currentMarkerRef = useRef<NaverMarkerInstance | null>(null);
 
   useEffect(() => {
     if (status !== 'ready' || !mapsApi || !mapRef.current) {

--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -3,13 +3,12 @@ import type { MutableRefObject } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { FestivalItem } from '../../types/core';
 import { festivalMarkerContent, hasFestivalCoordinates } from './markerContent';
-
-type MapsApi = typeof window.naver.maps;
+import type { NaverMapInstance, NaverMapsApi, NaverMarkerInstance } from './naverMapTypes';
 
 type FestivalMarkersArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
-  mapRef: MutableRefObject<any>;
+  mapsApi: NaverMapsApi | undefined;
+  mapRef: MutableRefObject<NaverMapInstance | null>;
   festivals: FestivalItem[];
   selectedFestivalId: string | null;
   onSelectFestival: (festivalId: string) => void;
@@ -23,7 +22,7 @@ export function useNaverFestivalMarkers({
   selectedFestivalId,
   onSelectFestival,
 }: FestivalMarkersArgs) {
-  const festivalMarkersRef = useRef<Map<string, any>>(new Map());
+  const festivalMarkersRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
 
   useEffect(() => {
     if (status !== 'ready' || !mapsApi || !mapRef.current) {

--- a/src/components/naver-map/useNaverMapInstance.ts
+++ b/src/components/naver-map/useNaverMapInstance.ts
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { MapViewportConfig } from '../../config/mapConfig';
 import { DAEJEON_CENTER, loadNaverMaps } from './mapSdk';
+import type { NaverMapInstance } from './naverMapTypes';
 
 type MapInstanceArgs = {
   clientId: string;
@@ -15,7 +16,7 @@ export function useNaverMapInstance({
   initialCenter,
   initialZoom,
 }: MapInstanceArgs) {
-  const mapRef = useRef<any>(null);
+  const mapRef = useRef<NaverMapInstance | null>(null);
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 

--- a/src/components/naver-map/useNaverMapInteractions.ts
+++ b/src/components/naver-map/useNaverMapInteractions.ts
@@ -6,11 +6,12 @@ import { useNaverFestivalMarkers } from './useNaverFestivalMarkers';
 import { useNaverPlaceMarkers } from './useNaverPlaceMarkers';
 import { useNaverRoutePreviewOverlay } from './useNaverRoutePreviewOverlay';
 import { useNaverSelectionSync } from './useNaverSelectionSync';
+import type { NaverMapInstance, NaverMapsApi, NaverMarkerInstance, NaverPolylineInstance } from './naverMapTypes';
 
 type MapInteractionsArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: typeof window.naver.maps | undefined;
-  mapRef: React.MutableRefObject<any>;
+  mapsApi: NaverMapsApi | undefined;
+  mapRef: React.MutableRefObject<NaverMapInstance | null>;
   mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
   places: Place[];
   festivals: FestivalItem[];
@@ -38,8 +39,8 @@ export function useNaverMapInteractions({
   focusCurrentLocationKey,
   routePreviewPlaces,
 }: MapInteractionsArgs) {
-  const routeLineRef = useRef<any | null>(null);
-  const routeStepMarkersRef = useRef<any[]>([]);
+  const routeLineRef = useRef<NaverPolylineInstance | null>(null);
+  const routeStepMarkersRef = useRef<NaverMarkerInstance[]>([]);
   const lastHandledCurrentLocationFocusKeyRef = useRef(0);
 
   useNaverPlaceMarkers({

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -3,13 +3,12 @@ import type { MutableRefObject } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { Place } from '../../types/core';
 import { placeMarkerContent } from './markerContent';
-
-type MapsApi = typeof window.naver.maps;
+import type { NaverMapInstance, NaverMapsApi, NaverMarkerInstance } from './naverMapTypes';
 
 type PlaceMarkersArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
-  mapRef: MutableRefObject<any>;
+  mapsApi: NaverMapsApi | undefined;
+  mapRef: MutableRefObject<NaverMapInstance | null>;
   places: Place[];
   selectedPlaceId: string | null;
   onSelectPlace: (placeId: string) => void;
@@ -23,7 +22,7 @@ export function useNaverPlaceMarkers({
   selectedPlaceId,
   onSelectPlace,
 }: PlaceMarkersArgs) {
-  const placeMarkersRef = useRef<Map<string, any>>(new Map());
+  const placeMarkersRef = useRef<Map<string, NaverMarkerInstance>>(new Map());
 
   useEffect(() => {
     if (status !== 'ready' || !mapsApi || !mapRef.current) {

--- a/src/components/naver-map/useNaverRoutePreviewOverlay.ts
+++ b/src/components/naver-map/useNaverRoutePreviewOverlay.ts
@@ -2,28 +2,14 @@ import { useEffect } from 'react';
 import { NaverMarkerConfig } from '../../config/mapConfig';
 import type { Place } from '../../types/core';
 import { routeStepMarkerContent } from './markerContent';
-
-type NaverMapInstance = {
-  fitBounds?: (bounds: unknown, padding?: Record<string, number>) => void;
-  panTo?: (position: unknown) => void;
-};
-
-type MarkerInstance = {
-  setMap: (map: unknown) => void;
-};
-
-type PolylineInstance = {
-  setMap: (map: unknown) => void;
-};
-
-type MapsApi = typeof window.naver.maps;
+import type { NaverMapInstance, NaverMapsApi, NaverMarkerInstance, NaverPolylineInstance } from './naverMapTypes';
 
 type RoutePreviewOverlayArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
+  mapsApi: NaverMapsApi | undefined;
   mapRef: React.MutableRefObject<NaverMapInstance | null>;
-  routeLineRef: React.MutableRefObject<PolylineInstance | null>;
-  routeStepMarkersRef: React.MutableRefObject<MarkerInstance[]>;
+  routeLineRef: React.MutableRefObject<NaverPolylineInstance | null>;
+  routeStepMarkersRef: React.MutableRefObject<NaverMarkerInstance[]>;
   routePreviewPlaces: Place[];
   selectedPlaceId: string | null;
   selectedFestivalId: string | null;

--- a/src/components/naver-map/useNaverSelectionSync.ts
+++ b/src/components/naver-map/useNaverSelectionSync.ts
@@ -2,21 +2,12 @@ import { useEffect } from 'react';
 import { MapViewportConfig, SelectionMotionConfig } from '../../config/mapConfig';
 import type { FestivalItem, Place } from '../../types/core';
 import { hasFestivalCoordinates } from './markerContent';
+import type { NaverMapInstance, NaverMapsApi } from './naverMapTypes';
 import { getSelectionVerticalOffset } from './selectionOffset';
-
-type NaverMapInstance = {
-  getZoom?: () => number;
-  setZoom?: (zoom: number, effect?: boolean) => void;
-  panTo?: (position: unknown) => void;
-  setCenter?: (position: unknown) => void;
-  panBy?: (x: number, y: number) => void;
-};
-
-type MapsApi = typeof window.naver.maps;
 
 type SelectionSyncArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: MapsApi | undefined;
+  mapsApi: NaverMapsApi | undefined;
   mapRef: React.MutableRefObject<NaverMapInstance | null>;
   mapElementRef: React.MutableRefObject<HTMLDivElement | null>;
   places: Place[];

--- a/src/components/naver-map/useNaverViewportSync.ts
+++ b/src/components/naver-map/useNaverViewportSync.ts
@@ -1,12 +1,13 @@
 import { useEffect, useRef } from 'react';
 import { SelectionMotionConfig } from '../../config/mapConfig';
+import type { NaverMapEventListener, NaverMapInstance, NaverMapsApi } from './naverMapTypes';
 
 type ViewportChangeHandler = ((lat: number, lng: number, zoom: number) => void) | undefined;
 
 type NaverViewportSyncArgs = {
   status: 'loading' | 'ready' | 'error';
-  mapsApi: typeof window.naver.maps | undefined;
-  mapRef: React.MutableRefObject<any>;
+  mapsApi: NaverMapsApi | undefined;
+  mapRef: React.MutableRefObject<NaverMapInstance | null>;
   onViewportChangeRef: React.MutableRefObject<ViewportChangeHandler>;
 };
 
@@ -16,7 +17,7 @@ export function useNaverViewportSync({
   mapRef,
   onViewportChangeRef,
 }: NaverViewportSyncArgs) {
-  const idleListenerRef = useRef<any>(null);
+  const idleListenerRef = useRef<NaverMapEventListener | null>(null);
   const viewportDebounceTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {

--- a/test/unit/interface-locality-source-quality.test.ts
+++ b/test/unit/interface-locality-source-quality.test.ts
@@ -84,10 +84,10 @@ describe('interface locality source quality baseline', () => {
     expect(countTrackedSourceMatches(['src/types'], /from\s+['"][^'"]*\/api(?:\/|['"])/g)).toBe(0);
   });
 
-  it('keeps the Naver map SDK any baseline from growing before local contracts are added', () => {
-    expect(countTrackedSourceMatches(['src/components/naver-map'], /\bany\b/g)).toBeLessThanOrEqual(14);
-    expect(countTrackedSourceMatches(['src/components/naver-map'], /Promise<any>/g)).toBeLessThanOrEqual(1);
-    expect(countTrackedSourceMatches(['src/components/naver-map'], /Map<string,\s*any>/g)).toBeLessThanOrEqual(2);
+  it('keeps the Naver map SDK contract local and free of any fallbacks', () => {
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /\bany\b/g)).toBe(0);
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /Promise<any>/g)).toBe(0);
+    expect(countTrackedSourceMatches(['src/components/naver-map'], /Map<string,\s*any>/g)).toBe(0);
   });
 
   it('keeps wide stage prop coupling from growing before stage-local props are split', () => {


### PR DESCRIPTION
## Scope

- Scope-ID: TSK-005-05
- Parent Issue: #286
- Child Issue: #291
- Branch: frontend-naver-map-sdk-contract
- Target release candidate: 1.2.11

## Summary

Localizes the minimal Naver Maps SDK contract inside `src/components/naver-map` and removes `any` fallbacks from the Naver map adapter hooks.

## Changes

- Adds `naverMapTypes.ts` as the owner-local SDK contract for map, marker, polyline, event listener, bounds, point, and LatLng usage.
- Replaces `window.naver.maps`-derived `any` usage in Naver map hooks with local types.
- Lowers the Naver map source-quality gate to require 0 `any`, 0 `Promise<any>`, and 0 `Map<string, any>` matches.

## Validation

- `npx.cmd vitest run test/unit/interface-locality-source-quality.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`

## Non-Goals

- No visual redesign.
- No API path, response shape, DB schema, user-facing copy, or OAuth flow changes.

Refs #291.