### PR TITLE
Reduce redundant array iterations and lookups across React hooks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,7 @@
+## 2024-05-18 - Passing Down Objects Prevents Redundant Lookups
+**Learning:** In deeply nested component trees like `NaverMap`, passing only an ID (`selectedPlaceId`) requires child components or hooks to repeatedly iterate over large state arrays (`places.find`) on every render or state change. This causes redundant $O(N)$ lookups. Similarly, action handlers like `onToggleReviewLike` can bypass finding the targeted object entirely if the list item component itself passes the already-known object reference as an argument.
+**Action:** When designing component props or event handler signatures in list views or heavily memoized trees, prefer passing the fully resolved object reference (e.g., `selectedPlace`, `knownReview`) alongside the ID, or use it directly instead of performing repeated lookups.
+
+## 2024-05-18 - Array Updates: findIndex vs some + map
+**Learning:** Using `current.some(condition) ? current.map(updateFn) : current` to update an array involves two $O(N)$ passes and creates a full array copy where every element runs through the map function.
+**Action:** For targeted array updates, use `const idx = current.findIndex(condition)` first. If found, copy the array `const next = [...current]` and update only the targeted element `next[idx] = updateFn(current[idx])`. This executes a single $O(N)$ search and an $O(1)$ update operation, bypassing unnecessary iteration while maintaining referential stability.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,7 +1,0 @@
-## 2024-05-18 - Passing Down Objects Prevents Redundant Lookups
-**Learning:** In deeply nested component trees like `NaverMap`, passing only an ID (`selectedPlaceId`) requires child components or hooks to repeatedly iterate over large state arrays (`places.find`) on every render or state change. This causes redundant $O(N)$ lookups. Similarly, action handlers like `onToggleReviewLike` can bypass finding the targeted object entirely if the list item component itself passes the already-known object reference as an argument.
-**Action:** When designing component props or event handler signatures in list views or heavily memoized trees, prefer passing the fully resolved object reference (e.g., `selectedPlace`, `knownReview`) alongside the ID, or use it directly instead of performing repeated lookups.
-
-## 2024-05-18 - Array Updates: findIndex vs some + map
-**Learning:** Using `current.some(condition) ? current.map(updateFn) : current` to update an array involves two $O(N)$ passes and creates a full array copy where every element runs through the map function.
-**Action:** For targeted array updates, use `const idx = current.findIndex(condition)` first. If found, copy the array `const next = [...current]` and update only the targeted element `next[idx] = updateFn(current[idx])`. This executes a single $O(N)$ search and an $O(1)$ update operation, bypassing unnecessary iteration while maintaining referential stability.

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "7e3820dfeb5d739fe65ec1ba7b41f7a27c6ab3cb",
+  "generatedFrom": "934357ff0da3fc21f4cb9936110404fac5a92a75",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -523,32 +523,32 @@
       "examples": [
         {
           "value": "1.0",
-          "line": 100,
+          "line": 104,
           "column": 29
         },
         {
           "value": "0",
-          "line": 119,
+          "line": 133,
           "column": 24
         },
         {
           "value": "1",
-          "line": 135,
+          "line": 151,
           "column": 33
         },
         {
           "value": "1",
-          "line": 146,
+          "line": 162,
           "column": 62
         },
         {
           "value": "0",
-          "line": 166,
+          "line": 182,
           "column": 23
         },
         {
           "value": "1",
-          "line": 208,
+          "line": 234,
           "column": 36
         }
       ]
@@ -3878,7 +3878,7 @@
       "examples": [
         {
           "value": "100%",
-          "line": 41,
+          "line": 43,
           "column": 17
         }
       ]
@@ -4213,7 +4213,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 44,
+          "line": 48,
           "column": 56
         }
       ]
@@ -4268,7 +4268,7 @@
       "examples": [
         {
           "value": "0",
-          "line": 71,
+          "line": 75,
           "column": 23
         }
       ]
@@ -4283,12 +4283,12 @@
       "examples": [
         {
           "value": "100%",
-          "line": 45,
+          "line": 49,
           "column": 13
         },
         {
           "value": "100%",
-          "line": 92,
+          "line": 98,
           "column": 49
         }
       ]
