### PR TITLE
Optimize place name dictionary building

### DIFF
--- a/src/hooks/app-view-models/placeSelections.ts
+++ b/src/hooks/app-view-models/placeSelections.ts
@@ -48,5 +48,11 @@ export function getSelectedFestival(festivals: FestivalItem[], selectedFestivalI
 }
 
 export function buildPlaceNameById(places: Place[]) {
-  return Object.fromEntries(places.map((place) => [place.id, place.name]));
+  // ⚡ Bolt optimization: Use a single for...of loop instead of Object.fromEntries(array.map(...))
+  // to avoid O(N) memory allocation for intermediate tuple arrays.
+  const placeNameById: Record<string, string> = {};
+  for (const place of places) {
+    placeNameById[place.id] = place.name;
+  }
+  return placeNameById;
 }

--- a/src/hooks/app-view-models/placeSelections.ts
+++ b/src/hooks/app-view-models/placeSelections.ts
@@ -48,7 +48,7 @@ export function getSelectedFestival(festivals: FestivalItem[], selectedFestivalI
 }
 
 export function buildPlaceNameById(places: Place[]) {
-  // ⚡ Bolt optimization: Use a single for...of loop instead of Object.fromEntries(array.map(...))
+  // Use a single for...of loop instead of Object.fromEntries(array.map(...))
   // to avoid O(N) memory allocation for intermediate tuple arrays.
   const placeNameById: Record<string, string> = {};
   for (const place of places) {


### PR DESCRIPTION
💡 **What**: Refactored `buildPlaceNameById` in `src/hooks/app-view-models/placeSelections.ts` to use a `for...of` loop instead of `Object.fromEntries(places.map(...))`.
🎯 **Why**: The previous implementation created an unnecessary intermediate array of tuples, resulting in O(N) memory allocation and slower execution, particularly when processing large place collections during view model memoization.
📊 **Impact**: Eliminates the intermediate tuple array allocation, improving memory efficiency and speed for this frequently called utility.
🔬 **Measurement**: Run `npm run test:all` to ensure no regressions in routing or map view models. Behavior remains functionally identical.

---
*PR created automatically by Jules for task [2091026185255254835](https://jules.google.com/task/2091026185255254835) started by @ClarusIubar*