### PR TITLE
Fix review write flow after stamp claims

### DIFF
--- a/deploy/api-worker-shell/services/review-domain/notifications.ts
+++ b/deploy/api-worker-shell/services/review-domain/notifications.ts
@@ -6,18 +6,22 @@ export async function publishReviewNotification(
   deps: WorkerReviewInteractionDeps,
   payload: WorkerNotificationCreatePayload,
 ): Promise<void> {
-  const createdNotification = await deps.createUserNotification(env, payload);
-  if (!createdNotification?.notification_id) {
-    return;
-  }
+  try {
+    const createdNotification = await deps.createUserNotification(env, payload);
+    if (!createdNotification?.notification_id) {
+      return;
+    }
 
-  const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
-  if (!notification) {
-    return;
-  }
+    const notification = await deps.loadNotificationById(env, createdNotification.notification_id);
+    if (!notification) {
+      return;
+    }
 
-  await deps.publishNotificationEvent(env, payload.userId, 'notification.created', {
-    notification,
-    unreadCount: await deps.countUnreadNotifications(env, payload.userId),
-  });
+    await deps.publishNotificationEvent(env, payload.userId, 'notification.created', {
+      notification,
+      unreadCount: await deps.countUnreadNotifications(env, payload.userId),
+    });
+  } catch (error) {
+    console.error('Review notification side effect failed', error);
+  }
 }

--- a/deploy/api-worker-shell/services/review-write-handlers.ts
+++ b/deploy/api-worker-shell/services/review-write-handlers.ts
@@ -64,7 +64,9 @@ export async function handleCreateReview(request: Request, env: WorkerEnv, deps:
     image_url: imageUrl,
   });
   const createdReviewId = insertedRow?.feed_id as string | number | undefined;
