### PR TITLE
ci: Cloudflare Pages secret 없는 PR 빌드 통과 처리

### DIFF
--- a/.github/workflows/cloudflare-pages.yml
+++ b/.github/workflows/cloudflare-pages.yml
@@ -34,7 +34,21 @@ jobs:
           registry-username: ${{ github.actor }}
           registry-password: ${{ secrets.GITHUB_TOKEN }}
       - run: npm ci --prefer-offline --no-audit
+      - name: Resolve Cloudflare deployment availability
+        id: cloudflare
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          set -euo pipefail
+          if [ -n "${CLOUDFLARE_API_TOKEN}" ] && [ -n "${CLOUDFLARE_ACCOUNT_ID}" ]; then
+            echo "can_deploy=true" >> "${GITHUB_OUTPUT}"
+          else
+            echo "can_deploy=false" >> "${GITHUB_OUTPUT}"
+            echo "Cloudflare credentials are unavailable; running build-only Pages validation."
+          fi
       - name: Ensure Pages project exists and production branch is main
+        if: steps.cloudflare.outputs.can_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -65,6 +79,7 @@ jobs:
       - name: Build static frontend
         run: npm run build
       - name: Publish to Cloudflare Pages
+        if: steps.cloudflare.outputs.can_deploy == 'true'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## 요약
- Dependabot PR처럼 GitHub Actions에서 Cloudflare secret이 제공되지 않는 경우 Pages 배포성 단계를 스킵합니다.
- 
pm ci와 정적 프론트 빌드는 유지해서 PR 검증은 계속 수행합니다.
- main/수동 실행처럼 Cloudflare credential이 있는 경우 기존 프로젝트 확인과 Pages 배포 경로는 유지됩니다.

## 원인
- PR #345 cloudflare-pages의 deploy-pages job에서 CLOUDFLARE_API_TOKEN, CLOUDFLARE_ACCOUNT_ID가 빈 값이었지만 Cloudflare API 호출이 실행되었습니다.
- Dependabot 보안 PR에서는 repo secret이 비어 들어올 수 있어 배포 단계가 실패했습니다.

## 검증
- git diff --check
- Python YAML parse: yaml.safe_load(.github/workflows/cloudflare-pages.yml)

## 참고
- PR #345의 ws 업데이트 자체는 ci/frontend가 통과했습니다.
- 이 PR이 main에 들어간 뒤 PR #345를 re-run/rebase하면 cloudflare-pages는 build-only 검증으로 통과해야 합니다.