@@ -4664,6 +4664,36 @@
       ]
     },
     {
+      "path": "src/hooks/app-data/useReviewCollectionState.ts",
+      "count": 4,
+      "owner": "frontend-ui",
+      "category": "frontend-ui-inline-token-baseline",
+      "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",
+      "reason": "Frontend component, hook, store, and UI-domain numeric values are classified for token or config review.",
+      "examples": [
+        {
+          "value": "-1",
+          "line": 26,
+          "column": 19
+        },
+        {
+          "value": "-1",
+          "line": 34,
+          "column": 19
+        },
+        {
+          "value": "-1",
+          "line": 46,
+          "column": 21
+        },
+        {
+          "value": "-1",
+          "line": 59,
+          "column": 19
+        }
+      ]
+    },
+    {
       "path": "src/hooks/app-navigation/shellBackNavigation.ts",
       "count": 2,
       "owner": "frontend-ui",
@@ -4798,22 +4828,22 @@
       "examples": [
         {
           "value": "0",
-          "line": 30,
+          "line": 31,
           "column": 58
         },
         {
           "value": "0",
-          "line": 32,
+          "line": 33,
           "column": 42
         },
         {
           "value": "1",
-          "line": 32,
+          "line": 33,
           "column": 88
         },
         {
           "value": "-1",
-          "line": 32,
+          "line": 33,
           "column": 92
         }
       ]

--- a/src/components/FeedTab.tsx
+++ b/src/components/FeedTab.tsx
@@ -33,7 +33,7 @@ interface FeedTabProps {
   };
   feedActions: {
     onLoadMore: () => Promise<void>;
-    onToggleReviewLike: (reviewId: string) => Promise<void>;
+    onToggleReviewLike: (reviewId: string, knownReview?: Review) => Promise<void>;
     onCreateComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
     onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
     onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;

--- a/src/components/NaverMap.tsx
+++ b/src/components/NaverMap.tsx
@@ -12,6 +12,8 @@ interface NaverMapProps {
   festivals: FestivalItem[];
   selectedPlaceId: string | null;
   selectedFestivalId: string | null;
+  selectedPlace?: Place | null;
+  selectedFestival?: FestivalItem | null;
   onSelectPlace: (placeId: string) => void;
   onSelectFestival: (festivalId: string) => void;
   currentPosition: { latitude: number; longitude: number } | null;
@@ -31,6 +33,8 @@ export function NaverMap({
   festivals,
   selectedPlaceId,
   selectedFestivalId,
+  selectedPlace = null,
+  selectedFestival = null,
   onSelectPlace,
   onSelectFestival,
   currentPosition,
@@ -71,6 +75,8 @@ export function NaverMap({
     festivals,
     selectedPlaceId,
     selectedFestivalId,
+    selectedPlace,
+    selectedFestival,
     onSelectPlace,
     onSelectFestival,
     currentPosition,

--- a/src/components/ReviewList.tsx
+++ b/src/components/ReviewList.tsx
@@ -12,7 +12,7 @@ interface ReviewListProps {
   highlightedReviewId?: string | null;
   likingReviewId: string | null;
   submittingReviewId: string | null;
-  onToggleLike: (reviewId: string) => Promise<void>;
+  onToggleLike: (reviewId: string, knownReview?: Review) => Promise<void>;
   onSubmitComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
   onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
   onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;

--- a/src/components/map-stage/MapStageMapSurface.tsx
+++ b/src/components/map-stage/MapStageMapSurface.tsx
@@ -27,6 +27,8 @@ export function MapStageMapSurface({
         festivals={mapData.festivals}
         selectedPlaceId={placeSheet.selectedPlace?.id ?? null}
         selectedFestivalId={festivalSheet.selectedFestival?.id ?? null}
+        selectedPlace={placeSheet.selectedPlace ?? null}
+        selectedFestival={festivalSheet.selectedFestival ?? null}
         onSelectPlace={placeSheet.onOpenPlace}
         onSelectFestival={festivalSheet.onOpenFestival}
         currentPosition={mapData.currentPosition}

--- a/src/components/naver-map/useNaverMapInteractions.ts
+++ b/src/components/naver-map/useNaverMapInteractions.ts
@@ -17,6 +17,8 @@ type MapInteractionsArgs = {
   festivals: FestivalItem[];
   selectedPlaceId: string | null;
   selectedFestivalId: string | null;
+  selectedPlace?: Place | null;
+  selectedFestival?: FestivalItem | null;
   onSelectPlace: (placeId: string) => void;
   onSelectFestival: (festivalId: string) => void;
   currentPosition: { latitude: number; longitude: number } | null;
@@ -33,6 +35,8 @@ export function useNaverMapInteractions({
   festivals,
   selectedPlaceId,
   selectedFestivalId,
+  selectedPlace,
+  selectedFestival,
   onSelectPlace,
   onSelectFestival,
   currentPosition,
@@ -77,6 +81,8 @@ export function useNaverMapInteractions({
     festivals,
     selectedPlaceId,
     selectedFestivalId,
+    selectedPlace,
+    selectedFestival,
   });
 
   useNaverCurrentLocationFocus({

--- a/src/components/naver-map/useNaverSelectionSync.ts
+++ b/src/components/naver-map/useNaverSelectionSync.ts
@@ -14,6 +14,8 @@ type SelectionSyncArgs = {
   festivals: FestivalItem[];
   selectedPlaceId: string | null;
   selectedFestivalId: string | null;
+  selectedPlace?: Place | null;
+  selectedFestival?: FestivalItem | null;
 };
 
 export function useNaverSelectionSync({
@@ -25,19 +27,21 @@ export function useNaverSelectionSync({
   festivals,
   selectedPlaceId,
   selectedFestivalId,
+  selectedPlace,
+  selectedFestival,
 }: SelectionSyncArgs) {
   useEffect(() => {
     if (status !== 'ready' || !mapsApi || !mapRef.current) {
       return;
     }
 
-    const selectedPlace = selectedPlaceId ? places.find((place) => place.id === selectedPlaceId) : null;
-    const selectedFestival = selectedFestivalId ? festivals.find((festival) => festival.id === selectedFestivalId) : null;
-    const targetType = selectedPlace ? 'place' : selectedFestival ? 'festival' : null;
-    const target = selectedPlace
-      ? { latitude: selectedPlace.latitude, longitude: selectedPlace.longitude }
-      : selectedFestival && hasFestivalCoordinates(selectedFestival)
-        ? { latitude: selectedFestival.latitude, longitude: selectedFestival.longitude }
+    const targetPlace = selectedPlace || (selectedPlaceId ? places.find((place) => place.id === selectedPlaceId) : null);
+    const targetFestival = selectedFestival || (selectedFestivalId ? festivals.find((festival) => festival.id === selectedFestivalId) : null);
+    const targetType = targetPlace ? 'place' : targetFestival ? 'festival' : null;
+    const target = targetPlace
+      ? { latitude: targetPlace.latitude, longitude: targetPlace.longitude }
+      : targetFestival && hasFestivalCoordinates(targetFestival)
+        ? { latitude: targetFestival.latitude, longitude: targetFestival.longitude }
         : null;
 
     if (!target || !targetType) {
@@ -72,5 +76,5 @@ export function useNaverSelectionSync({
         }
       }, panDelayMs);
     }
-  }, [festivals, mapElementRef, mapRef, mapsApi, places, selectedFestivalId, selectedPlaceId, status]);
+  }, [festivals, mapElementRef, mapRef, mapsApi, places, selectedFestival, selectedFestivalId, selectedPlace, selectedPlaceId, status]);
 }

--- a/src/components/review/ReviewListItem.tsx
+++ b/src/components/review/ReviewListItem.tsx
@@ -14,7 +14,7 @@ interface ReviewListItemProps {
   canToggleLike: boolean;
   isLiking: boolean;
   isSubmitting: boolean;
-  onToggleLike: (reviewId: string) => Promise<void>;
+  onToggleLike: (reviewId: string, knownReview?: Review) => Promise<void>;
   onSubmitComment: (reviewId: string, body: string, parentId?: string) => Promise<void>;
   onUpdateComment: (reviewId: string, commentId: string, body: string) => Promise<void>;
   onDeleteComment: (reviewId: string, commentId: string) => Promise<void>;
@@ -69,7 +69,7 @@ export const ReviewListItem = memo(function ReviewListItem({
             type="button"
             className={review.likedByMe ? 'review-action-button is-active' : 'review-action-button'}
             disabled={isLiking}
-            onClick={() => (canToggleLike ? onToggleLike(review.id) : onRequestLogin())}
+            onClick={() => (canToggleLike ? onToggleLike(review.id, review) : onRequestLogin())}
             aria-pressed={review.likedByMe}
           >
             <span className="review-action-button__icon" aria-hidden="true">

--- a/src/hooks/app-data/useReviewCollectionState.ts
+++ b/src/hooks/app-data/useReviewCollectionState.ts
@@ -12,29 +12,54 @@ export function useReviewCollectionState(selectedPlaceId: string | null) {
   const coursesLoadedRef = useRef(false);
 
   function patchReviewCollections(reviewId: string, updater: (review: ReviewSummary) => ReviewSummary) {
-    const patchFn = (r: ReviewSummary) => (r.id === reviewId ? toReviewSummary(updater(r)) : r);
     const hasReview = (r: ReviewSummary) => r.id === reviewId;
+    let patchedReview: ReviewSummary | null = null;
+    const getPatched = (original: ReviewSummary) => {
+      if (!patchedReview) {
+        patchedReview = toReviewSummary(updater(original));
+      }
+      return patchedReview;
+    };
 
-    setReviews((current) => (current.some(hasReview) ? current.map(patchFn) : current));
-    setSelectedPlaceReviews((current) => (current.some(hasReview) ? current.map(patchFn) : current));
+    setReviews((current) => {
+      const idx = current.findIndex(hasReview);
+      if (idx === -1) return current;
+      const next = [...current];
+      next[idx] = getPatched(current[idx]);
+      return next;
+    });
 
-    const existingReview =
-      reviews.find(hasReview) || selectedPlaceReviews.find(hasReview);
+    setSelectedPlaceReviews((current) => {
+      const idx = current.findIndex(hasReview);
+      if (idx === -1) return current;
+      const next = [...current];
+      next[idx] = getPatched(current[idx]);
+      return next;
+    });
 
+    const existingReview = reviews.find(hasReview) || selectedPlaceReviews.find(hasReview);
     if (existingReview) {
       const { placeId } = existingReview;
       const collection = placeReviewsCacheRef.current[placeId];
-      if (collection && collection.some(hasReview)) {
-        placeReviewsCacheRef.current[placeId] = collection.map(patchFn);
-        return;
+      if (collection) {
+        const idx = collection.findIndex(hasReview);
+        if (idx !== -1) {
+          const next = [...collection];
+          next[idx] = getPatched(collection[idx]);
+          placeReviewsCacheRef.current[placeId] = next;
+          return;
+        }
       }
     }
 
     const cache = placeReviewsCacheRef.current;
     for (const placeId of Object.keys(cache)) {
       const collection = cache[placeId];
-      if (collection.some(hasReview)) {
-        cache[placeId] = collection.map(patchFn);
+      const idx = collection.findIndex(hasReview);
+      if (idx !== -1) {
+        const next = [...collection];
+        next[idx] = getPatched(collection[idx]);
+        cache[placeId] = next;
         break;
       }
     }

--- a/src/hooks/useAppReviewLikeActions.ts
+++ b/src/hooks/useAppReviewLikeActions.ts
@@ -2,6 +2,7 @@ import { useEventCallback } from './useEventCallback';
 import { toggleReviewLike } from '../api/reviewsClient';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import type { UseAppReviewActionsParams } from './useAppReviewActions.types';
+import type { Review } from '../types/review';
 
 export function useAppReviewLikeActions({
   sessionUser,
@@ -15,14 +16,15 @@ export function useAppReviewLikeActions({
 }: UseAppReviewActionsParams) {
   const setReviewLikeUpdatingId = useAppPageRuntimeStore((state) => state.setReviewLikeUpdatingId);
 
-  const handleToggleReviewLike = useEventCallback(async (reviewId: string) => {
+  const handleToggleReviewLike = useEventCallback(async (reviewId: string, knownReview?: Review) => {
     if (!sessionUser) {
       goToTab('my');
       setNotice('좋아요를 누르려면 먼저 로그인해 주세요.');
       return;
     }
 
-    const targetReview = reviews.find((review) => review.id === reviewId)
+    const targetReview = knownReview
+      ?? reviews.find((review) => review.id === reviewId)
       ?? selectedPlaceReviews.find((review) => review.id === reviewId)
       ?? myPage?.reviews.find((review) => review.id === reviewId)
       ?? null;

--- a/test/regression/review-list.test.tsx
+++ b/test/regression/review-list.test.tsx
@@ -39,7 +39,7 @@ describe('ReviewList regression', () => {
     expect(article).toHaveClass('review-card--feed');
 
     fireEvent.click(getByRole('button', { name: String(review.likeCount) }));
-    expect(onToggleLike).toHaveBeenCalledWith(review.id);
+    expect(onToggleLike).toHaveBeenCalledWith(review.id, review);
 
     fireEvent.click(getByRole('button', { name: /댓글 4개/ }));
     expect(onOpenComments).toHaveBeenCalledWith(review.id);


### PR DESCRIPTION
🎯 What
- Implemented three targeted performance optimizations in React components and hooks to reduce O(N) array operations.
- Modified `useNaverSelectionSync.ts` and `NaverMap.tsx` to accept the fully resolved `selectedPlace` and `selectedFestival` objects via props.
- Refactored `useAppReviewLikeActions.ts` and `ReviewListItem.tsx` to pass the known `review` reference to the `onToggleReviewLike` action.
- Optimized the state update logic in `useReviewCollectionState.ts` (`patchReviewCollections`) to use a single `findIndex` targeted update instead of a `some` and `map` double-iteration.

⚠️ Risk
- Medium. The API changes in `NaverMap` ensure backwards compatibility via fallback `.find()` lookup logic. Type signatures were carefully updated.

🛡️ Solution
- Bypassed redundant lookups in `useNaverSelectionSync` by passing already-computed objects from the top-level `useAppViewModels` layer.
- Bypassed the target review lookup by accepting `knownReview` directly from the list item component's click handler.
- Reduced the two-pass `$O(2N)$` array recreation down to an `$O(N)$` search and `$O(1)$` targeted modification, while accurately propagating changes to React state and cached references.

---
*PR created automatically by Jules for task [7974107065652216230](https://jules.google.com/task/7974107065652216230) started by @ClarusIubar*