### PR TITLE
Restrict permissive CORS policy with credentials

### DIFF
--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -113,6 +113,14 @@ class Settings(BaseSettings):
             if not jwt_secret or jwt_secret == insecure_jwt_secret:
                 raise ValueError("APP_JWT_SECRET must be explicitly set to a secure value in production")
 
+        # Wildcard origins are insecure when allow_credentials=True.
+        # FastAPI's CORSMiddleware also blocks ["*"] + allow_credentials=True at runtime.
+        cors_origins = data.get("cors_origins", "")
+        if isinstance(cors_origins, str):
+            origins = [o.strip() for o in cors_origins.split(",") if o.strip()]
+            if "*" in origins:
+                raise ValueError("Wildcard '*' in APP_CORS_ORIGINS is not allowed when credentials are enabled")
+
         return data
 
     @property

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -33,8 +33,8 @@ app.add_middleware(
     CORSMiddleware,
     allow_origins=settings.cors_origin_list,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PATCH", "DELETE", "OPTIONS"],
+    allow_headers=["Content-Type", "Authorization"],
 )
 app.add_middleware(
     SessionMiddleware,

--- a/backend/tests/test_cors_middleware.py
+++ b/backend/tests/test_cors_middleware.py
@@ -1,0 +1,9 @@
+from app.main import app
+
+
+def test_cors_middleware_restricts_methods_and_headers() -> None:
+    cors = next(m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware")
+
+    assert cors.kwargs["allow_credentials"] is True
+    assert cors.kwargs["allow_methods"] == ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]
+    assert cors.kwargs["allow_headers"] == ["Content-Type", "Authorization"]

--- a/backend/tests/test_cors_middleware.py
+++ b/backend/tests/test_cors_middleware.py
@@ -1,8 +1,10 @@
+from fastapi.middleware.cors import CORSMiddleware
+
 from app.main import app
 
 
 def test_cors_middleware_restricts_methods_and_headers() -> None:
-    cors = next((m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"), None)
+    cors = next((m for m in app.user_middleware if m.cls is CORSMiddleware), None)
     assert cors is not None
 
     assert cors.kwargs["allow_credentials"] is True

--- a/backend/tests/test_cors_middleware.py
+++ b/backend/tests/test_cors_middleware.py
@@ -2,7 +2,8 @@ from app.main import app
 
 
 def test_cors_middleware_restricts_methods_and_headers() -> None:
-    cors = next(m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware")
+    cors = next((m for m in app.user_middleware if m.cls.__name__ == "CORSMiddleware"), None)
+    assert cors is not None
 
     assert cors.kwargs["allow_credentials"] is True
     assert cors.kwargs["allow_methods"] == ["GET", "POST", "PATCH", "DELETE", "OPTIONS"]


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed is a permissive CORS policy where `allow_credentials=True` was used with potentially dynamic or wildcard origins.

⚠️ **Risk:** Allowing wildcard origins with credentials enables Cross-Origin attacks, where a malicious site can make authenticated requests to the API on behalf of a user.

🛡️ **Solution:**
1.  **Restrict `CORSMiddleware`:** Updated `backend/app/main.py` to use explicit lists for `allow_methods` (`GET`, `POST`, `PATCH`, `DELETE`, `OPTIONS`) and `allow_headers` (`Content-Type`, `Authorization`) instead of wildcards.
2.  **Origin Validation:** Added a `model_validator` in `backend/app/config.py` that raises a `ValueError` if the `APP_CORS_ORIGINS` configuration contains a wildcard `*`. This ensures that the application cannot be started in an insecure state.
3.  **Secure Defaults:** These changes ensure that even if the framework allows it, the application enforces a "secure by default" policy for CORS and credentials.

---
*PR created automatically by Jules for task [13188186348445739387](https://jules.google.com/task/13188186348445739387) started by @ClarusIubar*