### PR TITLE
Refactor Worker notification persistence boundary

### DIFF
--- a/deploy/api-worker-shell/services/notification-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/notification-domain/contracts.ts
@@ -1,0 +1,36 @@
+import type { WorkerJsonRecord } from '../../types';
+
+export interface WorkerNotificationRow extends WorkerJsonRecord {
+  notification_id: string | number;
+  user_id: string;
+  actor_user_id?: string | null;
+  type: string;
+  title: string;
+  body?: string | null;
+  review_id?: string | number | null;
+  comment_id?: string | number | null;
+  route_id?: string | number | null;
+  is_read?: boolean | null;
+  created_at: string;
+}
+
+export interface WorkerNotificationActorRow extends WorkerJsonRecord {
+  user_id: string;
+  nickname?: string | null;
+}
+
+export interface WorkerNotificationInsertResult extends WorkerJsonRecord {
+  notification_id?: string | number | null;
+}
+
+export interface WorkerNotificationCreatePayload extends WorkerJsonRecord {
+  userId: string;
+  actorUserId?: string | null;
+  type: string;
+  title: string;
+  body?: string;
+  reviewId?: string | number | null;
+  commentId?: string | number | null;
+  routeId?: string | number | null;
+  metadata?: WorkerJsonRecord;
+}

--- a/deploy/api-worker-shell/services/notification-domain/publisher.ts
+++ b/deploy/api-worker-shell/services/notification-domain/publisher.ts
@@ -1,0 +1,46 @@
+import { getSupabaseKey } from '../../lib/supabase';
+import type { WorkerEnv, WorkerJsonRecord } from '../../types';
+import { getSigningSecret, sha256Base64Url } from '../auth';
+
+export async function buildNotificationRealtimeTopic(env: WorkerEnv, userId: string) {
+  const secret = getSigningSecret(env);
+  if (!secret) {
+    throw new Error('Notification realtime secret is missing.');
+  }
+  const signature = await sha256Base64Url(`${userId}:${secret}:notifications`);
+  return `user-notifications:${userId}:${signature}`;
+}
+
+export async function sendRealtimeBroadcast(
+  env: WorkerEnv,
+  topic: string,
+  event: string,
+  payload: WorkerJsonRecord,
+) {
+  if (!env.APP_SUPABASE_URL) {
+    return;
+  }
+  const apiKey = getSupabaseKey(env);
+  if (!apiKey) {
+    return;
+  }
+
+  await fetch(`${env.APP_SUPABASE_URL}/realtime/v1/api/broadcast`, {
+    method: 'POST',
+    headers: {
+      apikey: apiKey,
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      messages: [
+        {
+          topic,
+          event,
+          payload,
+          private: false,
+        },
+      ],
+    }),
+  });
+}

