### PR TITLE
refactor: isolate worker review read persistence

### DIFF
--- a/deploy/api-worker-shell/services/review-domain/read-repository.ts
+++ b/deploy/api-worker-shell/services/review-domain/read-repository.ts
@@ -1,0 +1,113 @@
+/*
+ * File: read-repository.ts
+ * Purpose: Keep review read Supabase queries behind the review-domain repository boundary.
+ * Primary Responsibility: Fetch review read-model rows without exposing REST query details to services.
+ */
+
+import type { SupabaseMapRow } from '../../runtime/base-data-contracts';
+import type { WorkerEnv } from '../../types';
+import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type {
+  WorkerReviewCommentRow,
+  WorkerReviewFeedRow,
+  WorkerReviewLikeRow,
+  WorkerReviewRouteRow,
+  WorkerReviewStampRow,
+  WorkerReviewUserRow,
+} from './contracts';
+
+type ReviewFeedFilters = {
+  positionId?: string | null;
+  userId?: string;
+};
+
+type ReviewPageQuery = {
+  cursor?: string | null;
+  limit: number;
+};
+
+export async function readReviewFeedRows(env: WorkerEnv, filters: ReviewFeedFilters = {}) {
+  const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc'];
+  if (filters.positionId) {
+    reviewQuery.push(`position_id=eq.${encodeFilterValue(filters.positionId)}`);
+  }
+  if (filters.userId) {
+    reviewQuery.push(`user_id=eq.${encodeFilterValue(filters.userId)}`);
+  }
+
+  return supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
+}
+
+export async function readReviewPageRows(env: WorkerEnv, { cursor = null, limit }: ReviewPageQuery) {
+  const reviewQuery = [
+    'select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at',
+    'order=created_at.desc',
+    `limit=${limit + 1}`,
+  ];
+  if (cursor) {
+    reviewQuery.push(`created_at=lt.${encodeFilterValue(cursor)}`);
+  }
+
+  return supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
+}
+
+export async function readSingleReviewFeedRow(env: WorkerEnv, reviewId: string | number) {
+  const rows = await supabaseRequest<WorkerReviewFeedRow[]>(
+    env,
+    `feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`,
+  );
+  return rows?.[0] ?? null;
+}
+
+export async function readReviewCommentRows(env: WorkerEnv, feedIds: Array<string | number>) {
+  const feedIdsFilter = buildInFilter(feedIds);
+  return feedIdsFilter
+    ? supabaseRequest<WorkerReviewCommentRow[]>(
+      env,
+      `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`,
+    )
+    : [];
+}
+
+export async function readReviewLikeRows(env: WorkerEnv, feedIds: Array<string | number>) {
+  const feedIdsFilter = buildInFilter(feedIds);
+  return feedIdsFilter ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : [];
+}
+
+export async function readReviewStampRows(env: WorkerEnv, stampIds: Array<string | number | null | undefined>) {
+  const stampIdsFilter = buildInFilter(stampIds.filter(Boolean));
+  return stampIdsFilter
+    ? supabaseRequest<WorkerReviewStampRow[]>(
+      env,
+      `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${stampIdsFilter}`,
+    )
+    : [];
+}
+
+export async function readUserFeedLikeRows(env: WorkerEnv, feedIds: Array<string | number>, userId: string | null) {
+  const feedIdsFilter = buildInFilter(feedIds);
+  return userId && feedIdsFilter
+    ? supabaseRequest<WorkerReviewLikeRow[]>(
+      env,
+      `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(userId)}&feed_id=${feedIdsFilter}`,
+    )
+    : [];
+}
+
+export async function readReviewRouteRows(env: WorkerEnv, travelSessionIds: string[]) {
+  return travelSessionIds.length > 0
+    ? supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(travelSessionIds)}`)
+    : [];
+}
+
+export async function readReviewUserRows(env: WorkerEnv, userIds: Array<string | number>) {
+  const userIdsFilter = buildInFilter(userIds);
+  return userIdsFilter ? supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+}
+
+export async function readReviewPlaceRows(env: WorkerEnv, positionId: string | number) {
+  return supabaseRequest<SupabaseMapRow[]>(
+    env,
+    `map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&position_id=eq.${encodeFilterValue(positionId)}&limit=1`,
+  );
+}

--- a/deploy/api-worker-shell/services/reviews.ts
+++ b/deploy/api-worker-shell/services/reviews.ts
@@ -1,21 +1,31 @@
 import { jsonResponse } from '../lib/http';
-import { buildInFilter, encodeFilterValue, parseListLimit, supabaseRequest } from '../lib/supabase';
+import { parseListLimit } from '../lib/supabase';
 import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
 import { createReviewMapper } from './review-domain/mapper';
-import type { SupabaseMapRow } from '../runtime/base-data-contracts';
 import type { WorkerEnv } from '../types';
 import type {
-  WorkerReviewCommentRow,
   WorkerReviewDataFilters,
-  WorkerReviewFeedRow,
-  WorkerReviewLikeRow,
   WorkerReviewPageOptions,
   WorkerReviewReadServiceDeps,
-  WorkerReviewRouteRow,
-  WorkerReviewStampRow,
   WorkerReviewUserRow,
 } from './review-domain/contracts';
+import {
+  readReviewCommentRows,
+  readReviewFeedRows,
+  readReviewLikeRows,
+  readReviewPageRows,
+  readReviewPlaceRows,
+  readReviewRouteRows,
+  readReviewStampRows,
+  readReviewUserRows,
+  readSingleReviewFeedRow,
+  readUserFeedLikeRows,
+} from './review-domain/read-repository';
+
+function indexUsersById(userRows: WorkerReviewUserRow[]) {
+  return new Map(userRows.map((row) => [row.user_id, row] as const));
+}
 
 export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, mapPlace }: WorkerReviewReadServiceDeps) {
   const { buildCommentTree, countComments, mapReviewRows } = createReviewMapper(formatVisitLabel);
@@ -25,32 +35,21 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     const places = placeRows.map(mapPlace);
     const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
     const placeIdToPositionId = new Map(places.map((place) => [place.id, place.positionId]));
-    const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc'];
+    let positionId: string | null = null;
     if (filters.placeId) {
-      const positionId = placeIdToPositionId.get(filters.placeId);
+      positionId = placeIdToPositionId.get(filters.placeId) ?? null;
       if (!positionId) {
         return [];
       }
-      reviewQuery.push(`position_id=eq.${encodeFilterValue(positionId)}`);
-    }
-    if (filters.userId) {
-      reviewQuery.push(`user_id=eq.${encodeFilterValue(filters.userId)}`);
     }
 
-    const feedRows = await supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
-    const feedIdsFilter = buildInFilter(feedRows.map((row) => row.feed_id));
-    const reviewStampIdsFilter = buildInFilter(feedRows.map((row) => row.stamp_id).filter(Boolean));
+    const feedRows = await readReviewFeedRows(env, { positionId, userId: filters.userId });
+    const feedIds = feedRows.map((row) => row.feed_id);
     const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
-      feedIdsFilter
-        ? supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
-        : Promise.resolve([]),
-      feedIdsFilter ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
-      reviewStampIdsFilter
-        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
-        : Promise.resolve([]),
-      sessionUserId && feedIdsFilter
-        ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
-        : Promise.resolve([]),
+      readReviewCommentRows(env, feedIds),
+      readReviewLikeRows(env, feedIds),
+      readReviewStampRows(env, feedRows.map((row) => row.stamp_id)),
+      readUserFeedLikeRows(env, feedIds, sessionUserId),
     ]);
     const reviewTravelSessionIds = [
       ...new Set(
@@ -60,13 +59,9 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
           .map((value) => String(value)),
       ),
     ];
-    const reviewRouteRows =
-      reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
-        : [];
-    const userIdsFilter = buildInFilter([...feedRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
-    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const reviewRouteRows = await readReviewRouteRows(env, reviewTravelSessionIds);
+    const userRows = await readReviewUserRows(env, [...feedRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
+    const usersById = indexUsersById(userRows);
     const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
     const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
     return mapReviewRows(feedRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds);
@@ -77,27 +72,15 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
     const { placeRows } = await loadStaticBaseRows(env);
     const places = placeRows.map(mapPlace);
     const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
-    const reviewQuery = ['select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at', 'order=created_at.desc', `limit=${limit + 1}`];
-    if (cursor) {
-      reviewQuery.push(`created_at=lt.${encodeFilterValue(cursor)}`);
-    }
-
-    const feedRows = await supabaseRequest<WorkerReviewFeedRow[]>(env, `feed?${reviewQuery.join('&')}`);
+    const feedRows = await readReviewPageRows(env, { cursor, limit });
     const nextCursor = feedRows.length > limit ? String(feedRows[limit].created_at) : null;
     const pageRows = feedRows.slice(0, limit);
-    const feedIdsFilter = buildInFilter(pageRows.map((row) => row.feed_id));
-    const reviewStampIdsFilter = buildInFilter(pageRows.map((row) => row.stamp_id).filter(Boolean));
+    const feedIds = pageRows.map((row) => row.feed_id);
     const [commentRows, likeRows, reviewStampRows, userFeedLikeRows = []] = await Promise.all([
-      feedIdsFilter
-        ? supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=${feedIdsFilter}&order=created_at.asc`)
-        : Promise.resolve([]),
-      feedIdsFilter ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=${feedIdsFilter}`) : Promise.resolve([]),
-      reviewStampIdsFilter
-        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=${reviewStampIdsFilter}`)
-        : Promise.resolve([]),
-      sessionUserId && feedIdsFilter
-        ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=${feedIdsFilter}`)
-        : Promise.resolve([]),
+      readReviewCommentRows(env, feedIds),
+      readReviewLikeRows(env, feedIds),
+      readReviewStampRows(env, pageRows.map((row) => row.stamp_id)),
+      readUserFeedLikeRows(env, feedIds, sessionUserId),
     ]);
     const reviewTravelSessionIds = [
       ...new Set(
@@ -107,38 +90,25 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
           .map((value) => String(value)),
       ),
     ];
-    const reviewRouteRows =
-      reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
-        : [];
-    const userIdsFilter = buildInFilter([...pageRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
-    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const reviewRouteRows = await readReviewRouteRows(env, reviewTravelSessionIds);
+    const userRows = await readReviewUserRows(env, [...pageRows.map((row) => row.user_id), ...commentRows.map((row) => row.user_id)]);
+    const usersById = indexUsersById(userRows);
     const stampRowsById = new Map((reviewStampRows ?? []).map((row) => [String(row.stamp_id), row]));
     const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
     return { items: mapReviewRows(pageRows, commentRows, likeRows, usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds), nextCursor };
   }
 
   async function loadSingleReview(env: WorkerEnv, reviewId: string, sessionUserId: string | null = null) {
-    const reviewRows = await supabaseRequest<WorkerReviewFeedRow[]>(
-      env,
-      `feed?select=feed_id,position_id,user_id,stamp_id,body,mood,badge,image_url,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`,
-    );
-    const reviewRow = reviewRows?.[0] ?? null;
+    const reviewRow = await readSingleReviewFeedRow(env, reviewId);
     if (!reviewRow) {
       return null;
     }
     const [commentRows, likeRows, placeRows, stampRows, userFeedLikeRows = []] = await Promise.all([
-      supabaseRequest<WorkerReviewCommentRow[]>(env, `user_comment?select=comment_id,feed_id,user_id,parent_id,body,is_deleted,created_at&feed_id=eq.${encodeFilterValue(reviewId)}&order=created_at.asc`),
-      supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id,user_id&feed_id=eq.${encodeFilterValue(reviewId)}`),
-      supabaseRequest<SupabaseMapRow[]>(
-        env,
-        `map?select=position_id,slug,name,district,category,latitude,longitude,summary,description,image_url,image_storage_path,vibe_tags,visit_time,route_hint,stamp_reward,hero_label,jam_color,accent_color,is_active&position_id=eq.${encodeFilterValue(reviewRow.position_id)}&limit=1`,
-      ),
-      reviewRow.stamp_id
-        ? supabaseRequest<WorkerReviewStampRow[]>(env, `user_stamp?select=stamp_id,user_id,position_id,travel_session_id,stamp_date,visit_ordinal,created_at&stamp_id=eq.${encodeFilterValue(reviewRow.stamp_id)}&limit=1`)
-        : Promise.resolve([]),
-      sessionUserId ? supabaseRequest<WorkerReviewLikeRow[]>(env, `feed_like?select=feed_id&user_id=eq.${encodeFilterValue(sessionUserId)}&feed_id=eq.${encodeFilterValue(reviewId)}&limit=1`) : Promise.resolve([]),
+      readReviewCommentRows(env, [reviewId]),
+      readReviewLikeRows(env, [reviewId]),
+      readReviewPlaceRows(env, reviewRow.position_id),
+      readReviewStampRows(env, [reviewRow.stamp_id]),
+      readUserFeedLikeRows(env, [reviewId], sessionUserId),
     ]);
     const reviewTravelSessionIds = [
       ...new Set(
@@ -148,15 +118,11 @@ export function createReviewReadService({ formatVisitLabel, loadStaticBaseRows, 
           .map((value) => String(value)),
       ),
     ];
-    const reviewRouteRows =
-      reviewTravelSessionIds.length > 0
-        ? await supabaseRequest<WorkerReviewRouteRow[]>(env, `user_route?select=route_id,travel_session_id&travel_session_id=${buildInFilter(reviewTravelSessionIds)}`)
-        : [];
-    const userIdsFilter = buildInFilter([reviewRow.user_id, ...commentRows.map((row) => row.user_id)]);
-    const userRows = userIdsFilter ? await supabaseRequest<WorkerReviewUserRow[]>(env, `user?select=user_id,nickname&user_id=${userIdsFilter}`) : [];
+    const reviewRouteRows = await readReviewRouteRows(env, reviewTravelSessionIds);
+    const userRows = await readReviewUserRows(env, [reviewRow.user_id, ...commentRows.map((row) => row.user_id)]);
     const places = placeRows.map(mapPlace);
     const placesByPositionId = new Map(places.map((place) => [place.positionId, place]));
-    const usersById = new Map(userRows.map((row) => [row.user_id, row]));
+    const usersById = indexUsersById(userRows);
     const stampRowsById = new Map((stampRows ?? []).map((row) => [String(row.stamp_id), row]));
     const likedFeedIds = new Set((userFeedLikeRows ?? []).map((row) => String(row.feed_id)));
     return mapReviewRows([reviewRow], commentRows ?? [], likeRows ?? [], usersById, placesByPositionId, stampRowsById, reviewRouteRows, likedFeedIds)[0] ?? null;

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "cb04022cd5fd091ddf0c61d56726f8eb1f818975",
+  "generatedFrom": "fc6e8b81f02e1409202c6c03fc5d377fb5503abf",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -1583,7 +1583,7 @@
       "examples": [
         {
           "value": "00",
-          "line": 56,
+          "line": 64,
           "column": 47
         }
       ]
@@ -2023,33 +2023,33 @@
       "examples": [
         {
           "value": "401",
-          "line": 7,
+          "line": 44,
           "column": 37
         },
         {
           "value": "1",
-          "line": 9,
-          "column": 290
+          "line": 46,
+          "column": 343
         },
         {
           "value": "0",
-          "line": 9,
-          "column": 309
+          "line": 46,
+          "column": 362
         },
         {
           "value": "0",
-          "line": 12,
-          "column": 462
+          "line": 49,
+          "column": 496
         },
         {
           "value": "0",
-          "line": 14,
-          "column": 228
+          "line": 51,
+          "column": 281
         },
         {
           "value": "1",
-          "line": 18,
-          "column": 137
+          "line": 55,
+          "column": 167
         }
       ]
     },
@@ -2175,7 +2175,7 @@
     },
     {
       "path": "deploy/api-worker-shell/services/reviews.ts",
-      "count": 15,
+      "count": 6,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -2183,33 +2183,33 @@
       "examples": [
         {
           "value": "0",
-          "line": 64,
-          "column": 39
-        },
-        {
-          "value": "1",
-          "line": 80,
-          "column": 152
-        },
-        {
-          "value": "0",
-          "line": 87,
+          "line": 77,
           "column": 37
         },
         {
           "value": "0",
-          "line": 111,
-          "column": 39
+          "line": 128,
+          "column": 151
         },
         {
-          "value": "1",
-          "line": 125,
-          "column": 142
+          "value": "200",
+          "line": 137,
+          "column": 25
         },
         {
-          "value": "0",
-          "line": 127,
-          "column": 36
+          "value": "200",
+          "line": 146,
+          "column": 25
+        },
+        {
+          "value": "404",
+          "line": 153,
+          "column": 27
+        },
+        {
+          "value": "200",
+          "line": 155,
+          "column": 25
         }
       ]
     },
