### PR TITLE
refactor: add worker domain entrypoints

### DIFF
--- a/deploy/api-worker-shell/index.ts
+++ b/deploy/api-worker-shell/index.ts
@@ -22,7 +22,7 @@ import {
   normalizePlaceCategory,
 } from './runtime/base-data';
 import { createRouteRequest } from './runtime/routing';
-import type { WorkerReviewInteractionDeps } from './services/review-domain/contracts';
+import type { WorkerReviewInteractionDeps } from './services/review-domain';
 import type { WorkerEnv } from './types';
 
 const reviewReadService = createReviewReadService({

--- a/deploy/api-worker-shell/runtime/base-data-assembler.ts
+++ b/deploy/api-worker-shell/runtime/base-data-assembler.ts
@@ -1,4 +1,4 @@
-import type { WorkerReviewReadService } from '../services/review-domain/contracts';
+import type { WorkerReviewReadService } from '../services/review-domain';
 import type { WorkerBaseData, WorkerCourse, WorkerPlace } from './base-data-contracts';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
 import {

--- a/deploy/api-worker-shell/runtime/base-data-contracts.ts
+++ b/deploy/api-worker-shell/runtime/base-data-contracts.ts
@@ -7,7 +7,7 @@
  * Dependencies: Shared JSON records and review read-model contracts.
  */
 import type { WorkerJsonRecord } from '../types';
-import type { WorkerReview } from '../services/review-domain/read-model';
+import type { WorkerReview } from '../services/review-domain';
 
 export interface SupabaseMapRow extends WorkerJsonRecord {
   position_id: string | number;

--- a/deploy/api-worker-shell/runtime/base-data-repository.ts
+++ b/deploy/api-worker-shell/runtime/base-data-repository.ts
@@ -22,7 +22,7 @@ import type {
   WorkerReviewRouteRow,
   WorkerReviewStampRow,
   WorkerReviewUserRow,
-} from '../services/review-domain/contracts';
+} from '../services/review-domain';
 
 const STATIC_BASE_CACHE_TTL_MS = WorkerBaseDataRuntimeConfig.staticBaseCacheTtlMs;
 

--- a/deploy/api-worker-shell/runtime/route-runtime.ts
+++ b/deploy/api-worker-shell/runtime/route-runtime.ts
@@ -8,11 +8,11 @@
  */
 import type { WorkerBaseData, WorkerCourse } from './base-data-contracts';
 import type { WorkerEnv } from '../types';
-import type { WorkerAdminService } from '../services/admin-domain/contracts';
-import type { WorkerCommunityRouteService } from '../services/community-domain/contracts';
-import type { WorkerMyService } from '../services/my-domain/contracts';
-import type { WorkerReviewInteractionDeps, WorkerReviewReadService } from '../services/review-domain/contracts';
-import type { WorkerStampService } from '../services/stamp-domain/contracts';
+import type { WorkerAdminService } from '../services/admin-domain';
+import type { WorkerCommunityRouteService } from '../services/community-domain';
+import type { WorkerMyService } from '../services/my-domain';
+import type { WorkerReviewInteractionDeps, WorkerReviewReadService } from '../services/review-domain';
+import type { WorkerStampService } from '../services/stamp-domain';
 
 export interface RouteRuntime {
   adminService: WorkerAdminService;

--- a/deploy/api-worker-shell/services/admin-domain/index.ts
+++ b/deploy/api-worker-shell/services/admin-domain/index.ts
@@ -1,0 +1,15 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for the Worker admin domain.
+ * Primary Responsibility: Let callers depend on the admin domain surface instead of internal filenames.
+ * Design Intent: Human readers should see one admin-domain import before choosing to inspect contracts or repositories.
+ * Non-Goals: This file does not implement authorization, summary loading, or place visibility mutations.
+ * Dependencies: Admin domain contracts and repository functions.
+ */
+export type { WorkerAdminService, WorkerAdminServiceDeps } from './contracts';
+export {
+  loadAdminSummaryRows,
+  loadPlaceReviewRows,
+  loadPublicDataSource,
+  updateAdminPlaceVisibility,
+} from './repository';

--- a/deploy/api-worker-shell/services/admin.ts
+++ b/deploy/api-worker-shell/services/admin.ts
@@ -6,9 +6,9 @@ import {
   loadPlaceReviewRows,
   loadPublicDataSource,
   updateAdminPlaceVisibility,
-} from './admin-domain/repository';
+} from './admin-domain';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
-import type { WorkerAdminServiceDeps } from './admin-domain/contracts';
+import type { WorkerAdminServiceDeps } from './admin-domain';
 
 export function createAdminService({ normalizePlaceCategory }: WorkerAdminServiceDeps) {
   async function requireAdmin(request: Request, env: WorkerEnv) {

--- a/deploy/api-worker-shell/services/community-domain/index.ts
+++ b/deploy/api-worker-shell/services/community-domain/index.ts
@@ -1,0 +1,25 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for community-route domain collaborators.
+ * Primary Responsibility: Keep service callers on one domain import instead of mapper, repository, and contract internals.
+ * Design Intent: The community-route facade can reveal its owned domain without leaking its internal file layout.
+ * Non-Goals: This file does not map routes, authorize requests, or persist route data.
+ * Dependencies: Community domain contracts, mapper, and repository functions.
+ */
+export type { WorkerCommunityRouteLoadOptions, WorkerCommunityRouteService, WorkerCommunityRouteServiceDeps } from './contracts';
+export { mapCommunityRoutes } from './mapper';
+export {
+  countRouteLikes,
+  createRouteLike,
+  createUserRoute,
+  createUserRoutePlaces,
+  deleteRouteLike,
+  loadRouteDetailRows,
+  loadRouteRows,
+  loadSessionStampRows,
+  readExistingRouteForSession,
+  readRouteLikeRow,
+  readRouteRow,
+  readTravelSessionForOwner,
+  updateRouteLikeCount,
+} from './repository';

--- a/deploy/api-worker-shell/services/community-routes.ts
+++ b/deploy/api-worker-shell/services/community-routes.ts
@@ -1,6 +1,5 @@
 import { jsonResponse } from '../lib/http';
 import { readSessionUser } from './auth';
-import { mapCommunityRoutes } from './community-domain/mapper';
 import {
   countRouteLikes,
   createRouteLike,
@@ -15,10 +14,11 @@ import {
   readRouteRow,
   readTravelSessionForOwner,
   updateRouteLikeCount,
-} from './community-domain/repository';
+  mapCommunityRoutes,
+} from './community-domain';
 import { countUnreadNotifications, createUserNotification, loadNotificationById, publishNotificationEvent } from './notifications';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
-import type { WorkerCommunityRouteLoadOptions, WorkerCommunityRouteServiceDeps } from './community-domain/contracts';
+import type { WorkerCommunityRouteLoadOptions, WorkerCommunityRouteServiceDeps } from './community-domain';
 
 export function createCommunityRouteService({ loadStaticBaseRows }: WorkerCommunityRouteServiceDeps) {
   async function requireSessionUser(request: Request, env: WorkerEnv) {

--- a/deploy/api-worker-shell/services/festival-domain/index.ts
+++ b/deploy/api-worker-shell/services/festival-domain/index.ts
@@ -1,0 +1,12 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for the Worker festival domain.
+ * Primary Responsibility: Let the festival HTTP facade depend on domain capabilities without naming internal files.
+ * Design Intent: Festival internals are larger than other domains, so callers should start from one owned entrypoint.
+ * Non-Goals: This file does not normalize imports, query Supabase, or manage cache state directly.
+ * Dependencies: Festival cache, import service, mapper, and read service.
+ */
+export { clearFestivalCache, loadCachedFestivalCards } from './cache';
+export { upsertImportedFestivalItems } from './import-service';
+export { parseFestivalDate } from './mapper';
+export { loadBannerEvents, loadFestivalCards } from './read-service';

--- a/deploy/api-worker-shell/services/festivals.ts
+++ b/deploy/api-worker-shell/services/festivals.ts
@@ -9,10 +9,14 @@
 import { WorkerFestivalRuntimeConfig } from '../config/runtime';
 import { jsonResponse } from '../lib/http';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
-import { clearFestivalCache, loadCachedFestivalCards } from './festival-domain/cache';
-import { upsertImportedFestivalItems } from './festival-domain/import-service';
-import { parseFestivalDate } from './festival-domain/mapper';
-import { loadBannerEvents, loadFestivalCards } from './festival-domain/read-service';
+import {
+  clearFestivalCache,
+  loadBannerEvents,
+  loadCachedFestivalCards,
+  loadFestivalCards,
+  parseFestivalDate,
+  upsertImportedFestivalItems,
+} from './festival-domain';
 
 const INTERNAL_FESTIVAL_SOURCE_NAME = WorkerFestivalRuntimeConfig.internalSourceName;
 

--- a/deploy/api-worker-shell/services/my-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/my-domain/contracts.ts
@@ -8,7 +8,7 @@
  */
 import type { WorkerEnv, WorkerJsonRecord } from '../../types';
 import type { WorkerBaseData, WorkerStaticBaseRows } from '../../runtime/base-data-contracts';
-import type { WorkerCommunityRouteService } from '../community-domain/contracts';
+import type { WorkerCommunityRouteService } from '../community-domain';
 
 export interface WorkerMyCommentRow extends WorkerJsonRecord {
   comment_id: string | number;

--- a/deploy/api-worker-shell/services/my-domain/index.ts
+++ b/deploy/api-worker-shell/services/my-domain/index.ts
@@ -1,0 +1,11 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for My Page domain collaborators.
+ * Primary Responsibility: Keep My service callers on one domain import instead of mapper and repository internals.
+ * Design Intent: My Page ownership rules should remain local to the domain while preserving a small caller surface.
+ * Non-Goals: This file does not load comments, map DTOs, or compose My Page responses.
+ * Dependencies: My domain contracts, mapper, and repository functions.
+ */
+export type { WorkerMyService, WorkerMyServiceDeps } from './contracts';
+export { mapMyComments } from './mapper';
+export { loadFeedsForCommentRows, loadMyCommentRows, loadMySummaryCommentRows } from './repository';

--- a/deploy/api-worker-shell/services/my.ts
+++ b/deploy/api-worker-shell/services/my.ts
@@ -2,10 +2,9 @@ import { jsonResponse } from '../lib/http';
 import { parseListLimit } from '../lib/supabase';
 import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
-import { mapMyComments } from './my-domain/mapper';
-import { loadFeedsForCommentRows, loadMyCommentRows, loadMySummaryCommentRows } from './my-domain/repository';
+import { loadFeedsForCommentRows, loadMyCommentRows, loadMySummaryCommentRows, mapMyComments } from './my-domain';
 import type { WorkerEnv } from '../types';
-import type { WorkerMyServiceDeps } from './my-domain/contracts';
+import type { WorkerMyServiceDeps } from './my-domain';
 
 interface WorkerMyCommentPageOptions {
   cursor?: string | null;

--- a/deploy/api-worker-shell/services/notification-domain/index.ts
+++ b/deploy/api-worker-shell/services/notification-domain/index.ts
@@ -1,0 +1,25 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for notification persistence and publishing.
+ * Primary Responsibility: Hide notification repository and realtime publisher filenames from the service facade.
+ * Design Intent: Notification handlers should read as domain operations without exposing Supabase or broadcast layout.
+ * Non-Goals: This file does not implement notification HTTP handlers or realtime protocol details.
+ * Dependencies: Notification contracts, repository functions, and realtime publisher helpers.
+ */
+export type {
+  WorkerNotificationCreatePayload,
+  WorkerNotificationInsertResult,
+  WorkerNotificationRow,
+} from './contracts';
+export { buildNotificationRealtimeTopic, sendRealtimeBroadcast } from './publisher';
+export {
+  createNotification,
+  deleteNotificationRow,
+  markAllNotificationsRead,
+  markNotificationRead,
+  readNotificationActorRow,
+  readNotificationActorRows,
+  readNotificationRow,
+  readUnreadNotificationRows,
+  readUserNotificationRows,
+} from './repository';

--- a/deploy/api-worker-shell/services/notifications.ts
+++ b/deploy/api-worker-shell/services/notifications.ts
@@ -7,9 +7,9 @@ import type {
   WorkerNotificationCreatePayload,
   WorkerNotificationInsertResult,
   WorkerNotificationRow,
-} from './notification-domain/contracts';
-import { buildNotificationRealtimeTopic, sendRealtimeBroadcast } from './notification-domain/publisher';
+} from './notification-domain';
 import {
+  buildNotificationRealtimeTopic,
   createNotification,
   deleteNotificationRow,
   markAllNotificationsRead,
@@ -19,7 +19,8 @@ import {
   readNotificationRow,
   readUnreadNotificationRows,
   readUserNotificationRows,
-} from './notification-domain/repository';
+  sendRealtimeBroadcast,
+} from './notification-domain';
 
 async function requireSessionUser(request: Request, env: WorkerEnv) {
   const sessionUser = await readSessionUser(request, env);

--- a/deploy/api-worker-shell/services/review-domain/index.ts
+++ b/deploy/api-worker-shell/services/review-domain/index.ts
@@ -1,0 +1,53 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for Worker review domain collaborators.
+ * Primary Responsibility: Keep review callers on one domain import while preserving domain-local ownership.
+ * Design Intent: Review read, interaction, repository, and mapper contracts are related but should not expand global Worker types.
+ * Non-Goals: This file does not implement review handlers, persistence, notification side effects, or DTO mapping.
+ * Dependencies: Review contracts, read model, mapper, notification helper, and repository functions.
+ */
+export type {
+  WorkerNotificationCreatePayload,
+  WorkerNotificationInsertResult,
+  WorkerReviewCommentRow,
+  WorkerReviewDataFilters,
+  WorkerReviewFeedRow,
+  WorkerReviewInteractionDeps,
+  WorkerReviewLikeRow,
+  WorkerReviewPageOptions,
+  WorkerReviewReadService,
+  WorkerReviewReadServiceDeps,
+  WorkerReviewRouteRow,
+  WorkerReviewStampRow,
+  WorkerReviewUserRow,
+} from './contracts';
+export type { WorkerReview, WorkerReviewComment } from './read-model';
+export { createReviewMapper } from './mapper';
+export { publishReviewNotification } from './notifications';
+export {
+  countReviewLikes,
+  createCommentRow,
+  createReviewLikeRow,
+  createReviewRow,
+  deleteReviewLikeRow,
+  deleteReviewRow,
+  readCommentRow,
+  readFeedRow,
+  readReviewLikeRow,
+  readStampRow,
+  softDeleteCommentRow,
+  updateCommentRow,
+  updateReviewRow,
+} from './repository';
+export {
+  readReviewCommentRows,
+  readReviewFeedRows,
+  readReviewLikeRows,
+  readReviewPageRows,
+  readReviewPlaceRows,
+  readReviewRouteRows,
+  readReviewStampRows,
+  readReviewUserRows,
+  readSingleReviewFeedRow,
+  readUserFeedLikeRows,
+} from './read-repository';

--- a/deploy/api-worker-shell/services/review-interactions.ts
+++ b/deploy/api-worker-shell/services/review-interactions.ts
@@ -1,8 +1,7 @@
 import { jsonResponse } from '../lib/http';
 import { getSupabaseKey } from '../lib/supabase';
 import type { WorkerEnv, WorkerJsonRecord, WorkerSessionUser } from '../types';
-import type { WorkerReviewInteractionDeps } from './review-domain/contracts';
-import { publishReviewNotification } from './review-domain/notifications';
+import type { WorkerReviewInteractionDeps } from './review-domain';
 import {
   countReviewLikes,
   createCommentRow,
@@ -14,10 +13,11 @@ import {
   readFeedRow,
   readReviewLikeRow,
   readStampRow,
+  publishReviewNotification,
   softDeleteCommentRow,
   updateCommentRow,
   updateReviewRow,
-} from './review-domain/repository';
+} from './review-domain';
 
 function sanitizeFileName(fileName: string) {
   return String(fileName || 'upload.jpg').replace(/[^a-zA-Z0-9._-]+/g, '-');

--- a/deploy/api-worker-shell/services/reviews.ts
+++ b/deploy/api-worker-shell/services/reviews.ts
@@ -2,15 +2,15 @@ import { jsonResponse } from '../lib/http';
 import { parseListLimit } from '../lib/supabase';
 import { WorkerPaginationRuntimeConfig } from '../config/runtime';
 import { readSessionUser } from './auth';
-import { createReviewMapper } from './review-domain/mapper';
 import type { WorkerEnv } from '../types';
 import type {
   WorkerReviewDataFilters,
   WorkerReviewPageOptions,
   WorkerReviewReadServiceDeps,
   WorkerReviewUserRow,
-} from './review-domain/contracts';
+} from './review-domain';
 import {
+  createReviewMapper,
   readReviewCommentRows,
   readReviewFeedRows,
   readReviewLikeRows,
@@ -21,7 +21,7 @@ import {
   readReviewUserRows,
   readSingleReviewFeedRow,
   readUserFeedLikeRows,
-} from './review-domain/read-repository';
+} from './review-domain';
 
 function indexUsersById(userRows: WorkerReviewUserRow[]) {
   return new Map(userRows.map((row) => [row.user_id, row] as const));

--- a/deploy/api-worker-shell/services/stamp-domain/index.ts
+++ b/deploy/api-worker-shell/services/stamp-domain/index.ts
@@ -1,0 +1,19 @@
+/*
+ * File: index.ts
+ * Purpose: Expose the readable public entrypoint for Worker stamp domain collaborators.
+ * Primary Responsibility: Let the stamp service facade import one owned domain surface.
+ * Design Intent: Stamp persistence is domain-owned, while callers should not need repository file names.
+ * Non-Goals: This file does not implement stamp claim logic or database operations.
+ * Dependencies: Stamp domain contracts and repository functions.
+ */
+export type { WorkerStampService, WorkerStampServiceDeps } from './contracts';
+export {
+  createTravelSession,
+  createUserStamp,
+  readLastStampRow,
+  readPlaceStampRows,
+  readTodayStampRow,
+  readTravelSessionRow,
+  updateStampTravelSession,
+  updateTravelSession,
+} from './repository';

--- a/deploy/api-worker-shell/services/stamps.ts
+++ b/deploy/api-worker-shell/services/stamps.ts
@@ -3,7 +3,7 @@ import { toSeoulDateKey } from '../lib/dates';
 import { jsonResponse } from '../lib/http';
 import type { WorkerEnv, WorkerJsonRecord } from '../types';
 import { readSessionUser } from './auth';
-import type { WorkerStampServiceDeps } from './stamp-domain/contracts';
+import type { WorkerStampServiceDeps } from './stamp-domain';
 import {
   createTravelSession,
   createUserStamp,
@@ -13,7 +13,7 @@ import {
   readTravelSessionRow,
   updateStampTravelSession,
   updateTravelSession,
-} from './stamp-domain/repository';
+} from './stamp-domain';
 
 function getStampUnlockRadius(env: WorkerEnv) {
   const parsed = Number(env.APP_STAMP_UNLOCK_RADIUS_METERS ?? WorkerStampRuntimeConfig.defaultUnlockRadiusMeters);

--- a/reports/completion/TSK-006-02-worker-domain-entrypoint-readability.md
+++ b/reports/completion/TSK-006-02-worker-domain-entrypoint-readability.md
@@ -2,7 +2,7 @@
 
 Scope-ID: `TSK-006-02-WORKER-DOMAIN-ENTRYPOINT-READABILITY`
 Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/305
-PR: `TBD-TSK-006-02-WORKER-DOMAIN-ENTRYPOINT-READABILITY`
+PR: https://github.com/STH-1-Class-One-Group/JamIssue/pull/310
 Branch: `worker-domain-entrypoint-readability`
 Status: `validated-local`
 Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/303

--- a/reports/completion/TSK-006-02-worker-domain-entrypoint-readability.md
+++ b/reports/completion/TSK-006-02-worker-domain-entrypoint-readability.md
@@ -1,0 +1,45 @@
+# TSK-006-02 Worker Domain Entrypoint Readability
+
+Scope-ID: `TSK-006-02-WORKER-DOMAIN-ENTRYPOINT-READABILITY`
+Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/305
+PR: `TBD-TSK-006-02-WORKER-DOMAIN-ENTRYPOINT-READABILITY`
+Branch: `worker-domain-entrypoint-readability`
+Status: `validated-local`
+Parent Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/303
+Child Issue: https://github.com/STH-1-Class-One-Group/JamIssue/issues/305
+
+## Purpose
+
+Worker domain 외부 caller가 `contracts`, `mapper`, `repository` 같은 내부 파일명을 직접 알지 않아도 되도록 domain-local public entrypoint를 추가한다. 이 작업은 global barrel 회귀가 아니라 각 domain 소유 경계 안에서 읽기 시작점을 명확히 하는 작업이다.
+
+## Current Decisions
+
+- `services/*.ts` HTTP/service facade는 유지한다.
+- `*-domain/index.ts`는 domain-local public entrypoint로만 사용한다.
+- global `deploy/api-worker-shell/types.ts`에는 domain contract를 추가하지 않는다.
+- 외부 API path, response shape, DB schema, 사용자-facing copy, OAuth 성공 경로는 변경하지 않는다.
+
+## PR Scope
+
+- Worker `*-domain/index.ts` public entrypoint 추가
+- Worker service/runtime/index 계층의 `*-domain/contracts`, `mapper`, `repository` 직접 import를 domain root import로 전환
+- `worker-source-quality`에 domain internal import 회귀 방지 gate 추가
+
+## Validation Results
+
+- [x] `npm.cmd run typecheck` 통과
+- [x] `npm.cmd exec vitest -- run test/unit/worker-source-quality.test.ts` 통과
+- [x] `npm.cmd exec vitest -- run test/unit/architecture-readability-source-quality.test.ts` 통과
+- [x] `npm.cmd run check:numeric-literals` 통과
+- [x] `npm.cmd run lint` 통과
+- [x] `npm.cmd run test:unit` 통과
+- [x] `npm.cmd run build` 통과
+- [x] `git diff --check` 통과
+- [x] UTF-8 integrity check 통과
+- [ ] PR checks
+
+## Remaining Follow-Up Work
+
+- #306에서 frontend hook navigation 구조를 정리한다.
+- #307에서 250라인 초과 내부 파일을 업무 언어 기준으로 검토한다.
+- #308에서 최종 readability 문서와 release traceability를 갱신한다.

--- a/test/unit/worker-source-quality.test.ts
+++ b/test/unit/worker-source-quality.test.ts
@@ -232,7 +232,7 @@ describe('worker source quality gates', () => {
 
     expect(interactionSource).not.toContain('supabaseRequest');
     expect(interactionSource).not.toContain('feed?select=');
-    expect(reviewReadSource).toContain("import { createReviewMapper } from './review-domain/mapper';");
+    expect(reviewReadSource).toContain("from './review-domain';");
     expect(reviewReadSource).not.toContain('supabaseRequest');
     expect(reviewReadSource).not.toContain('function mapReviewRows');
     expect(repositorySource).toContain('supabaseRequest');
@@ -302,6 +302,19 @@ describe('worker source quality gates', () => {
     expect(testImportSource).not.toMatch(
       /RouteRuntime|WorkerBaseData|WorkerStaticBaseRows|WorkerReviewInteractionDeps|Supabase[A-Za-z]+Row/,
     );
+  });
+
+  it('keeps Worker domain internals behind domain entrypoints for external callers', () => {
+    const internalDomainImportLines = collectTrackedWorkerTsFiles().flatMap((file) => {
+      const relativePath = relative(workspaceRoot, file);
+      const source = readFileSync(file, 'utf8');
+      return source
+        .split(/\r?\n/)
+        .filter((line) => /from\s+['"][^'"]+-domain\/[^'"]+['"]/.test(line))
+        .map((line) => `${relativePath}: ${line.trim()}`);
+    });
+
+    expect(internalDomainImportLines).toEqual([]);
   });
 
   it('keeps Worker service constructor dependency contracts explicit', () => {


### PR DESCRIPTION
## Summary

- Closes #305
- Adds domain-local index.ts entrypoints for Worker domain modules.
- Replaces service/runtime imports of *-domain/contracts, mapper, and epository internals with domain root imports.
- Adds a Worker source-quality gate preventing external callers from importing *-domain/... internals again.

## Invariants

- No product behavior changes.
- No user-facing copy changes.
- No API path, response shape, DB schema, or OAuth success-path changes.
- No global Worker type barrel expansion.

## Validation

- npm.cmd run typecheck
- npm.cmd exec vitest -- run test/unit/worker-source-quality.test.ts
- npm.cmd exec vitest -- run test/unit/architecture-readability-source-quality.test.ts
- npm.cmd run check:numeric-literals
- npm.cmd run lint
- npm.cmd run test:unit
- npm.cmd run build
- git diff --check
- UTF-8 integrity check