### PR TITLE
Eliminate intermediate array allocation in getKnownMyReviews

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2025-05-12 - Prevent intermediate array allocations with spread operator
+**Learning:** In frontend performance, building multiple lookup mechanisms using the spread operator (`[...a, ...b]`) inside frequent getters creates intermediate arrays, causing unnecessary memory allocation overhead.
+**Action:** Replace `[...a, ...b]` with sequential loops like `for...of` when inserting items into a `Map` or searching for elements.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2025-05-12 - Prevent intermediate array allocations with spread operator
-**Learning:** In frontend performance, building multiple lookup mechanisms using the spread operator (`[...a, ...b]`) inside frequent getters creates intermediate arrays, causing unnecessary memory allocation overhead.
-**Action:** Replace `[...a, ...b]` with sequential loops like `for...of` when inserting items into a `Map` or searching for elements.

--- a/src/hooks/app-view-models/reviewCapability.ts
+++ b/src/hooks/app-view-models/reviewCapability.ts
@@ -2,6 +2,14 @@ import type { SessionUser } from '../../types/auth';
 import type { Review, StampLog } from '../../types/review';
 import type { MyPageResponse } from '../../types/my-page';
 
+function addSessionReviews(reviewMap: Map<string, Review>, source: readonly Review[], sessionUserId: string) {
+  for (const review of source) {
+    if (review.userId === sessionUserId) {
+      reviewMap.set(review.id, review);
+    }
+  }
+}
+
 export function getKnownMyReviews({
   reviews,
   selectedPlaceReviews,
@@ -18,19 +26,10 @@ export function getKnownMyReviews({
   }
 
   const reviewMap = new Map<string, Review>();
-  // ⚡ Bolt: Performance Optimization
-  // Avoid O(N) array allocations using spread syntax [...a, ...b] just to populate a Map.
-  // Instead, process each list sequentially to maintain identical behavior with lower overhead.
-  const addReview = (review: Review) => {
-    if (review.userId === sessionUser.id) {
-      reviewMap.set(review.id, review);
-    }
-  };
-
-  for (const review of reviews) addReview(review);
-  for (const review of selectedPlaceReviews) addReview(review);
+  addSessionReviews(reviewMap, reviews, sessionUser.id);
+  addSessionReviews(reviewMap, selectedPlaceReviews, sessionUser.id);
   if (myPageReviews) {
-    for (const review of myPageReviews) addReview(review);
+    addSessionReviews(reviewMap, myPageReviews, sessionUser.id);
   }
 
   return [...reviewMap.values()];

--- a/src/hooks/app-view-models/reviewCapability.ts
+++ b/src/hooks/app-view-models/reviewCapability.ts
@@ -18,11 +18,19 @@ export function getKnownMyReviews({
   }
 
   const reviewMap = new Map<string, Review>();
-  for (const review of [...reviews, ...selectedPlaceReviews, ...(myPageReviews ?? [])]) {
-    if (review.userId !== sessionUser.id) {
-      continue;
+  // ⚡ Bolt: Performance Optimization
+  // Avoid O(N) array allocations using spread syntax [...a, ...b] just to populate a Map.
+  // Instead, process each list sequentially to maintain identical behavior with lower overhead.
+  const addReview = (review: Review) => {
+    if (review.userId === sessionUser.id) {
+      reviewMap.set(review.id, review);
     }
-    reviewMap.set(review.id, review);
+  };
+
+  for (const review of reviews) addReview(review);
+  for (const review of selectedPlaceReviews) addReview(review);
+  if (myPageReviews) {
+    for (const review of myPageReviews) addReview(review);
   }
 
   return [...reviewMap.values()];

--- a/test/unit/reviewCapability.test.ts
+++ b/test/unit/reviewCapability.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from 'vitest';
+import { getKnownMyReviews } from '../../src/hooks/app-view-models/reviewCapability';
+import type { SessionUser } from '../../src/types/auth';
+import type { Review } from '../../src/types/review';
+
+const sessionUser = {
+  id: 'user-1',
+  nickname: 'tester',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+} satisfies SessionUser;
+
+function createReview(overrides: Pick<Review, 'id' | 'userId'> & Partial<Review>): Review {
+  return {
+    id: overrides.id,
+    userId: overrides.userId,
+    placeId: 'place-1',
+    placeName: 'place',
+    author: 'author',
+    body: 'body',
+    mood: '혼자서',
+    badge: 'badge',
+    visitedAt: '2026-05-12T00:00:00Z',
+    imageUrl: null,
+    thumbnailUrl: null,
+    commentCount: 0,
+    likeCount: 0,
+    likedByMe: false,
+    stampId: null,
+    visitNumber: 1,
+    visitLabel: '1회차',
+    travelSessionId: null,
+    hasPublishedRoute: false,
+    comments: [],
+    ...overrides,
+  };
+}
+
+describe('getKnownMyReviews', () => {
+  test('filters to the session user and keeps later source precedence for duplicate review ids', () => {
+    const knownMyReviews = getKnownMyReviews({
+      reviews: [
+        createReview({ id: 'shared-review', userId: sessionUser.id, body: 'from feed' }),
+        createReview({ id: 'feed-only', userId: sessionUser.id, body: 'from feed only' }),
+        createReview({ id: 'other-user-review', userId: 'user-2', body: 'other user' }),
+      ],
+      selectedPlaceReviews: [
+        createReview({ id: 'selected-only', userId: sessionUser.id, body: 'from selected place' }),
+      ],
+      myPageReviews: [
+        createReview({ id: 'shared-review', userId: sessionUser.id, body: 'from my page' }),
+      ],
+      sessionUser,
+    });
+
+    expect(knownMyReviews.map((review) => review.id)).toEqual([
+      'shared-review',
+      'feed-only',
+      'selected-only',
+    ]);
+    expect(knownMyReviews.find((review) => review.id === 'shared-review')?.body).toBe('from my page');
+  });
+
+  test('returns no known reviews without an authenticated session', () => {
+    expect(getKnownMyReviews({
+      reviews: [createReview({ id: 'review-1', userId: sessionUser.id })],
+      selectedPlaceReviews: [],
+      myPageReviews: undefined,
+      sessionUser: null,
+    })).toEqual([]);
+  });
+});


### PR DESCRIPTION
💡 What: Replaced spread operator array creation with sequential `for...of` loops when populating `reviewMap` in `getKnownMyReviews`.
🎯 Why: Creating a temporary array from `[...reviews, ...selectedPlaceReviews, ...(myPageReviews ?? [])]` introduces unnecessary memory allocation overhead, which is avoided by sequentially iterating over each source list.
📊 Impact: Reduces memory usage and intermediate garbage collection overhead by eliminating O(N) intermediate array allocations in a frequently accessed view model getter.
🔬 Measurement: Can be verified by running the test suite (`npm run test:all`) to ensure no logical regressions are introduced.

---
*PR created automatically by Jules for task [17656763532901916188](https://jules.google.com/task/17656763532901916188) started by @ClarusIubar*