--- a/deploy/api-worker-shell/services/notification-domain/repository.ts
+++ b/deploy/api-worker-shell/services/notification-domain/repository.ts
@@ -1,0 +1,103 @@
+import { buildInFilter, encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv } from '../../types';
+import type {
+  WorkerNotificationActorRow,
+  WorkerNotificationCreatePayload,
+  WorkerNotificationInsertResult,
+  WorkerNotificationRow,
+} from './contracts';
+
+const notificationSelect =
+  'notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at';
+
+export async function readNotificationRow(env: WorkerEnv, notificationId: string | number) {
+  const rows = await supabaseRequest<WorkerNotificationRow[]>(
+    env,
+    `user_notification?select=${notificationSelect}&notification_id=eq.${encodeFilterValue(notificationId)}&limit=1`,
+  );
+
+  return rows?.[0] ?? null;
+}
+
+export async function createNotification(env: WorkerEnv, payload: WorkerNotificationCreatePayload) {
+  const nowIso = new Date().toISOString();
+  const rows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, 'user_notification?select=notification_id', {
+    method: 'POST',
+    body: JSON.stringify({
+      user_id: payload.userId,
+      actor_user_id: payload.actorUserId ?? null,
+      type: payload.type,
+      title: payload.title,
+      body: payload.body ?? '',
+      review_id: payload.reviewId ? Number(payload.reviewId) : null,
+      comment_id: payload.commentId ? Number(payload.commentId) : null,
+      route_id: payload.routeId ? Number(payload.routeId) : null,
+      metadata: payload.metadata ?? {},
+      is_read: false,
+      created_at: nowIso,
+      updated_at: nowIso,
+    }),
+  });
+
+  return rows?.[0] ?? null;
+}
+
+export async function readUserNotificationRows(env: WorkerEnv, userId: string, limit: number) {
+  return (
+    (await supabaseRequest<WorkerNotificationRow[]>(
+      env,
+      `user_notification?select=${notificationSelect}&user_id=eq.${encodeFilterValue(
+        userId,
+      )}&order=created_at.desc&limit=${limit}`,
+    )) ?? []
+  );
+}
+
+export async function readNotificationActorRows(env: WorkerEnv, actorUserIds: Array<string | null | undefined>) {
+  const actorIdsFilter = buildInFilter(actorUserIds.filter(Boolean));
+  return actorIdsFilter
+    ? ((await supabaseRequest<WorkerNotificationActorRow[]>(
+        env,
+        `user?select=user_id,nickname&user_id=${actorIdsFilter}`,
+      )) ?? [])
+    : [];
+}
+
+export async function readNotificationActorRow(env: WorkerEnv, actorUserId: string) {
+  const rows = await supabaseRequest<WorkerNotificationActorRow[]>(
+    env,
+    `user?select=user_id,nickname&user_id=eq.${encodeFilterValue(actorUserId)}&limit=1`,
+  );
+
+  return rows?.[0] ?? null;
+}
+
+export async function readUnreadNotificationRows(env: WorkerEnv, userId: string) {
+  return (
+    (await supabaseRequest<WorkerNotificationInsertResult[]>(
+      env,
+      `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`,
+    )) ?? []
+  );
+}
+
+export async function markNotificationRead(env: WorkerEnv, notificationId: string | number, nowIso: string) {
+  await supabaseRequest(env, `user_notification?notification_id=eq.${encodeFilterValue(notificationId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso }),
+  });
+}
+
+export async function markAllNotificationsRead(env: WorkerEnv, userId: string, nowIso: string) {
+  await supabaseRequest(env, `user_notification?user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`, {
+    method: 'PATCH',
+    body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso }),
+  });
+}
+
+export async function deleteNotificationRow(env: WorkerEnv, notificationId: string | number) {
+  await supabaseRequest(env, `user_notification?notification_id=eq.${encodeFilterValue(notificationId)}`, {
+    method: 'DELETE',
+    headers: { Prefer: 'return=minimal' },
+  });
+}

--- a/deploy/api-worker-shell/services/notifications.ts
+++ b/deploy/api-worker-shell/services/notifications.ts
@@ -1,98 +1,190 @@
+import { WorkerNotificationRuntimeConfig } from '../config/runtime';
 import { formatDateTime } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
-import { buildInFilter, encodeFilterValue, getSupabaseKey, supabaseRequest } from '../lib/supabase';
-import { WorkerNotificationRuntimeConfig } from '../config/runtime';
-import { getSigningSecret, readSessionUser, sha256Base64Url } from './auth';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
+import { readSessionUser } from './auth';
+import type {
+  WorkerNotificationCreatePayload,
+  WorkerNotificationInsertResult,
+  WorkerNotificationRow,
+} from './notification-domain/contracts';
+import { buildNotificationRealtimeTopic, sendRealtimeBroadcast } from './notification-domain/publisher';
+import {
+  createNotification,
+  deleteNotificationRow,
+  markAllNotificationsRead,
+  markNotificationRead,
+  readNotificationActorRow,
+  readNotificationActorRows,
+  readNotificationRow,
+  readUnreadNotificationRows,
+  readUserNotificationRows,
+} from './notification-domain/repository';
 
-interface WorkerNotificationRow extends WorkerJsonRecord {
-    notification_id: string | number;
-    user_id: string;
-    actor_user_id?: string | null;
-    type: string;
-    title: string;
-    body?: string | null;
-    review_id?: string | number | null;
-    comment_id?: string | number | null;
-    route_id?: string | number | null;
-    is_read?: boolean | null;
-    created_at: string;
-}
-
-interface WorkerNotificationActorRow extends WorkerJsonRecord {
-    user_id: string;
-    nickname?: string | null;
-}
-
-interface WorkerNotificationInsertResult extends WorkerJsonRecord {
-    notification_id?: string | number | null;
-}
-
-interface WorkerNotificationCreatePayload extends WorkerJsonRecord {
-    userId: string;
-    actorUserId?: string | null;
-    type: string;
-    title: string;
-    body?: string;
-    reviewId?: string | number | null;
-    commentId?: string | number | null;
-    routeId?: string | number | null;
-    metadata?: WorkerJsonRecord;
-}
-
-async function requireSessionUser(request: Request, env: WorkerEnv) { const sessionUser = await readSessionUser(request, env); if (!sessionUser) {
+async function requireSessionUser(request: Request, env: WorkerEnv) {
+  const sessionUser = await readSessionUser(request, env);
+  if (!sessionUser) {
     return { response: jsonResponse(401, { detail: '로그인이 필요해요.' }, env, request) };
-} return { sessionUser }; }
-async function readNotificationRow(env: WorkerEnv, notificationId: string | number) { const rows = await supabaseRequest<WorkerNotificationRow[]>(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&notification_id=eq.${encodeFilterValue(notificationId)}&limit=1`); return rows?.[0] ?? null; }
-export async function createUserNotification(env: WorkerEnv, { userId, actorUserId = null, type, title, body = '', reviewId = null, commentId = null, routeId = null, metadata = {} }: WorkerNotificationCreatePayload): Promise<WorkerNotificationInsertResult | null> { if (!userId) {
-    return null;
-} const nowIso = new Date().toISOString(); const rows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, 'user_notification?select=notification_id', { method: 'POST', body: JSON.stringify({ user_id: userId, actor_user_id: actorUserId, type, title, body, review_id: reviewId ? Number(reviewId) : null, comment_id: commentId ? Number(commentId) : null, route_id: routeId ? Number(routeId) : null, metadata, is_read: false, created_at: nowIso, updated_at: nowIso, }), }); return rows?.[0] ?? null; }
-export async function loadUserNotifications(env: WorkerEnv, userId: string, limit = WorkerNotificationRuntimeConfig.defaultListLimit) { const rows = await supabaseRequest<WorkerNotificationRow[]>(env, `user_notification?select=notification_id,user_id,actor_user_id,type,title,body,review_id,comment_id,route_id,is_read,created_at&user_id=eq.${encodeFilterValue(userId)}&order=created_at.desc&limit=${limit}`); const actorIdsFilter = buildInFilter((rows || []).map((row) => row.actor_user_id).filter(Boolean)); const actorRows = actorIdsFilter ? await supabaseRequest<WorkerNotificationActorRow[]>(env, `user?select=user_id,nickname&user_id=${actorIdsFilter}`) : []; const actorNameById = new Map((actorRows || []).map((row) => [row.user_id, row.nickname])); return (rows || []).map((row) => ({ id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName: row.actor_user_id ? actorNameById.get(row.actor_user_id) ?? null : null, })); }
-export async function countUnreadNotifications(env: WorkerEnv, userId: string) { const rows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(userId)}&is_read=eq.false`); return rows?.length ?? 0; }
-export async function loadNotificationById(env: WorkerEnv, notificationId: string | number) { const row = await readNotificationRow(env, notificationId); if (!row) {
-    return null;
-} let actorName = null; if (row.actor_user_id) {
-    const actorRows = await supabaseRequest<WorkerNotificationActorRow[]>(env, `user?select=user_id,nickname&user_id=eq.${encodeFilterValue(row.actor_user_id)}&limit=1`);
-    actorName = actorRows?.[0]?.nickname ?? null;
-} return { id: String(row.notification_id), type: row.type, title: row.title, body: row.body ?? '', createdAt: formatDateTime(row.created_at), isRead: Boolean(row.is_read), reviewId: row.review_id ? String(row.review_id) : null, commentId: row.comment_id ? String(row.comment_id) : null, routeId: row.route_id ? String(row.route_id) : null, actorName, }; }
-async function buildNotificationRealtimeTopic(env: WorkerEnv, userId: string) { const secret = getSigningSecret(env); if (!secret) {
-    throw new Error('Notification realtime secret is missing.');
-} const signature = await sha256Base64Url(`${userId}:${secret}:notifications`); return `user-notifications:${userId}:${signature}`; }
-async function sendRealtimeBroadcast(env: WorkerEnv, topic: string, event: string, payload: WorkerJsonRecord) { if (!env.APP_SUPABASE_URL) {
-    return;
-} const apiKey = getSupabaseKey(env); if (!apiKey) {
-    return;
-} await fetch(`${env.APP_SUPABASE_URL}/realtime/v1/api/broadcast`, { method: 'POST', headers: { apikey: apiKey, Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json', }, body: JSON.stringify({ messages: [{ topic, event, payload, private: false, },], }), }); }
-export async function publishNotificationEvent(env: WorkerEnv, userId: string, event: string, payload: WorkerJsonRecord) { const topic = await buildNotificationRealtimeTopic(env, userId); await sendRealtimeBroadcast(env, topic, event, payload); }
-export async function handleMyNotifications(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const notifications = await loadUserNotifications(env, sessionResult.sessionUser.id, WorkerNotificationRuntimeConfig.myNotificationsListLimit); return jsonResponse(200, notifications, env, request); }
-export async function handleNotificationRealtimeChannel(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const topic = await buildNotificationRealtimeTopic(env, sessionResult.sessionUser.id); return jsonResponse(200, { topic }, env, request); }
-export async function handleMarkNotificationRead(request: Request, env: WorkerEnv, notificationId: string) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const notificationRow = await readNotificationRow(env, notificationId); if (!notificationRow) {
-    return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);
-} if (notificationRow.user_id !== sessionResult.sessionUser.id) {
-    return jsonResponse(403, { detail: '내 알림만 확인할 수 있어요.' }, env, request);
-} if (!notificationRow.is_read) {
-    const nowIso = new Date().toISOString();
-    await supabaseRequest(env, `user_notification?notification_id=eq.${encodeFilterValue(notificationId)}`, { method: 'PATCH', body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso, }), });
-    await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.read', { notificationId: String(notificationId), unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id), });
-} return jsonResponse(200, { notificationId: String(notificationId), read: true }, env, request); }
-export async function handleMarkAllNotificationsRead(request: Request, env: WorkerEnv) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const unreadRows = await supabaseRequest<WorkerNotificationInsertResult[]>(env, `user_notification?select=notification_id&user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&is_read=eq.false`); const updated = unreadRows?.length ?? 0; if (updated > 0) {
-    const nowIso = new Date().toISOString();
-    await supabaseRequest(env, `user_notification?user_id=eq.${encodeFilterValue(sessionResult.sessionUser.id)}&is_read=eq.false`, { method: 'PATCH', body: JSON.stringify({ is_read: true, read_at: nowIso, updated_at: nowIso, }), });
-    await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.all-read', { updated, unreadCount: 0, });
-} return jsonResponse(200, { updated }, env, request); }
-export async function handleDeleteNotification(request: Request, env: WorkerEnv, notificationId: string) { const sessionResult = await requireSessionUser(request, env); if (sessionResult.response) {
-    return sessionResult.response;
-} const notificationRow = await readNotificationRow(env, notificationId); if (!notificationRow) {
-    return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);
-} if (notificationRow.user_id !== sessionResult.sessionUser.id) {
-    return jsonResponse(403, { detail: '내 알림만 삭제할 수 있어요.' }, env, request);
-} await supabaseRequest(env, `user_notification?notification_id=eq.${encodeFilterValue(notificationId)}`, { method: 'DELETE', headers: { Prefer: 'return=minimal' }, }); await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.deleted', { notificationId: String(notificationId), unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id), }); return jsonResponse(200, { notificationId: String(notificationId), deleted: true }, env, request); }
+  }
+  return { sessionUser };
+}
 
+function mapNotificationRow(row: WorkerNotificationRow, actorName: string | null | undefined) {
+  return {
+    id: String(row.notification_id),
+    type: row.type,
+    title: row.title,
+    body: row.body ?? '',
+    createdAt: formatDateTime(row.created_at),
+    isRead: Boolean(row.is_read),
+    reviewId: row.review_id ? String(row.review_id) : null,
+    commentId: row.comment_id ? String(row.comment_id) : null,
+    routeId: row.route_id ? String(row.route_id) : null,
+    actorName: row.actor_user_id ? actorName ?? null : null,
+  };
+}
+
+export async function createUserNotification(
+  env: WorkerEnv,
+  payload: WorkerNotificationCreatePayload,
+): Promise<WorkerNotificationInsertResult | null> {
+  if (!payload.userId) {
+    return null;
+  }
+
+  return createNotification(env, payload);
+}
+
+export async function loadUserNotifications(
+  env: WorkerEnv,
+  userId: string,
+  limit = WorkerNotificationRuntimeConfig.defaultListLimit,
+) {
+  const rows = await readUserNotificationRows(env, userId, limit);
+  const actorRows = await readNotificationActorRows(
+    env,
+    rows.map((row) => row.actor_user_id),
+  );
+  const actorNameById = new Map(actorRows.map((row) => [row.user_id, row.nickname]));
+
+  return rows.map((row) => mapNotificationRow(row, row.actor_user_id ? actorNameById.get(row.actor_user_id) : null));
+}
+
+export async function countUnreadNotifications(env: WorkerEnv, userId: string) {
+  const rows = await readUnreadNotificationRows(env, userId);
+  return rows.length;
+}
+
+export async function loadNotificationById(env: WorkerEnv, notificationId: string | number) {
+  const row = await readNotificationRow(env, notificationId);
+  if (!row) {
+    return null;
+  }
+
+  const actorRow = row.actor_user_id ? await readNotificationActorRow(env, row.actor_user_id) : null;
+  return mapNotificationRow(row, actorRow?.nickname ?? null);
+}
+
+export async function publishNotificationEvent(
+  env: WorkerEnv,
+  userId: string,
+  event: string,
+  payload: WorkerJsonRecord,
+) {
+  const topic = await buildNotificationRealtimeTopic(env, userId);
+  await sendRealtimeBroadcast(env, topic, event, payload);
+}
+
+export async function handleMyNotifications(request: Request, env: WorkerEnv) {
+  const sessionResult = await requireSessionUser(request, env);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const notifications = await loadUserNotifications(
+    env,
+    sessionResult.sessionUser.id,
+    WorkerNotificationRuntimeConfig.myNotificationsListLimit,
+  );
+  return jsonResponse(200, notifications, env, request);
+}
+
+export async function handleNotificationRealtimeChannel(request: Request, env: WorkerEnv) {
+  const sessionResult = await requireSessionUser(request, env);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const topic = await buildNotificationRealtimeTopic(env, sessionResult.sessionUser.id);
+  return jsonResponse(200, { topic }, env, request);
+}
+
+export async function handleMarkNotificationRead(request: Request, env: WorkerEnv, notificationId: string) {
+  const sessionResult = await requireSessionUser(request, env);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const notificationRow = await readNotificationRow(env, notificationId);
+  if (!notificationRow) {
+    return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);
+  }
+  if (notificationRow.user_id !== sessionResult.sessionUser.id) {
+    return jsonResponse(403, { detail: '내 알림만 확인할 수 있어요.' }, env, request);
+  }
+
+  if (!notificationRow.is_read) {
+    const nowIso = new Date().toISOString();
+    await markNotificationRead(env, notificationId, nowIso);
+    await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.read', {
+      notificationId: String(notificationId),
+      unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id),
+    });
+  }
+
+  return jsonResponse(200, { notificationId: String(notificationId), read: true }, env, request);
+}
+
+export async function handleMarkAllNotificationsRead(request: Request, env: WorkerEnv) {
+  const sessionResult = await requireSessionUser(request, env);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const unreadRows = await readUnreadNotificationRows(env, sessionResult.sessionUser.id);
+  const updated = unreadRows.length;
+
+  if (updated > 0) {
+    const nowIso = new Date().toISOString();
+    await markAllNotificationsRead(env, sessionResult.sessionUser.id, nowIso);
+    await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.all-read', {
+      updated,
+      unreadCount: 0,
+    });
+  }
+
+  return jsonResponse(200, { updated }, env, request);
+}
+
+export async function handleDeleteNotification(request: Request, env: WorkerEnv, notificationId: string) {
+  const sessionResult = await requireSessionUser(request, env);
+  if (sessionResult.response) {
+    return sessionResult.response;
+  }
+
+  const notificationRow = await readNotificationRow(env, notificationId);
+  if (!notificationRow) {
+    return jsonResponse(404, { detail: '알림을 찾지 못했어요.' }, env, request);
+  }
+  if (notificationRow.user_id !== sessionResult.sessionUser.id) {
+    return jsonResponse(403, { detail: '내 알림만 삭제할 수 있어요.' }, env, request);
+  }
+
+  await deleteNotificationRow(env, notificationId);
+  await publishNotificationEvent(env, sessionResult.sessionUser.id, 'notification.deleted', {
+    notificationId: String(notificationId),
+    unreadCount: await countUnreadNotifications(env, sessionResult.sessionUser.id),
+  });
+
+  return jsonResponse(200, { notificationId: String(notificationId), deleted: true }, env, request);
+}

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "bbbc572f6fd6c6869d5ba2b810d82d452e458aad",
+  "generatedFrom": "d8eff3e8d4ed26484f1735fbf4ee9ca3ef83fe4c",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -2014,8 +2014,43 @@
       ]
     },
     {
+      "path": "deploy/api-worker-shell/services/notification-domain/repository.ts",
+      "count": 5,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 16,
+          "column": 115
+        },
+        {
+          "value": "0",
+          "line": 19,
+          "column": 17
+        },
+        {
+          "value": "0",
+          "line": 42,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 69,
+          "column": 86
+        },
+        {
+          "value": "0",
+          "line": 72,
+          "column": 17
+        }
+      ]
+    },
+    {
       "path": "deploy/api-worker-shell/services/notifications.ts",
-      "count": 19,
+      "count": 12,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -2023,33 +2058,33 @@
       "examples": [
         {
           "value": "401",
-          "line": 44,
+          "line": 27,
           "column": 37
         },
         {
-          "value": "1",
-          "line": 46,
-          "column": 343
+          "value": "200",
+          "line": 109,
+          "column": 23
         },
         {
-          "value": "0",
-          "line": 46,
-          "column": 362
+          "value": "200",
+          "line": 119,
+          "column": 23
         },
         {
-          "value": "0",
-          "line": 49,
-          "column": 496
+          "value": "404",
+          "line": 130,
+          "column": 25
         },
         {
-          "value": "0",
-          "line": 51,
-          "column": 281
+          "value": "403",
+          "line": 133,
+          "column": 25
         },
         {
-          "value": "1",
-          "line": 55,
-          "column": 167
+          "value": "200",
+          "line": 145,
+          "column": 23
         }
       ]
     },
@@ -2245,6 +2280,46 @@
           "value": "200",
           "line": 155,
           "column": 25
+        }
+      ]
+    },
+    {
+      "path": "deploy/api-worker-shell/services/stamp-domain/repository.ts",
+      "count": 8,
+      "owner": "worker-backend",
+      "category": "worker-runtime-limit-baseline",
+      "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
+      "reason": "Worker TTL, limit, status, session, route, and adapter values are migrated through Worker config work.",
+      "examples": [
+        {
+          "value": "1",
+          "line": 28,
+          "column": 60
+        },
+        {
+          "value": "0",
+          "line": 31,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 50,
+          "column": 36
+        },
+        {
+          "value": "0",
+          "line": 53,
+          "column": 17
+        },
+        {
+          "value": "1",
+          "line": 62,
+          "column": 113
+        },
+        {
+          "value": "0",
+          "line": 65,
+          "column": 17
         }
       ]
     },

--- a/test/unit/worker-notification-service.test.ts
+++ b/test/unit/worker-notification-service.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { issueSessionCookie } from '../../deploy/api-worker-shell/services/auth/session';
+import {
+  handleDeleteNotification,
+  handleMarkAllNotificationsRead,
+  handleMarkNotificationRead,
+  handleNotificationRealtimeChannel,
+} from '../../deploy/api-worker-shell/services/notifications';
+import type { WorkerEnv, WorkerSessionUser } from '../../deploy/api-worker-shell/types';
+
+const env: WorkerEnv = {
+  APP_CORS_ORIGINS: 'http://localhost',
+  APP_FRONTEND_URL: 'http://localhost',
+  APP_SESSION_HTTPS: 'false',
+  APP_SESSION_SECRET: 'test-session-secret',
+  APP_SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+  APP_SUPABASE_URL: 'https://supabase.test',
+};
+
+const sessionUser: WorkerSessionUser = {
+  id: 'user-1',
+  nickname: 'tester',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+};
+
+const notificationRow = {
+  notification_id: 10,
+  user_id: sessionUser.id,
+  actor_user_id: 'actor-1',
+  type: 'comment',
+  title: 'title',
+  body: 'body',
+  review_id: 20,
+  comment_id: 30,
+  route_id: null,
+  is_read: false,
+  created_at: '2026-05-12T00:00:00.000Z',
+};
+
+async function createAuthedRequest(method = 'POST') {
+  const baseRequest = new Request('http://localhost/api/my/notifications', { method });
+  const cookie = await issueSessionCookie(sessionUser, baseRequest, env);
+
+  return new Request('http://localhost/api/my/notifications', {
+    method,
+    headers: { cookie },
+  });
+}
+
+function stubFetchRows(rowsByCall: unknown[][]) {
+  const calls: Array<{ init?: RequestInit; url: string }> = [];
+  const fetchMock = vi.fn<(input: RequestInfo | URL, init?: RequestInit) => Promise<Response>>(async (input, init) => {
+    calls.push({ init, url: String(input) });
+    const isRealtime = String(input).includes('/realtime/v1/api/broadcast');
+    const rows = isRealtime ? { ok: true } : rowsByCall.shift() ?? [];
+
+    return new Response(JSON.stringify(rows), {
+      headers: { 'content-type': 'application/json' },
+      status: 200,
+    });
+  });
+
+  vi.stubGlobal('fetch', fetchMock);
+
+  return { calls, fetchMock };
+}
+
+function realtimePayload(call: { init?: RequestInit }) {
+  return JSON.parse(String(call.init?.body)) as {
+    messages: Array<{ event: string; payload: Record<string, unknown>; topic: string }>;
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('worker notification service', () => {
+  it('marks a single notification as read and publishes a realtime event', async () => {
+    const { calls } = stubFetchRows([[notificationRow], [], []]);
+
+    const response = await handleMarkNotificationRead(await createAuthedRequest(), env, '10');
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ notificationId: '10', read: true });
+    expect(calls.map((call) => [call.init?.method ?? 'GET', new URL(call.url).pathname])).toEqual([
+      ['GET', '/rest/v1/user_notification'],
+      ['PATCH', '/rest/v1/user_notification'],
+      ['GET', '/rest/v1/user_notification'],
+      ['POST', '/realtime/v1/api/broadcast'],
+    ]);
+    expect(realtimePayload(calls.at(-1)!).messages[0]).toMatchObject({
+      event: 'notification.read',
+      payload: { notificationId: '10', unreadCount: 0 },
+    });
+  });
+
+  it('marks all unread notifications and publishes a realtime event with the updated count', async () => {
+    const { calls } = stubFetchRows([[{ notification_id: 10 }, { notification_id: 11 }], []]);
+
+    const response = await handleMarkAllNotificationsRead(await createAuthedRequest(), env);
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ updated: 2 });
+    expect(calls.map((call) => [call.init?.method ?? 'GET', new URL(call.url).pathname])).toEqual([
+      ['GET', '/rest/v1/user_notification'],
+      ['PATCH', '/rest/v1/user_notification'],
+      ['POST', '/realtime/v1/api/broadcast'],
+    ]);
+    expect(realtimePayload(calls.at(-1)!).messages[0]).toMatchObject({
+      event: 'notification.all-read',
+      payload: { unreadCount: 0, updated: 2 },
+    });
+  });
+
+  it('deletes a notification and publishes a realtime event', async () => {
+    const { calls } = stubFetchRows([[notificationRow], [], []]);
+
+    const response = await handleDeleteNotification(await createAuthedRequest('DELETE'), env, '10');
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({ deleted: true, notificationId: '10' });
+    expect(calls.map((call) => [call.init?.method ?? 'GET', new URL(call.url).pathname])).toEqual([
+      ['GET', '/rest/v1/user_notification'],
+      ['DELETE', '/rest/v1/user_notification'],
+      ['GET', '/rest/v1/user_notification'],
+      ['POST', '/realtime/v1/api/broadcast'],
+    ]);
+    expect(realtimePayload(calls.at(-1)!).messages[0]).toMatchObject({
+      event: 'notification.deleted',
+      payload: { notificationId: '10', unreadCount: 0 },
+    });
+  });
+
+  it('returns a signed notification realtime topic for the current session user', async () => {
+    const response = await handleNotificationRealtimeChannel(await createAuthedRequest('GET'), env);
+    const payload = (await response.json()) as { topic: string };
+
+    expect(response.status).toBe(200);
+    expect(payload.topic).toMatch(/^user-notifications:user-1:[A-Za-z0-9_-]+$/);
+  });
+});

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -78,7 +78,7 @@ describe('worker source quality gates', () => {
       {
         file: 'deploy/api-worker-shell/services/notifications.ts',
         limits: {
-          supabaseRequest: 11,
+          supabaseRequest: 0,
           exportedHandlers: 5,
           implicitEnvSignatures: 0,
         },
@@ -252,6 +252,25 @@ describe('worker source quality gates', () => {
     expect(repositorySource).toContain('supabaseRequest');
     expect(repositorySource).toContain('user_stamp?select=');
     expect(repositorySource).toContain('travel_session?select=');
+  });
+
+  it('keeps notification persistence and realtime broadcast behind notification-domain boundaries', () => {
+    const serviceSource = readFileSync(join(workspaceRoot, 'deploy/api-worker-shell/services/notifications.ts'), 'utf8');
+    const repositorySource = readFileSync(
+      join(workspaceRoot, 'deploy/api-worker-shell/services/notification-domain/repository.ts'),
+      'utf8',
+    );
+    const publisherSource = readFileSync(
+      join(workspaceRoot, 'deploy/api-worker-shell/services/notification-domain/publisher.ts'),
+      'utf8',
+    );
+
+    expect(serviceSource).not.toContain('supabaseRequest');
+    expect(serviceSource).not.toContain('user_notification?select=');
+    expect(serviceSource).not.toContain('/realtime/v1/api/broadcast');
+    expect(repositorySource).toContain('supabaseRequest');
+    expect(repositorySource).toContain('user_notification?select=');
+    expect(publisherSource).toContain('/realtime/v1/api/broadcast');
   });
 
   it('keeps account, community, and admin service persistence behind domain repositories', () => {


### PR DESCRIPTION
## 요약

- Closes #297
- Worker notification service의 `user_notification` persistence를 `notification-domain/repository.ts`로 이동했습니다.
- realtime broadcast 송신을 `notification-domain/publisher.ts`로 격리했습니다.
- `notifications.ts`의 직접 `supabaseRequest` 사용을 `11 -> 0`으로 낮추고 source-quality gate로 회귀를 차단했습니다.
- read / all-read / delete / realtime topic 경로를 단위 테스트로 고정했습니다.

## 검증

- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp/check_utf8_integrity.py --staged`

## 비변경 범위

- 외부 API path / response shape 변경 없음
- DB schema 변경 없음
- OAuth 성공 경로 변경 없음
- 사용자-facing copy는 기존 문구를 유지했습니다.
