### PR TITLE
Fix mobile keyboard viewport jump in review composer

### DIFF
--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "bfb636ae83ca2447030669d81e132a5cda4c1047",
+  "generatedFrom": "1522b336acd675e8b8358a4d03a8d4400c94913d",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -3025,6 +3025,46 @@
           "value": "1",
           "line": 64,
           "column": 24
+        }
+      ]
+    },
+    {
+      "path": "scripts/run-protected-write-smoke-checks.ts",
+      "count": 9,
+      "owner": "tooling",
+      "category": "tooling-script-baseline",
+      "scopeId": "TSK-002-01-HARDCODED-VALUE-AUDIT",
+      "reason": "Build, smoke, sync, and data scripts are tracked by the audit baseline before later extraction decisions.",
+      "examples": [
+        {
+          "value": "201",
+          "line": 49,
+          "column": 50
+        },
+        {
+          "value": "201",
+          "line": 49,
+          "column": 79
+        },
+        {
+          "value": "200",
+          "line": 58,
+          "column": 51
+        },
+        {
+          "value": "200",
+          "line": 58,
+          "column": 81
+        },
+        {
+          "value": "200",
+          "line": 66,
+          "column": 52
+        },
+        {
+          "value": "200",
+          "line": 66,
+          "column": 82
         }
       ]
     },