@@ -2223,33 +2223,33 @@
       "examples": [
         {
           "value": "0",
-          "line": 6,
-          "column": 194
+          "line": 8,
+          "column": 205
         },
         {
           "value": "2",
-          "line": 7,
-          "column": 506
+          "line": 9,
+          "column": 538
         },
         {
           "value": "2",
-          "line": 7,
-          "column": 512
+          "line": 9,
+          "column": 544
         },
         {
           "value": "2",
-          "line": 7,
-          "column": 606
+          "line": 9,
+          "column": 638
         },
         {
           "value": "2",
-          "line": 7,
-          "column": 612
+          "line": 9,
+          "column": 644
         },
         {
           "value": "2",
-          "line": 7,
-          "column": 668
+          "line": 9,
+          "column": 700
         }
       ]
     },
@@ -3763,32 +3763,32 @@
       "examples": [
         {
           "value": "95",
-          "line": 7,
+          "line": 12,
           "column": 45
         },
         {
           "value": "70",
-          "line": 7,
+          "line": 12,
           "column": 49
         },
         {
           "value": "96",
-          "line": 7,
+          "line": 12,
           "column": 53
         },
         {
           "value": "0.18",
-          "line": 7,
+          "line": 12,
           "column": 57
         },
         {
           "value": "50%",
-          "line": 15,
+          "line": 20,
           "column": 44
         },
         {
           "value": "999px",
-          "line": 15,
+          "line": 20,
           "column": 226
         }
       ]
