### PR TITLE
Refactor Worker stamp persistence boundary

### DIFF
--- a/deploy/api-worker-shell/services/stamp-domain/repository.ts
+++ b/deploy/api-worker-shell/services/stamp-domain/repository.ts
@@ -1,0 +1,113 @@
+import { encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+
+export interface WorkerStampRow extends WorkerJsonRecord {
+  stamp_id: string | number;
+  travel_session_id?: string | number | null;
+}
+
+export interface WorkerLastStampRow extends WorkerStampRow {
+  created_at: string;
+}
+
+export interface WorkerTravelSessionRow extends WorkerJsonRecord {
+  travel_session_id: string | number;
+  stamp_count?: string | number | null;
+}
+
+export async function readTodayStampRow(
+  env: WorkerEnv,
+  userId: string,
+  positionId: string,
+  stampDate: string,
+): Promise<WorkerStampRow | null> {
+  const rows = await supabaseRequest<WorkerStampRow[]>(
+    env,
+    `user_stamp?select=stamp_id&user_id=eq.${encodeFilterValue(userId)}&position_id=eq.${encodeFilterValue(
+      positionId,
+    )}&stamp_date=eq.${encodeFilterValue(stampDate)}&limit=1`,
+  );
+
+  return rows?.[0] ?? null;
+}
+
+export async function readPlaceStampRows(env: WorkerEnv, userId: string, positionId: string): Promise<WorkerStampRow[]> {
+  return (
+    (await supabaseRequest<WorkerStampRow[]>(
+      env,
+      `user_stamp?select=stamp_id&user_id=eq.${encodeFilterValue(userId)}&position_id=eq.${encodeFilterValue(
+        positionId,
+      )}`,
+    )) ?? []
+  );
+}
+
+export async function readLastStampRow(env: WorkerEnv, userId: string): Promise<WorkerLastStampRow | null> {
+  const rows = await supabaseRequest<WorkerLastStampRow[]>(
+    env,
+    `user_stamp?select=stamp_id,travel_session_id,created_at&user_id=eq.${encodeFilterValue(
+      userId,
+    )}&order=created_at.desc&limit=1`,
+  );
+
+  return rows?.[0] ?? null;
+}
+
+export async function readTravelSessionRow(
+  env: WorkerEnv,
+  travelSessionId: number,
+): Promise<WorkerTravelSessionRow | null> {
+  const rows = await supabaseRequest<WorkerTravelSessionRow[]>(
+    env,
+    `travel_session?select=stamp_count&travel_session_id=eq.${encodeFilterValue(String(travelSessionId))}&limit=1`,
+  );
+
+  return rows?.[0] ?? null;
+}
+
+export async function createTravelSession(
+  env: WorkerEnv,
+  payload: WorkerJsonRecord,
+): Promise<WorkerTravelSessionRow | null> {
+  const rows = await supabaseRequest<WorkerTravelSessionRow[]>(env, 'travel_session?select=travel_session_id', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+
+  return rows?.[0] ?? null;
+}
+
+export async function updateTravelSession(
+  env: WorkerEnv,
+  travelSessionId: number,
+  payload: WorkerJsonRecord,
+): Promise<void> {
+  await supabaseRequest(
+    env,
+    `travel_session?travel_session_id=eq.${encodeFilterValue(String(travelSessionId))}`,
+    {
+      method: 'PATCH',
+      body: JSON.stringify(payload),
+    },
+  );
+}
+
+export async function updateStampTravelSession(
+  env: WorkerEnv,
+  stampId: string | number,
+  travelSessionId: number,
+): Promise<void> {
+  await supabaseRequest(env, `user_stamp?stamp_id=eq.${encodeFilterValue(String(stampId))}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ travel_session_id: travelSessionId }),
+  });
+}
+
+export async function createUserStamp(env: WorkerEnv, payload: WorkerJsonRecord): Promise<WorkerStampRow | null> {
+  const rows = await supabaseRequest<WorkerStampRow[]>(env, 'user_stamp?select=stamp_id', {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  });
+
+  return rows?.[0] ?? null;
+}

--- a/deploy/api-worker-shell/services/stamps.ts
+++ b/deploy/api-worker-shell/services/stamps.ts
@@ -1,55 +1,188 @@
+import { WorkerStampRuntimeConfig } from '../config/runtime';
 import { toSeoulDateKey } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
-import { encodeFilterValue, supabaseRequest } from '../lib/supabase';
-import { WorkerStampRuntimeConfig } from '../config/runtime';
-import { readSessionUser } from './auth';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
+import { readSessionUser } from './auth';
 import type { WorkerStampServiceDeps } from './stamp-domain/contracts';
-function getStampUnlockRadius(env: WorkerEnv) { const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters); return Number.isFinite(parsed) && parsed > 0 ? parsed : WorkerStampRuntimeConfig.defaultUnlockRadiusMeters; }
-function calculateDistanceMeters(startLatitude: number, startLongitude: number, endLatitude: number, endLongitude: number) { const latitudeDelta = (endLatitude - startLatitude) * WorkerStampRuntimeConfig.radiansPerDegree; const longitudeDelta = (endLongitude - startLongitude) * WorkerStampRuntimeConfig.radiansPerDegree; const startLatitudeRadians = startLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const endLatitudeRadians = endLatitude * WorkerStampRuntimeConfig.radiansPerDegree; const haversine = Math.sin(latitudeDelta / 2) ** 2 + Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2; return WorkerStampRuntimeConfig.earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine))); }
-function formatDistanceMeters(distanceMeters: number) { if (!Number.isFinite(distanceMeters)) {
-    return '알 수 없음';
-} if (distanceMeters >= WorkerStampRuntimeConfig.metersPerKilometer) {
-    return `${(distanceMeters / WorkerStampRuntimeConfig.metersPerKilometer).toFixed(1)}km`;
-} return `${Math.round(distanceMeters)}m`; }
-function buildNearPlaceMessage(placeName: string, distanceMeters: number, unlockRadius: number) { return `${placeName}까지 ${formatDistanceMeters(distanceMeters)} 남아있어요. 반경 ${unlockRadius}m 안에 들어오면 열려요.`; }
-async function requireSessionUser(request: Request, env: WorkerEnv) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
-    return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
-} return { sessionUser }; }
-async function readJsonBody(request: Request): Promise<WorkerJsonRecord> { try {
-    return await request.json() as WorkerJsonRecord;
-}
-catch {
-    throw new Error('요청 형식이 올바르지 않아요.');
-} }
-export function createStampService({ loadBaseData }: WorkerStampServiceDeps) { async function handleToggleStamp(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const payload = await readJsonBody(request); const placeId = String(payload.placeId ?? '').trim(); const latitude = Number(payload.latitude); const longitude = Number(payload.longitude); if (!placeId || !Number.isFinite(latitude) || !Number.isFinite(longitude)) {
-    return jsonResponse(400, { detail: '장소와 현재 좌표가 필요해요.' }, env, request);
-} const baseData = await loadBaseData(env, sessionResult.sessionUser.id); const place = baseData.places.find((item) => item.id === placeId); if (!place) {
-    return jsonResponse(404, { detail: '장소를 찾지 못했어요.' }, env, request);
-} const distanceMeters = calculateDistanceMeters(latitude, longitude, place.latitude, place.longitude); const unlockRadius = getStampUnlockRadius(env); if (distanceMeters > unlockRadius) {
-    return jsonResponse(403, { detail: buildNearPlaceMessage(place.name, distanceMeters, unlockRadius) }, env, request);
-} const stampDate = toSeoulDateKey(); const existingTodayRows = await supabaseRequest(env, `user_stamp?select=stamp_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&position_id=eq.${encodeFilterValue(place.positionId)}&stamp_date=eq.${encodeFilterValue(stampDate)}&limit=1`); if (existingTodayRows?.[0]) {
-    const nextBaseData = await loadBaseData(env, sessionResult.sessionUser.id);
-    return jsonResponse(200, { collectedPlaceIds: nextBaseData.collectedPlaceIds, logs: nextBaseData.stampLogs, travelSessions: nextBaseData.travelSessions, }, env, request);
-} const nowIso = new Date().toISOString(); const placeStampRows = await supabaseRequest(env, `user_stamp?select=stamp_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&position_id=eq.${encodeFilterValue(place.positionId)}`); const visitOrdinal = (placeStampRows?.length ?? 0) + 1; const lastStampRows = await supabaseRequest(env, `user_stamp?select=stamp_id,travel_session_id,created_at&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&order=created_at.desc&limit=1`); const lastStampRow = lastStampRows?.[0] ?? null; let travelSessionId = null; if (lastStampRow) {
-    const gapMs = new Date(nowIso).getTime() - new Date(lastStampRow.created_at).getTime();
-    if (gapMs <= WorkerStampRuntimeConfig.travelSessionGapMs) {
-        if (lastStampRow.travel_session_id) {
-            travelSessionId = Number(lastStampRow.travel_session_id);
-            const sessionRows = await supabaseRequest(env, `travel_session?select=stamp_count&travel_session_id=eq.${encodeFilterValue(travelSessionId)}&limit=1`);
-            const sessionRow = sessionRows?.[0] ?? null;
-            await supabaseRequest(env, `travel_session?travel_session_id=eq.${encodeFilterValue(travelSessionId)}`, { method: 'PATCH', body: JSON.stringify({ ended_at: nowIso, last_stamp_at: nowIso, stamp_count: Number(sessionRow?.stamp_count ?? 0) + 1, updated_at: nowIso, }), });
-        }
-        else {
-            const createdSessions = await supabaseRequest(env, 'travel_session?select=travel_session_id', { method: 'POST', body: JSON.stringify({ user_id: sessionResult.sessionUser.id, started_at: lastStampRow.created_at, ended_at: nowIso, last_stamp_at: nowIso, stamp_count: 2, created_at: nowIso, updated_at: nowIso, }), });
-            travelSessionId = Number(createdSessions?.[0]?.travel_session_id);
-            await supabaseRequest(env, `user_stamp?stamp_id=eq.${encodeFilterValue(lastStampRow.stamp_id)}`, { method: 'PATCH', body: JSON.stringify({ travel_session_id: travelSessionId }), });
-        }
-    }
-} if (!travelSessionId) {
-    const createdSessions = await supabaseRequest(env, 'travel_session?select=travel_session_id', { method: 'POST', body: JSON.stringify({ user_id: sessionResult.sessionUser.id, started_at: nowIso, ended_at: nowIso, last_stamp_at: nowIso, stamp_count: 1, created_at: nowIso, updated_at: nowIso, }), });
-    travelSessionId = Number(createdSessions?.[0]?.travel_session_id);
-} await supabaseRequest(env, 'user_stamp?select=stamp_id', { method: 'POST', body: JSON.stringify({ user_id: sessionResult.sessionUser.id, position_id: Number(place.positionId), travel_session_id: travelSessionId, stamp_date: stampDate, visit_ordinal: visitOrdinal, created_at: nowIso, }), }); const nextBaseData = await loadBaseData(env, sessionResult.sessionUser.id); return jsonResponse(200, { collectedPlaceIds: nextBaseData.collectedPlaceIds, logs: nextBaseData.stampLogs, travelSessions: nextBaseData.travelSessions, }, env, request); } return { handleToggleStamp, }; }
+import {
+  createTravelSession,
+  createUserStamp,
+  readLastStampRow,
+  readPlaceStampRows,
+  readTodayStampRow,
+  readTravelSessionRow,
+  updateStampTravelSession,
+  updateTravelSession,
+} from './stamp-domain/repository';
 
+function getStampUnlockRadius(env: WorkerEnv) {
+  const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : WorkerStampRuntimeConfig.defaultUnlockRadiusMeters;
+}
+
+function calculateDistanceMeters(
+  startLatitude: number,
+  startLongitude: number,
+  endLatitude: number,
+  endLongitude: number,
+) {
+  const latitudeDelta = (endLatitude - startLatitude) * WorkerStampRuntimeConfig.radiansPerDegree;
+  const longitudeDelta = (endLongitude - startLongitude) * WorkerStampRuntimeConfig.radiansPerDegree;
+  const startLatitudeRadians = startLatitude * WorkerStampRuntimeConfig.radiansPerDegree;
+  const endLatitudeRadians = endLatitude * WorkerStampRuntimeConfig.radiansPerDegree;
+  const haversine =
+    Math.sin(latitudeDelta / 2) ** 2 +
+    Math.cos(startLatitudeRadians) * Math.cos(endLatitudeRadians) * Math.sin(longitudeDelta / 2) ** 2;
+  return WorkerStampRuntimeConfig.earthRadiusMeters * (2 * Math.asin(Math.sqrt(haversine)));
+}
+
+function formatDistanceMeters(distanceMeters: number) {
+  if (!Number.isFinite(distanceMeters)) {
+    return '알 수 없음';
+  }
+  if (distanceMeters >= WorkerStampRuntimeConfig.metersPerKilometer) {
+    return `${(distanceMeters / WorkerStampRuntimeConfig.metersPerKilometer).toFixed(1)}km`;
+  }
+  return `${Math.round(distanceMeters)}m`;
+}
+
+function buildNearPlaceMessage(placeName: string, distanceMeters: number, unlockRadius: number) {
+  return `${placeName}까지 ${formatDistanceMeters(distanceMeters)} 남아있어요. 반경 ${unlockRadius}m 안에 들어오면 열려요.`;
+}
+
+async function requireSessionUser(request: Request, env: WorkerEnv) {
+  const sessionUser = await readSessionUser(request, env);
+  if (!sessionUser) {
+    return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
+  }
+  return { sessionUser };
+}
+
+async function readJsonBody(request: Request): Promise<WorkerJsonRecord> {
+  try {
+    return (await request.json()) as WorkerJsonRecord;
+  } catch {
+    throw new Error('요청 형식이 올바르지 않아요.');
+  }
+}
+
+export function createStampService({ loadBaseData }: WorkerStampServiceDeps) {
+  async function handleToggleStamp(request: Request, env: WorkerEnv) {
+    const sessionResult = await requireSessionUser(request, env);
+    if (sessionResult.response) {
+      return sessionResult.response;
+    }
+
+    const payload = await readJsonBody(request);
+    const placeId = String(payload.placeId ?? '').trim();
+    const latitude = Number(payload.latitude);
+    const longitude = Number(payload.longitude);
+
+    if (!placeId || !Number.isFinite(latitude) || !Number.isFinite(longitude)) {
+      return jsonResponse(400, { detail: '장소와 현재 좌표가 필요해요.' }, env, request);
+    }
+
+    const baseData = await loadBaseData(env, sessionResult.sessionUser.id);
+    const place = baseData.places.find((item) => item.id === placeId);
+
+    if (!place) {
+      return jsonResponse(404, { detail: '장소를 찾지 못했어요.' }, env, request);
+    }
+
+    const distanceMeters = calculateDistanceMeters(latitude, longitude, place.latitude, place.longitude);
+    const unlockRadius = getStampUnlockRadius(env);
+
+    if (distanceMeters > unlockRadius) {
+      return jsonResponse(403, { detail: buildNearPlaceMessage(place.name, distanceMeters, unlockRadius) }, env, request);
+    }
+
+    const stampDate = toSeoulDateKey();
+    const existingTodayRow = await readTodayStampRow(env, sessionResult.sessionUser.id, place.positionId, stampDate);
+
+    if (existingTodayRow) {
+      const nextBaseData = await loadBaseData(env, sessionResult.sessionUser.id);
+      return jsonResponse(
+        200,
+        {
+          collectedPlaceIds: nextBaseData.collectedPlaceIds,
+          logs: nextBaseData.stampLogs,
+          travelSessions: nextBaseData.travelSessions,
+        },
+        env,
+        request,
+      );
+    }
+
+    const nowIso = new Date().toISOString();
+    const placeStampRows = await readPlaceStampRows(env, sessionResult.sessionUser.id, place.positionId);
+    const visitOrdinal = placeStampRows.length + 1;
+    const lastStampRow = await readLastStampRow(env, sessionResult.sessionUser.id);
+    let travelSessionId: number | null = null;
+
+    if (lastStampRow) {
+      const gapMs = new Date(nowIso).getTime() - new Date(lastStampRow.created_at).getTime();
+      if (gapMs <= WorkerStampRuntimeConfig.travelSessionGapMs) {
+        if (lastStampRow.travel_session_id) {
+          travelSessionId = Number(lastStampRow.travel_session_id);
+          const sessionRow = await readTravelSessionRow(env, travelSessionId);
+          await updateTravelSession(env, travelSessionId, {
+            ended_at: nowIso,
+            last_stamp_at: nowIso,
+            stamp_count: Number(sessionRow?.stamp_count ?? 0) + 1,
+            updated_at: nowIso,
+          });
+        } else {
+          const createdSession = await createTravelSession(env, {
+            user_id: sessionResult.sessionUser.id,
+            started_at: lastStampRow.created_at,
+            ended_at: nowIso,
+            last_stamp_at: nowIso,
+            stamp_count: 2,
+            created_at: nowIso,
+            updated_at: nowIso,
+          });
+
+          travelSessionId = Number(createdSession?.travel_session_id);
+          await updateStampTravelSession(env, lastStampRow.stamp_id, travelSessionId);
+        }
+      }
+    }
+
+    if (!travelSessionId) {
+      const createdSession = await createTravelSession(env, {
+        user_id: sessionResult.sessionUser.id,
+        started_at: nowIso,
+        ended_at: nowIso,
+        last_stamp_at: nowIso,
+        stamp_count: 1,
+        created_at: nowIso,
+        updated_at: nowIso,
+      });
+
+      travelSessionId = Number(createdSession?.travel_session_id);
+    }
+
+    await createUserStamp(env, {
+      user_id: sessionResult.sessionUser.id,
+      position_id: Number(place.positionId),
+      travel_session_id: travelSessionId,
+      stamp_date: stampDate,
+      visit_ordinal: visitOrdinal,
+      created_at: nowIso,
+    });
+
+    const nextBaseData = await loadBaseData(env, sessionResult.sessionUser.id);
+    return jsonResponse(
+      200,
+      {
+        collectedPlaceIds: nextBaseData.collectedPlaceIds,
+        logs: nextBaseData.stampLogs,
+        travelSessions: nextBaseData.travelSessions,
+      },
+      env,
+      request,
+    );
+  }
+
+  return { handleToggleStamp };
+}

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "fc6e8b81f02e1409202c6c03fc5d377fb5503abf",
+  "generatedFrom": "bbbc572f6fd6c6869d5ba2b810d82d452e458aad",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -2094,6 +2094,41 @@
       ]
     },
     {
+      "path": "deploy/api-worker-shell/services/review-domain/read-repository.ts",
+      "count": 5,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 45,
+          "column": 22
+        },
+        {
+          "value": "1",
+          "line": 57,
+          "column": 140
+        },
+        {
+          "value": "0",
+          "line": 59,
+          "column": 17
+        },
+        {
+          "value": "0",
+          "line": 98,
+          "column": 36
+        },
+        {
+          "value": "1",
+          "line": 111,
+          "column": 268
+        }
+      ]
+    },
+    {
       "path": "deploy/api-worker-shell/services/review-domain/repository.ts",
       "count": 10,
       "owner": "worker-backend",
@@ -2215,7 +2250,7 @@
     },
     {
       "path": "deploy/api-worker-shell/services/stamps.ts",
-      "count": 27,
+      "count": 18,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -2223,33 +2258,33 @@
       "examples": [
         {
           "value": "0",
-          "line": 8,
-          "column": 205
+          "line": 20,
+          "column": 46
         },
         {
           "value": "2",
-          "line": 9,
-          "column": 538
+          "line": 34,
+          "column": 30
         },
         {
           "value": "2",
-          "line": 9,
-          "column": 544
+          "line": 34,
+          "column": 36
         },
         {
           "value": "2",
-          "line": 9,
-          "column": 638
+          "line": 35,
+          "column": 95
         },
         {
           "value": "2",
-          "line": 9,
-          "column": 644
+          "line": 35,
+          "column": 101
         },
         {
           "value": "2",
-          "line": 9,
-          "column": 700
+          "line": 36,
+          "column": 56
         }
       ]
     },

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -86,7 +86,7 @@ describe('worker source quality gates', () => {
       {
         file: 'deploy/api-worker-shell/services/stamps.ts',
         limits: {
-          supabaseRequest: 10,
+          supabaseRequest: 0,
           implicitRequestBodyReaders: 0,
           implicitEnvSignatures: 0,
         },
@@ -237,6 +237,21 @@ describe('worker source quality gates', () => {
     expect(reviewReadSource).not.toContain('function mapReviewRows');
     expect(repositorySource).toContain('supabaseRequest');
     expect(readRepositorySource).toContain('supabaseRequest');
+  });
+
+  it('keeps stamp persistence behind the stamp repository boundary', () => {
+    const serviceSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/stamps.ts'), 'utf8');
+    const repositorySource = readFileSync(
+      join(workspaceRoot, 'deploy/api-worker-shell/services/stamp-domain/repository.ts'),
+      'utf8',
+    );
+
+    expect(serviceSource).not.toContain('supabaseRequest');
+    expect(serviceSource).not.toContain('user_stamp?select=');
+    expect(serviceSource).not.toContain('travel_session?select=');
+    expect(repositorySource).toContain('supabaseRequest');
+    expect(repositorySource).toContain('user_stamp?select=');
+    expect(repositorySource).toContain('travel_session?select=');
   });
 
   it('keeps account, community, and admin service persistence behind domain repositories', () => {

--- a/test/unit/worker-stamp-service.test.ts
+++ b/test/unit/worker-stamp-service.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { WorkerBaseData, WorkerPlace } from '../../deploy/api-worker-shell/runtime/base-data-contracts';
+import { issueSessionCookie } from '../../deploy/api-worker-shell/services/auth/session';
+import { createStampService } from '../../deploy/api-worker-shell/services/stamps';
+import type { WorkerEnv, WorkerSessionUser } from '../../deploy/api-worker-shell/types';
+
+const env: WorkerEnv = {
+  APP_CORS_ORIGINS: 'http://localhost',
+  APP_FRONTEND_URL: 'http://localhost',
+  APP_SESSION_HTTPS: 'false',
+  APP_SESSION_SECRET: 'test-session-secret',
+  APP_STAMP_UNLOCK_RADIUS_METERS: '100',
+  APP_SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  APP_SUPABASE_URL: 'https://supabase.test',
+};
+
+const sessionUser: WorkerSessionUser = {
+  id: 'user-1',
+  nickname: 'tester',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+};
+
+const place: WorkerPlace = {
+  id: 'place-1',
+  positionId: '101',
+  name: 'Place 1',
+  district: 'Daejeon',
+  category: 'cafe',
+  jamColor: '#ff66aa',
+  accentColor: '#ffccdd',
+  imageUrl: null,
+  latitude: 36.35,
+  longitude: 127.38,
+  summary: null,
+  description: null,
+  vibeTags: [],
+  visitTime: null,
+  routeHint: null,
+  stampReward: null,
+  heroLabel: null,
+  totalVisitCount: 0,
+};
+
+function buildBaseData(): WorkerBaseData {
+  return {
+    places: [place],
+    placesByPositionId: new Map([[place.positionId, place]]),
+    reviews: [],
+    courses: [],
+    collectedPlaceIds: [place.id],
+    stampLogs: [{ id: 'stamp-1', placeId: place.id }],
+    travelSessions: [{ id: 'session-1', placeIds: [place.id] }],
+  };
+}
+
+async function createAuthedRequest(payload: Record<string, unknown>) {
+  const baseRequest = new Request('http://localhost/api/stamps/toggle', { method: 'POST' });
+  const cookie = await issueSessionCookie(sessionUser, baseRequest, env);
+
+  return new Request('http://localhost/api/stamps/toggle', {
+    method: 'POST',
+    headers: {
+      cookie,
+      'content-type': 'application/json',
+    },
+    body: JSON.stringify(payload),
+  });
+}
+
+function stubSupabaseRows(rowsByCall: unknown[][]) {
+  const calls: Array<{ init?: RequestInit; url: string }> = [];
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async (input, init) => {
+    calls.push({ init, url: String(input) });
+    const rows = rowsByCall.shift() ?? [];
+
+    return new Response(JSON.stringify(rows), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    });
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return { calls, fetchMock };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('worker stamp service', () => {
+  it('returns duplicate stamp state without writing new persistence rows', async () => {
+    const { calls } = stubSupabaseRows([[{ stamp_id: 1 }]]);
+    const loadBaseData = vi.fn(async () => buildBaseData());
+    const service = createStampService({ loadBaseData });
+
+    const response = await service.handleToggleStamp(
+      await createAuthedRequest({ latitude: place.latitude, longitude: place.longitude, placeId: place.id }),
+      env,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ collectedPlaceIds: [place.id], logs: [{ placeId: place.id }] });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].url).toContain('user_stamp?select=stamp_id');
+    expect(calls.some((call) => call.init?.method === 'POST')).toBe(false);
+  });
+
+  it('rejects out-of-radius stamp claims before persistence access', async () => {
+    const { calls } = stubSupabaseRows([]);
+    const loadBaseData = vi.fn(async () => buildBaseData());
+    const service = createStampService({ loadBaseData });
+
+    const response = await service.handleToggleStamp(
+      await createAuthedRequest({ latitude: 37.5, longitude: 127.38, placeId: place.id }),
+      env,
+    );
+
+    expect(response.status).toBe(403);
+    expect(calls).toEqual([]);
+  });
+
+  it('creates travel session and stamp rows for successful first claims', async () => {
+    const { calls } = stubSupabaseRows([[], [], [], [{ travel_session_id: 7 }], [{ stamp_id: 11 }]]);
+    const loadBaseData = vi.fn(async () => buildBaseData());
+    const service = createStampService({ loadBaseData });
+
+    const response = await service.handleToggleStamp(
+      await createAuthedRequest({ latitude: place.latitude, longitude: place.longitude, placeId: place.id }),
+      env,
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toMatchObject({ collectedPlaceIds: [place.id], logs: [{ placeId: place.id }] });
+    expect(calls.map((call) => [call.init?.method ?? 'GET', new URL(call.url).pathname])).toEqual([
+      ['GET', '/rest/v1/user_stamp'],
+      ['GET', '/rest/v1/user_stamp'],
+      ['GET', '/rest/v1/user_stamp'],
+      ['POST', '/rest/v1/travel_session'],
+      ['POST', '/rest/v1/user_stamp'],
+    ]);
+    expect(JSON.parse(String(calls.at(-1)?.init?.body))).toMatchObject({
+      position_id: Number(place.positionId),
+      travel_session_id: 7,
+      user_id: sessionUser.id,
+    });
+  });
+});


### PR DESCRIPTION
## 요약

- Closes #296
- Worker stamp service의 `user_stamp` / `travel_session` 직접 persistence를 `stamp-domain/repository.ts`로 이동했습니다.
- `stamps.ts`의 직접 `supabaseRequest` 사용을 `10 -> 0`으로 낮추고 source-quality gate로 회귀를 차단했습니다.
- duplicate, out-of-radius, success stamp claim 경로를 단위 테스트로 고정했습니다.

## 검증

- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`

## 비변경 범위

- 외부 API path / response shape 변경 없음
- DB schema 변경 없음
- OAuth 성공 경로 변경 없음
- 사용자-facing copy는 기존 문구를 유지했습니다.