--- a/src/lib/viewportMetrics.ts
+++ b/src/lib/viewportMetrics.ts
@@ -1,0 +1,47 @@
+export interface ViewportMetricsSnapshot {
+  innerHeight: number;
+  innerWidth: number;
+  visualViewportHeight?: number;
+  visualViewportWidth?: number;
+  activeElementTagName?: string;
+  activeElementIsContentEditable?: boolean;
+}
+
+export interface ViewportMetricsState {
+  appHeight: number;
+  appWidth: number;
+}
+
+export interface ResolvedViewportMetrics extends ViewportMetricsState {
+  visualHeight: number;
+  visualWidth: number;
+  isKeyboardResize: boolean;
+}
+
+const editableTagNames = new Set(['input', 'select', 'textarea']);
+
+function hasEditableFocus(snapshot: ViewportMetricsSnapshot) {
+  return Boolean(
+    snapshot.activeElementIsContentEditable
+      || (snapshot.activeElementTagName && editableTagNames.has(snapshot.activeElementTagName.toLowerCase())),
+  );
+}
+
+export function resolveViewportMetrics(
+  snapshot: ViewportMetricsSnapshot,
+  previousState?: ViewportMetricsState,
+): ResolvedViewportMetrics {
+  const layoutHeight = Math.round(snapshot.innerHeight);
+  const layoutWidth = Math.round(snapshot.innerWidth);
+  const visualHeight = Math.round(snapshot.visualViewportHeight ?? snapshot.innerHeight);
+  const visualWidth = Math.round(snapshot.visualViewportWidth ?? snapshot.innerWidth);
+  const isKeyboardResize = hasEditableFocus(snapshot) && visualHeight < layoutHeight;
+
+  return {
+    appHeight: isKeyboardResize ? (previousState?.appHeight ?? layoutHeight) : Math.max(layoutHeight, visualHeight),
+    appWidth: layoutWidth,
+    visualHeight,
+    visualWidth,
+    isKeyboardResize,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,7 @@
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { RoadmapBannerPreview } from './components/RoadmapBannerPreview';
+import { resolveViewportMetrics, type ViewportMetricsState } from './lib/viewportMetrics';
 import './index.css';
 import './styles/refinements.css';
 
@@ -9,15 +10,26 @@ if (typeof window !== 'undefined' && 'scrollRestoration' in window.history) {
   window.history.scrollRestoration = 'manual';
 }
 
+let viewportMetricsState: ViewportMetricsState | undefined;
+
 function syncViewportMetrics() {
   if (typeof window === 'undefined') {
     return;
   }
 
-  const viewportHeight = window.visualViewport?.height ?? window.innerHeight;
-  const viewportWidth = window.visualViewport?.width ?? window.innerWidth;
-  document.documentElement.style.setProperty('--app-height', `${Math.round(viewportHeight)}px`);
-  document.documentElement.style.setProperty('--app-width', `${Math.round(viewportWidth)}px`);
+  const activeElement = document.activeElement;
+  const metrics = resolveViewportMetrics({
+    innerHeight: window.innerHeight,
+    innerWidth: window.innerWidth,
+    visualViewportHeight: window.visualViewport?.height,
+    visualViewportWidth: window.visualViewport?.width,
+    activeElementTagName: activeElement instanceof HTMLElement ? activeElement.tagName : undefined,
+    activeElementIsContentEditable: activeElement instanceof HTMLElement ? activeElement.isContentEditable : undefined,
+  }, viewportMetricsState);
+
+  viewportMetricsState = metrics;
+  document.documentElement.style.setProperty('--app-height', `${metrics.appHeight}px`);
+  document.documentElement.style.setProperty('--app-width', `${metrics.appWidth}px`);
 }
 
 if (typeof window !== 'undefined') {

--- a/test/integration/place-detail-sheet.test.tsx
+++ b/test/integration/place-detail-sheet.test.tsx
@@ -86,4 +86,41 @@ describe('PlaceDetailSheet integration', () => {
 
     expect(screen.getByRole('button', { name: '오늘 스탬프 완료' })).toBeDisabled();
   });
+
+  it('keeps the review composer inside the scrollable drawer content in full mode', () => {
+    render(
+      <PlaceDetailSheet
+        place={placeFixture}
+        reviews={[reviewFixture]}
+        isOpen={true}
+        drawerState="full"
+        loggedIn={true}
+        visitCount={2}
+        latestStamp={todayStampFixture}
+        todayStamp={todayStampFixture}
+        hasCreatedReviewToday={false}
+        stampActionStatus="ready"
+        stampActionMessage="오늘 스탬프를 이미 찍었어요."
+        reviewProofMessage="방문 후 피드를 작성해 주세요."
+        reviewError={null}
+        reviewSubmitting={false}
+        canCreateReview={true}
+        onOpenFeedReview={vi.fn()}
+        onClose={vi.fn()}
+        onExpand={vi.fn()}
+        onCollapse={vi.fn()}
+        onRequestLogin={vi.fn()}
+        onClaimStamp={vi.fn().mockResolvedValue(undefined)}
+        onCreateReview={vi.fn().mockResolvedValue(undefined)}
+      />,
+    );
+
+    const textarea = screen.getByRole('textbox');
+    const drawerContent = textarea.closest('.place-drawer__content');
+    const drawer = textarea.closest('.place-drawer');
+
+    expect(textarea).toBeEnabled();
+    expect(drawerContent).not.toBeNull();
+    expect(drawer).toHaveClass('place-drawer--full');
+  });
 });

--- a/test/unit/viewportMetrics.test.ts
+++ b/test/unit/viewportMetrics.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { resolveViewportMetrics } from '../../src/lib/viewportMetrics';
+
+describe('resolveViewportMetrics', () => {
+  it('keeps stable app height when an editable field opens the iOS keyboard', () => {
+    const previous = resolveViewportMetrics({
+      innerHeight: 844,
+      innerWidth: 390,
+      visualViewportHeight: 844,
+      visualViewportWidth: 390,
+    });
+
+    const next = resolveViewportMetrics({
+      innerHeight: 844,
+      innerWidth: 390,
+      visualViewportHeight: 512,
+      visualViewportWidth: 390,
+      activeElementTagName: 'textarea',
+    }, previous);
+
+    expect(next.isKeyboardResize).toBe(true);
+    expect(next.appHeight).toBe(844);
+    expect(next.visualHeight).toBe(512);
+  });
+
+  it('updates stable app height for normal viewport resize', () => {
+    const previous = resolveViewportMetrics({
+      innerHeight: 844,
+      innerWidth: 390,
+      visualViewportHeight: 844,
+      visualViewportWidth: 390,
+    });
+
+    const next = resolveViewportMetrics({
+      innerHeight: 700,
+      innerWidth: 390,
+      visualViewportHeight: 700,
+      visualViewportWidth: 390,
+    }, previous);
+
+    expect(next.isKeyboardResize).toBe(false);
+    expect(next.appHeight).toBe(700);
+  });
+
+  it('restores stable metrics when the keyboard closes', () => {
+    const keyboardState = resolveViewportMetrics({
+      innerHeight: 844,
+      innerWidth: 390,
+      visualViewportHeight: 512,
+      visualViewportWidth: 390,
+      activeElementTagName: 'input',
+    }, { appHeight: 844, appWidth: 390 });
+
+    const next = resolveViewportMetrics({
+      innerHeight: 844,
+      innerWidth: 390,
+      visualViewportHeight: 844,
+      visualViewportWidth: 390,
+      activeElementTagName: 'input',
+    }, keyboardState);
+
+    expect(next.isKeyboardResize).toBe(false);
+    expect(next.appHeight).toBe(844);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the mobile keyboard viewport jump by keeping `--app-height` stable while an editable field owns focus and `visualViewport.height` shrinks.
- Extracts viewport metric calculation into a testable helper.
- Adds regression coverage for iOS keyboard-style viewport shrink and the PlaceDetailSheet review composer scroll container.
- Updates the numeric literal baseline for the pre-existing protected write smoke script drift so the required quality gate passes.

## Scope
- No user-facing copy changes.
- No API path/response shape changes.
- No DB schema changes.
- No OAuth flow changes.
- Existing mojibake strings are intentionally not repaired in this PR.

## Validation
- `npm.cmd run check:numeric-literals`
- `npm.cmd run lint`
- `npm.cmd run typecheck`
- `npm.cmd run test:unit`
- `npm.cmd run test:integration`
- `npm.cmd run build`
- `git diff --check`
- `.\.tools\python313\python.exe .tmp\check_utf8_integrity.py --staged`

## Manual QA Gap
- iPhone Safari/WebView manual verification is still required after merge/deploy, so #321 should remain open until that evidence is recorded.

Refs #321
Refs #320