@@ -3823,7 +3823,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 31,
+          "line": 26,
           "column": 110
         }
       ]
@@ -3838,7 +3838,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 43,
+          "line": 44,
           "column": 56
         }
       ]
@@ -3853,32 +3853,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 54,
+          "line": 40,
           "column": 62
         },
         {
           "value": "0.82",
-          "line": 63,
+          "line": 49,
           "column": 22
         },
         {
           "value": "4",
-          "line": 64,
+          "line": 50,
           "column": 21
         },
         {
           "value": "1",
-          "line": 78,
+          "line": 64,
           "column": 53
         },
         {
           "value": "2",
-          "line": 84,
+          "line": 70,
           "column": 38
         },
         {
           "value": "1",
-          "line": 88,
+          "line": 74,
           "column": 46
         }
       ]
@@ -3893,7 +3893,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 80,
+          "line": 71,
           "column": 23
         }
       ]

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -72,7 +72,7 @@ describe('worker source quality gates', () => {
       {
         file: 'deploy/api-worker-shell/services/reviews.ts',
         limits: {
-          supabaseRequest: 23,
+          supabaseRequest: 0,
         },
       },
       {
@@ -227,13 +227,16 @@ describe('worker source quality gates', () => {
   it('keeps review interaction persistence behind the review repository boundary', () => {
     const interactionSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/review-interactions.ts'), 'utf8');
     const repositorySource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/review-domain/repository.ts'), 'utf8');
+    const readRepositorySource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/review-domain/read-repository.ts'), 'utf8');
     const reviewReadSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/reviews.ts'), 'utf8');
 
     expect(interactionSource).not.toContain('supabaseRequest');
     expect(interactionSource).not.toContain('feed?select=');
     expect(reviewReadSource).toContain("import { createReviewMapper } from './review-domain/mapper';");
+    expect(reviewReadSource).not.toContain('supabaseRequest');
     expect(reviewReadSource).not.toContain('function mapReviewRows');
     expect(repositorySource).toContain('supabaseRequest');
+    expect(readRepositorySource).toContain('supabaseRequest');
   });
 
   it('keeps account, community, and admin service persistence behind domain repositories', () => {


### PR DESCRIPTION
## Scope

- Scope-ID: TSK-005-03
- Parent Issue: #286
- Child Issue: #289
- Branch: worker-persistence-boundary-gates
- Target release candidate: 1.2.11

## Summary

Moves Worker review read Supabase REST queries out of `services/reviews.ts` and into a review-domain read repository. This is the first persistence-boundary slice for #289; stamp and notification persistence boundaries remain open in the same child issue.

## Changes

- Adds `review-domain/read-repository.ts` for review feed/page/detail query functions.
- Removes direct `supabaseRequest`, `buildInFilter`, and `encodeFilterValue` usage from `services/reviews.ts`.
- Lowers the Worker source-quality gate for `services/reviews.ts` direct `supabaseRequest` count from 23 to 0.
- Updates numeric literal baseline after moving query literals out of the service file.

## Validation

- `npx.cmd vitest run test/unit/worker-source-quality.test.ts test/unit/worker-review-domain.test.ts test/unit/worker-bootstrap-shape.test.ts test/unit/worker-routing-runtime.test.ts`
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`

## Remaining in #289

- Stamp service direct persistence boundary.
- Notification service direct persistence/realtime publisher boundary.

Refs #289.