### PR TITLE
Optimize Set construction allocations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-03-08 - Intermediate Array Allocations during Set Construction
-**Learning:** Initializing a `Set` by mapping an array inline (`new Set(array.map(item => item.id))`) causes the browser to allocate unnecessary intermediate arrays in memory. If this is done inside heavily used hooks (like pagination) or React hooks that run often (like Naver Marker updates on re-render), it can lead to memory pressure and potential garbage collection stutter.
-**Action:** Always construct Sets using a `for...of` loop with `Set.add()` when you need to extract properties from a large array of objects. This avoids the `O(N)` memory overhead of intermediate mapped arrays.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-03-08 - Intermediate Array Allocations during Set Construction
+**Learning:** Initializing a `Set` by mapping an array inline (`new Set(array.map(item => item.id))`) causes the browser to allocate unnecessary intermediate arrays in memory. If this is done inside heavily used hooks (like pagination) or React hooks that run often (like Naver Marker updates on re-render), it can lead to memory pressure and potential garbage collection stutter.
+**Action:** Always construct Sets using a `for...of` loop with `Set.add()` when you need to extract properties from a large array of objects. This avoids the `O(N)` memory overhead of intermediate mapped arrays.

--- a/src/components/naver-map/useNaverFestivalMarkers.ts
+++ b/src/components/naver-map/useNaverFestivalMarkers.ts
@@ -29,7 +29,12 @@ export function useNaverFestivalMarkers({
       return;
     }
 
-    const nextIds = new Set(festivals.filter(hasFestivalCoordinates).map((festival) => festival.id));
+    const nextIds = new Set<string>();
+    for (const festival of festivals) {
+      if (hasFestivalCoordinates(festival)) {
+        nextIds.add(festival.id);
+      }
+    }
     const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     for (const [festivalId, marker] of festivalMarkersRef.current.entries()) {

--- a/src/components/naver-map/useNaverPlaceMarkers.ts
+++ b/src/components/naver-map/useNaverPlaceMarkers.ts
@@ -29,7 +29,10 @@ export function useNaverPlaceMarkers({
       return;
     }
 
-    const nextIds = new Set(places.map((place) => place.id));
+    const nextIds = new Set<string>();
+    for (const place of places) {
+      nextIds.add(place.id);
+    }
     const markerAnchor = new mapsApi.Point(NaverMarkerConfig.anchor.default.x, NaverMarkerConfig.anchor.default.y);
 
     for (const [placeId, marker] of placeMarkersRef.current.entries()) {

--- a/src/hooks/useAppPagePaginationActions.ts
+++ b/src/hooks/useAppPagePaginationActions.ts
@@ -48,7 +48,10 @@ export function useAppPagePaginationActions({
     try {
       const page = await getReviewFeedPage({ cursor: feedNextCursor, limit: PaginationRuntimeConfig.pageSize });
       setReviews((current) => {
-        const existingIds = new Set(current.map((review) => review.id));
+        const existingIds = new Set<string>();
+        for (const review of current) {
+          existingIds.add(review.id);
+        }
         const nextItems = toReviewSummaryList(page.items).filter((review) => !existingIds.has(review.id));
         return [...current, ...nextItems];
       });
@@ -90,7 +93,10 @@ export function useAppPagePaginationActions({
           return current;
         }
         const base = initial ? [] : current.comments;
-        const existingIds = new Set(base.map((comment) => comment.id));
+        const existingIds = new Set<string>();
+        for (const comment of base) {
+          existingIds.add(comment.id);
+        }
         const nextItems = page.items.filter((comment) => !existingIds.has(comment.id));
         return {
           ...current,


### PR DESCRIPTION
💡 What: Replaced inline array mapping (`new Set(array.map(...))`) with `for...of` loops and `Set.add()` in `useAppPagePaginationActions.ts`, `useNaverFestivalMarkers.ts`, and `useNaverPlaceMarkers.ts`.
🎯 Why: Constructing a `Set` by passing a mapped array causes the browser to allocate a temporary intermediate array in memory (`O(N)` allocation overhead). Doing this inside React effects (which run on map interactions) or frequent pagination fetches increases memory pressure and potential garbage collection stutter. 
📊 Impact: Reduces memory allocation and avoids intermediate `O(N)` array creation whenever these hooks execute.
🔬 Measurement: Verify by checking memory profiles when scrolling the feed or rendering large numbers of map markers. Also confirmed functionality with `npm run lint` and `npm run test:all`.

---
*PR created automatically by Jules for task [7661640885643322322](https://jules.google.com/task/7661640885643322322) started by @ClarusIubar*