-  const createdReview = await deps.loadSingleReview(env, createdReviewId as string, sessionResult.sessionUser.id);
+  const createdReview = createdReviewId == null
+    ? null
+    : await deps.loadSingleReview(env, String(createdReviewId), sessionResult.sessionUser.id);
 
   await publishReviewNotification(env, deps, {
     userId: sessionResult.sessionUser.id,

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "check:numeric-literals": "tsx scripts/numeric-literal-audit.ts --check",
     "smoke": "tsx scripts/run-public-smoke-checks.ts",
     "smoke:public": "tsx scripts/run-public-smoke-checks.ts",
-    "smoke:protected": "tsx scripts/run-protected-smoke-checks.ts"
+    "smoke:protected": "tsx scripts/run-protected-smoke-checks.ts",
+    "smoke:protected:write": "tsx scripts/run-protected-write-smoke-checks.ts"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.57.4",

--- a/scripts/run-protected-write-smoke-checks.ts
+++ b/scripts/run-protected-write-smoke-checks.ts
@@ -1,0 +1,111 @@
+import {
+  assert,
+  fetchJson,
+  loadRuntimeConfig,
+  runCheck,
+  runSmokeSuite,
+  scriptEntryMatches,
+} from './smoke/shared';
+import {
+  getProtectedWriteAuthHeaders,
+  getProtectedWriteSmokeConfig,
+  getProtectedWriteSmokeSkipReason,
+} from './smoke/protected-write';
+
+interface CreatedReviewPayload {
+  id?: string;
+}
+
+function hasReviewId(payload: unknown): payload is CreatedReviewPayload {
+  return Boolean(payload && typeof payload === 'object' && 'id' in payload);
+}
+
+export function createProtectedWriteSmokeChecks({ apiBaseUrl, env = process.env }) {
+  const authHeaders = getProtectedWriteAuthHeaders(env);
+  const jsonHeaders = {
+    ...authHeaders,
+    'content-type': 'application/json',
+  };
+  const config = getProtectedWriteSmokeConfig(env);
+
+  return [
+    {
+      name: 'api-review-write-roundtrip',
+      run: () => runCheck('api-review-write-roundtrip', async () => {
+        let reviewId: string | null = null;
+
+        try {
+          const { response: createReviewResponse, json: createReviewJson } = await fetchJson(`${apiBaseUrl}/api/reviews`, {
+            method: 'POST',
+            headers: jsonHeaders,
+            body: JSON.stringify({
+              placeId: config.placeId,
+              stampId: config.stampId,
+              body: config.reviewBody,
+              mood: '혼자서',
+              imageUrl: null,
+            }),
+          });
+          assert(createReviewResponse.status === 201, `expected review create 201, received ${createReviewResponse.status}`);
+          assert(hasReviewId(createReviewJson) && Boolean(createReviewJson.id), 'created review id is missing');
+          reviewId = String(createReviewJson.id);
+
+          const { response: createCommentResponse, json: createCommentJson } = await fetchJson(`${apiBaseUrl}/api/reviews/${reviewId}/comments`, {
+            method: 'POST',
+            headers: jsonHeaders,
+            body: JSON.stringify({ body: config.commentBody }),
+          });
+          assert(createCommentResponse.status === 200, `expected comment create 200, received ${createCommentResponse.status}`);
+          assert(Array.isArray(createCommentJson), 'created comment thread response is not an array');
+        } finally {
+          if (reviewId) {
+            const { response: deleteReviewResponse } = await fetchJson(`${apiBaseUrl}/api/reviews/${reviewId}`, {
+              method: 'DELETE',
+              headers: authHeaders,
+            });
+            assert(deleteReviewResponse.status === 200, `expected review cleanup 200, received ${deleteReviewResponse.status}`);
+          }
+        }
+      }),
+    },
+  ];
+}
+
+export async function runProtectedWriteSmokeSuite({
+  env = process.env,
+  loadRuntimeConfigImpl = loadRuntimeConfig,
+  runSmokeSuiteImpl = runSmokeSuite,
+} = {}) {
+  const skipReason = getProtectedWriteSmokeSkipReason(env);
+  if (skipReason) {
+    const payload = {
+      suite: 'protected-write',
+      skipped: true,
+      reason: skipReason,
+      checkedAt: new Date().toISOString(),
+      endpoints: ['api-review-write-roundtrip'],
+    };
+    console.log(JSON.stringify(payload, null, 2));
+    return payload;
+  }
+
+  const { appConfigResult, runtimeConfig, apiBaseUrl } = await loadRuntimeConfigImpl();
+  return runSmokeSuiteImpl({
+    suiteName: 'protected-write',
+    checks: createProtectedWriteSmokeChecks({ apiBaseUrl, env }),
+    runtimeConfig,
+    appConfigResult,
+    apiBaseUrl,
+  });
+}
+
+export async function main() {
+  return runProtectedWriteSmokeSuite();
+}
+
+if (scriptEntryMatches(import.meta.url, process.argv[1])) {
+  main().catch((error) => {
+    console.error('[smoke] fatal error', error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/smoke/protected-write.ts
+++ b/scripts/smoke/protected-write.ts
@@ -1,0 +1,44 @@
+import { getProtectedAuthHeaders } from './protected';
+
+export interface ProtectedWriteSmokeConfig {
+  placeId: string;
+  stampId: string;
+  reviewBody: string;
+  commentBody: string;
+}
+
+export function isProtectedWriteSmokeEnabled(env = process.env) {
+  return String(env.SMOKE_WRITE_ENABLED || '').toLowerCase() === 'true';
+}
+
+export function getProtectedWriteSmokeSkipReason(env = process.env) {
+  if (!isProtectedWriteSmokeEnabled(env)) {
+    return 'SMOKE_WRITE_ENABLED is not true';
+  }
+  if (!String(env.SMOKE_AUTH_BEARER_TOKEN || '').trim()) {
+    return 'SMOKE_AUTH_BEARER_TOKEN is not configured';
+  }
+  if (!String(env.SMOKE_WRITE_PLACE_ID || '').trim() || !String(env.SMOKE_WRITE_STAMP_ID || '').trim()) {
+    return 'SMOKE_WRITE_PLACE_ID and SMOKE_WRITE_STAMP_ID are required for protected write smoke checks';
+  }
+  return null;
+}
+
+export function getProtectedWriteSmokeConfig(env = process.env): ProtectedWriteSmokeConfig {
+  const placeId = String(env.SMOKE_WRITE_PLACE_ID || '').trim();
+  const stampId = String(env.SMOKE_WRITE_STAMP_ID || '').trim();
+  if (!placeId || !stampId) {
+    throw new Error('SMOKE_WRITE_PLACE_ID and SMOKE_WRITE_STAMP_ID are required for protected write smoke checks');
+  }
+
+  return {
+    placeId,
+    stampId,
+    reviewBody: String(env.SMOKE_WRITE_REVIEW_BODY || 'protected smoke review roundtrip'),
+    commentBody: String(env.SMOKE_WRITE_COMMENT_BODY || 'protected smoke comment'),
+  };
+}
+
+export function getProtectedWriteAuthHeaders(env = process.env) {
+  return getProtectedAuthHeaders(env);
+}

--- a/test/unit/smoke-checks.test.ts
+++ b/test/unit/smoke-checks.test.ts
@@ -15,6 +15,14 @@ import {
   createProtectedSmokeChecks,
   runProtectedSmokeSuite,
 } from '../../scripts/run-protected-smoke-checks';
+import {
+  getProtectedWriteSmokeConfig,
+  getProtectedWriteSmokeSkipReason,
+  isProtectedWriteSmokeEnabled,
+} from '../../scripts/smoke/protected-write';
+import {
+  runProtectedWriteSmokeSuite,
+} from '../../scripts/run-protected-write-smoke-checks';
 
 describe('run-smoke-checks helpers', () => {
   it('parses runtime app config from the bootstrap script', () => {
@@ -133,5 +141,53 @@ describe('run-smoke-checks helpers', () => {
     });
     expect(loadRuntimeConfigImpl).not.toHaveBeenCalled();
     expect(runSmokeSuiteImpl).not.toHaveBeenCalled();
+  });
+
+  it('keeps protected write smoke disabled unless explicitly opted in', async () => {
+    const loadRuntimeConfigImpl = vi.fn();
+    const runSmokeSuiteImpl = vi.fn();
+
+    const result = await runProtectedWriteSmokeSuite({
+      env: {},
+      loadRuntimeConfigImpl,
+      runSmokeSuiteImpl,
+    });
+
+    expect(result).toMatchObject({
+      suite: 'protected-write',
+      skipped: true,
+      reason: 'SMOKE_WRITE_ENABLED is not true',
+      endpoints: ['api-review-write-roundtrip'],
+    });
+    expect(loadRuntimeConfigImpl).not.toHaveBeenCalled();
+    expect(runSmokeSuiteImpl).not.toHaveBeenCalled();
+  });
+
+  it('requires explicit protected write smoke identifiers after opt-in', () => {
+    expect(isProtectedWriteSmokeEnabled({ SMOKE_WRITE_ENABLED: 'true' })).toBe(true);
+    expect(getProtectedWriteSmokeSkipReason({
+      SMOKE_WRITE_ENABLED: 'true',
+      SMOKE_AUTH_BEARER_TOKEN: 'token-123',
+    })).toBe('SMOKE_WRITE_PLACE_ID and SMOKE_WRITE_STAMP_ID are required for protected write smoke checks');
+    expect(getProtectedWriteSmokeSkipReason({
+      SMOKE_WRITE_ENABLED: 'true',
+      SMOKE_AUTH_BEARER_TOKEN: 'token-123',
+      SMOKE_WRITE_PLACE_ID: 'bread-house',
+      SMOKE_WRITE_STAMP_ID: '11',
+    })).toBeNull();
+  });
+
+  it('builds protected write smoke config from explicit env only', () => {
+    expect(getProtectedWriteSmokeConfig({
+      SMOKE_WRITE_PLACE_ID: 'bread-house',
+      SMOKE_WRITE_STAMP_ID: '11',
+      SMOKE_WRITE_REVIEW_BODY: 'review body',
+      SMOKE_WRITE_COMMENT_BODY: 'comment body',
+    })).toEqual({
+      placeId: 'bread-house',
+      stampId: '11',
+      reviewBody: 'review body',
+      commentBody: 'comment body',
+    });
   });
 });

--- a/test/unit/worker-review-domain.test.ts
+++ b/test/unit/worker-review-domain.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   handleCreateComment,
+  handleCreateReview,
   handleToggleReviewLike,
   handleUpdateReview,
 } from '../../deploy/api-worker-shell/services/review-interactions';
@@ -53,6 +54,24 @@ function createDeps(overrides: Partial<WorkerReviewInteractionDeps> = {}): Worke
   };
 }
 
+function createBaseDataWithPlace() {
+  const place = {
+    id: 'bread-house',
+    positionId: '101',
+    name: 'Bread House',
+  };
+
+  return {
+    places: [place],
+    placesByPositionId: new Map([[place.positionId, place]]),
+    reviews: [],
+    courses: [],
+    collectedPlaceIds: [],
+    stampLogs: [],
+    travelSessions: [],
+  };
+}
+
 async function readJson(response: Response) {
   return (await response.json()) as Record<string, any>;
 }
@@ -60,6 +79,46 @@ async function readJson(response: Response) {
 describe('worker review domain service boundaries', () => {
   beforeEach(() => {
     supabaseMock.supabaseRequest.mockReset();
+  });
+
+  it('keeps review creation successful when notification side effects fail after persistence', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    supabaseMock.supabaseRequest.mockImplementation(async (_env, path: string, init?: RequestInit) => {
+      if (path.startsWith('user_stamp?select=')) {
+        return [{ stamp_id: 11, position_id: 101, user_id: 'actor' }];
+      }
+      if (path === 'feed?select=feed_id' && init?.method === 'POST') {
+        return [{ feed_id: 7 }];
+      }
+      return [];
+    });
+    const deps = createDeps({
+      createUserNotification: vi.fn(async () => {
+        throw new Error('notification insert failed');
+      }),
+      loadBaseData: vi.fn(async () => createBaseDataWithPlace()),
+      loadSingleReview: vi.fn(async () => ({ id: '7', comments: [] })),
+    });
+
+    const response = await handleCreateReview(
+      new Request('https://api.daejeon.jamissue.com/api/reviews', {
+        method: 'POST',
+        body: JSON.stringify({
+          placeId: 'bread-house',
+          stampId: '11',
+          body: 'visited today',
+          mood: '혼자서',
+        }),
+      }),
+      env,
+      deps,
+    );
+
+    expect(response.status).toBe(201);
+    expect(await readJson(response)).toEqual({ id: '7', comments: [] });
+    expect(deps.loadSingleReview).toHaveBeenCalledWith(env, '7', 'actor');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Review notification side effect failed', expect.any(Error));
+    consoleErrorSpy.mockRestore();
   });
 
   it('keeps review owner checks before update persistence', async () => {
@@ -122,6 +181,40 @@ describe('worker review domain service boundaries', () => {
       'notification.created',
       expect.objectContaining({ unreadCount: 1 }),
     );
+  });
+
+  it('keeps comment creation successful when notification side effects fail after persistence', async () => {
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    supabaseMock.supabaseRequest.mockImplementation(async (_env, path: string) => {
+      if (path.startsWith('feed?select=')) {
+        return [{ feed_id: 1, position_id: 101, user_id: 'owner' }];
+      }
+      if (path === 'user_comment?select=comment_id') {
+        return [{ comment_id: 22 }];
+      }
+      return [];
+    });
+    const deps = createDeps({
+      createUserNotification: vi.fn(async () => {
+        throw new Error('notification insert failed');
+      }),
+    });
+
+    const response = await handleCreateComment(
+      new Request('https://api.daejeon.jamissue.com/api/reviews/1/comments', {
+        method: 'POST',
+        body: JSON.stringify({ body: '좋아요' }),
+      }),
+      env,
+      '1',
+      deps,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readJson(response)).toEqual([{ id: '22' }]);
+    expect(deps.loadSingleReview).toHaveBeenCalledWith(env, '1', 'actor');
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Review notification side effect failed', expect.any(Error));
+    consoleErrorSpy.mockRestore();
   });
 
   it('toggles review likes through the repository boundary', async () => {

--- a/test/unit/worker-routing-runtime.test.ts
+++ b/test/unit/worker-routing-runtime.test.ts
@@ -4,7 +4,15 @@ import { createRouteRequest } from '../../deploy/api-worker-shell/runtime/routin
 import type { RouteRuntime } from '../../deploy/api-worker-shell/runtime/route-runtime';
 import type { WorkerBaseData } from '../../deploy/api-worker-shell/runtime/base-data-contracts';
 import type { WorkerReviewInteractionDeps } from '../../deploy/api-worker-shell/services/review-domain/contracts';
-import type { WorkerEnv } from '../../deploy/api-worker-shell/types';
+import type { WorkerEnv, WorkerSessionUser } from '../../deploy/api-worker-shell/types';
+
+const supabaseMock = vi.hoisted(() => ({
+  encodeFilterValue: (value: unknown) => encodeURIComponent(String(value)),
+  getSupabaseKey: vi.fn(() => 'service-role-key'),
+  supabaseRequest: vi.fn(),
+}));
+
+vi.mock('../../deploy/api-worker-shell/lib/supabase', () => supabaseMock);
 
 const apiUrl = 'https://api.daejeon.jamissue.com';
 
@@ -22,6 +30,28 @@ const emptyBaseData: WorkerBaseData = {
   travelSessions: [],
 };
 
+const routeSessionUser: WorkerSessionUser = {
+  id: 'actor',
+  nickname: 'Actor',
+  email: null,
+  provider: 'kakao',
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: null,
+};
+
+const routePlace = {
+  id: 'bread-house',
+  positionId: '101',
+  name: 'Bread House',
+};
+
+const baseDataWithPlace: WorkerBaseData = {
+  ...emptyBaseData,
+  places: [routePlace],
+  placesByPositionId: new Map([[routePlace.positionId, routePlace]]),
+};
+
 function createJsonResponse(route: string, status = 200) {
   return new Response(JSON.stringify({ route }), {
     headers: { 'content-type': 'application/json' },
@@ -29,7 +59,7 @@ function createJsonResponse(route: string, status = 200) {
   });
 }
 
-function createReviewInteractionDeps(): WorkerReviewInteractionDeps {
+function createReviewInteractionDeps(overrides: Partial<WorkerReviewInteractionDeps> = {}): WorkerReviewInteractionDeps {
   return {
     badgeByMood: {},
     countUnreadNotifications: vi.fn(async () => 0),
@@ -39,6 +69,7 @@ function createReviewInteractionDeps(): WorkerReviewInteractionDeps {
     loadSingleReview: vi.fn(async () => null),
     publishNotificationEvent: vi.fn(async () => undefined),
     readSessionUser: vi.fn(async () => null),
+    ...overrides,
   };
 }
 
@@ -83,6 +114,7 @@ async function readJson<T>(response: Response): Promise<T> {
 }
 
 afterEach(() => {
+  supabaseMock.supabaseRequest.mockReset();
   vi.restoreAllMocks();
 });
 
@@ -103,6 +135,72 @@ describe('worker routing runtime', () => {
     expect(response.status).toBe(200);
     expect(await readJson<Array<{ id: string }>>(response)).toEqual([{ id: 'comment-1' }]);
     expect(runtime.reviewReadService.loadSingleReview).toHaveBeenCalledWith(env, '7', null);
+  });
+
+  it('dispatches authenticated review creation through the Worker write route', async () => {
+    supabaseMock.supabaseRequest.mockImplementation(async (_env, path: string, init?: RequestInit) => {
+      if (path.startsWith('user_stamp?select=')) {
+        return [{ stamp_id: 11, position_id: 101, user_id: 'actor' }];
+      }
+      if (path === 'feed?select=feed_id' && init?.method === 'POST') {
+        return [{ feed_id: 7 }];
+      }
+      return [];
+    });
+    const reviewDeps = createReviewInteractionDeps({
+      loadBaseData: vi.fn(async () => baseDataWithPlace),
+      loadSingleReview: vi.fn(async () => ({ id: '7', comments: [] })),
+      readSessionUser: vi.fn(async () => routeSessionUser),
+    });
+    const runtime = createRuntime();
+    runtime.buildReviewInteractionDeps = vi.fn(() => reviewDeps);
+
+    const response = await createRouteRequest(runtime)(
+      new Request(`${apiUrl}/api/reviews`, {
+        method: 'POST',
+        body: JSON.stringify({
+          placeId: 'bread-house',
+          stampId: '11',
+          body: 'visited today',
+          mood: '혼자서',
+        }),
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(201);
+    expect(await readJson<{ id: string; comments: unknown[] }>(response)).toEqual({ id: '7', comments: [] });
+    expect(reviewDeps.loadSingleReview).toHaveBeenCalledWith(env, '7', 'actor');
+  });
+
+  it('dispatches authenticated comment creation through the Worker write route', async () => {
+    supabaseMock.supabaseRequest.mockImplementation(async (_env, path: string) => {
+      if (path.startsWith('feed?select=')) {
+        return [{ feed_id: 7, position_id: 101, user_id: 'owner' }];
+      }
+      if (path === 'user_comment?select=comment_id') {
+        return [{ comment_id: 22 }];
+      }
+      return [];
+    });
+    const reviewDeps = createReviewInteractionDeps({
+      loadSingleReview: vi.fn(async () => ({ id: '7', comments: [{ id: '22' }] })),
+      readSessionUser: vi.fn(async () => routeSessionUser),
+    });
+    const runtime = createRuntime();
+    runtime.buildReviewInteractionDeps = vi.fn(() => reviewDeps);
+
+    const response = await createRouteRequest(runtime)(
+      new Request(`${apiUrl}/api/reviews/7/comments`, {
+        method: 'POST',
+        body: JSON.stringify({ body: '좋아요' }),
+      }),
+      env,
+    );
+
+    expect(response.status).toBe(200);
+    expect(await readJson<Array<{ id: string }>>(response)).toEqual([{ id: '22' }]);
+    expect(reviewDeps.loadSingleReview).toHaveBeenCalledWith(env, '7', 'actor');
   });
 
   it('returns the existing fallback response when no origin is configured', async () => {


### PR DESCRIPTION
## Summary
- Fixes the Worker-first review/comment write path so notification side-effect failures no longer block persisted reviews or comments.
- Adds route-level regression coverage for `POST /api/reviews` and `POST /api/reviews/:id/comments`.
- Adds an opt-in protected write smoke script that can create a temporary review, add a comment, and delete the review when explicit smoke env is provided.

## Validation
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run test:integration`
- `npm.cmd run test:regression`
- `npm.cmd run build`
- `npm.cmd run smoke:protected:write` skipped by default with `SMOKE_WRITE_ENABLED is not true`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`

Closes #316
Closes #317
Closes #318
Refs #315