### PR TITLE
docs: API contract 소유권 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # JamIssue Web Front
 
-`STH-1-Class-One-Group/JamIssue`는 JamIssue의 공개 Web Front SPA 레포입니다.
+`STH-1-Class-One-Group/JamIssue`는 JamIssue 공개 Web Front SPA 레포입니다.
 
-이 레포는 사용자가 접속하는 React 기반 Web Front와 Cloudflare Pages 배포만 담당합니다. Backend API, Cloudflare Worker, DB schema/migration, 관리자 페이지, provider-side API contract의 정본은 `ClarusIubar/JamIssue_admin`입니다.
+이 레포는 사용자가 접속하는 React 기반 Web Front와 Cloudflare Pages 배포만 담당합니다. Backend API 구현, Cloudflare Worker, DB schema/migration, 관리자 페이지, provider-side API contract의 정본은 `ClarusIubar/JamIssue_admin`에서 관리합니다.
 
 ## 이 레포가 소유하는 것
 
@@ -10,8 +10,9 @@
 - 사용자-facing React UI
 - Cloudflare Pages 배포 설정
 - public client environment 설정
-- Web Front build, typecheck, smoke, UI 테스트
+- Web Front build, typecheck, lint, smoke, UI test
 - API consumer-side compatibility 확인
+- 프론트가 기대하는 API request/response 타입
 
 ## 이 레포가 소유하지 않는 것
 
@@ -24,6 +25,17 @@
 - provider-side API contract test
 
 위 항목은 `ClarusIubar/JamIssue_admin`에서 관리합니다.
+
+## API Contract 기준
+
+이 레포에는 backend 구현이 없습니다. 대신 Web Front가 소비하는 API 계약만 남아 있습니다.
+
+- API client: [src/api](src/api)
+- Consumer-side DTO/type: [src/types.ts](src/types.ts), [src/types](src/types)
+- API base URL 설정: [src/config](src/config)
+- API contract 소유권 문서: [docs/api-contract-ownership.md](docs/api-contract-ownership.md)
+
+Provider-side API contract, Worker handler, DB row/schema, migration, OAuth runtime contract는 `ClarusIubar/JamIssue_admin`이 정본입니다.
 
 ## Runtime Configuration
 
@@ -43,7 +55,7 @@ PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_ANON_KEY=
 ```
 
-이 레포에는 public client env만 둡니다. service-role key, OAuth secret, Worker runtime secret, DB migration credential은 두지 않습니다.
+이 레포에는 public client env만 둡니다. service-role key, OAuth secret, Worker runtime secret, DB migration credential은 저장하지 않습니다.
 
 ## Cloudflare
 
@@ -65,9 +77,10 @@ npm.cmd run smoke:public
 
 ## 문서 기준
 
-- Web Front 개발/배포/SPA 운영 문서: [이 레포의 Wiki](https://github.com/STH-1-Class-One-Group/JamIssue/wiki)
+- Web Front 개발/배포/SPA 운영 문서: [docs/README.md](docs/README.md)
+- Web Front Wiki: [JamIssue Wiki](https://github.com/STH-1-Class-One-Group/JamIssue/wiki)
 - Backend/API/Worker/DB/admin 문서: [`ClarusIubar/JamIssue_admin` Wiki](https://github.com/ClarusIubar/JamIssue_admin/wiki)
-- 이관 이슈와 완료 evidence: [`ClarusIubar/JamIssue_admin` issue tree](https://github.com/ClarusIubar/JamIssue_admin/issues)
+- Backend/API 완료 evidence: [`ClarusIubar/JamIssue_admin` issue tree](https://github.com/ClarusIubar/JamIssue_admin/issues)
 
 관련 이관 이슈:
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,12 +1,22 @@
 # Docs Guide
 
-JamIssue 문서는 아래 기준으로 관리합니다.
+JamIssue Web Front 문서는 아래 기준으로 관리합니다.
 
-## 1. 제품 기준 문서
+## 1. 현재 정본 문서
 
+- [api-contract-ownership.md](api-contract-ownership.md)
+  - Web Front가 소유하는 consumer-side API contract
+  - `ClarusIubar/JamIssue_admin`이 소유하는 provider-side API contract
+  - backend 제거 이후 이 레포에 남아 있는 API 관련 파일 위치
 - [prd-compliance.md](prd-compliance.md)
   - PRD 대비 현재 구현 상태
   - 구현됨 / 부분 구현 / 미구현 구분
+- [ui-ux-qa-matrix.md](ui-ux-qa-matrix.md)
+  - UI/UX 기대 동작 추적
+  - 자동 테스트와 수동 QA 근거 연결
+- [testing-coverage.md](testing-coverage.md)
+  - 테스트/커버리지 기준
+  - Web Front 검증 명령
 
 ## 2. 배포 기준 문서
 
@@ -18,18 +28,38 @@ JamIssue 문서는 아래 기준으로 관리합니다.
   - 장소, 이미지, 공공데이터 운영 수정 절차
   - 전체 리셋 및 재적재 절차
 
-## 3. 세부 설계 문서
+주의: Backend/API/Worker/DB/admin 운영 절차의 정본은 `ClarusIubar/JamIssue_admin`입니다. 이 레포의 runbook은 Web Front 관점에서 필요한 참조만 유지합니다.
+
+## 3. 화면/기능 설계 문서
 
 - [screen-spec.md](screen-spec.md)
 - [community-routes.md](community-routes.md)
-- [notification-sse-architecture.md](notification-sse-architecture.md)
 - [account-identity-schema.md](account-identity-schema.md)
-- [code-flow-diagrams.md](code-flow-diagrams.md)
+- [search-recommendation-scope.md](search-recommendation-scope.md)
+
+## 4. 리팩터링과 추적성 문서
+
 - [operations-refactor-roadmap.md](operations-refactor-roadmap.md)
-
-## 4. 리팩터링 추적 문서
-
 - [worker-backend-solid-traceability.md](worker-backend-solid-traceability.md)
 - [config-hardening-traceability.md](config-hardening-traceability.md)
 - [interface-locality-baseline.md](interface-locality-baseline.md)
 - [interface-locality-traceability.md](interface-locality-traceability.md)
+- [architecture-regression-traceability.md](architecture-regression-traceability.md)
+- [human-readable-architecture-baseline.md](human-readable-architecture-baseline.md)
+- [human-readable-architecture-traceability.md](human-readable-architecture-traceability.md)
+- [release-1.2.10-traceability.md](release-1.2.10-traceability.md)
+
+## 5. Legacy/reference 문서
+
+아래 문서는 Web Front와 backend가 같은 레포에 있던 시기의 설계/분석 기록을 포함할 수 있습니다. 최신 backend/API 정본으로 사용하지 않습니다.
+
+- [code-flow-diagrams.md](code-flow-diagrams.md)
+- [notification-sse-architecture.md](notification-sse-architecture.md)
+- [issue-55-improved.md](issue-55-improved.md)
+- [worker-first-poc.md](worker-first-poc.md)
+- [worker-backend-solid-baseline.md](worker-backend-solid-baseline.md)
+- [worker-residual-boundary-traceability.md](worker-residual-boundary-traceability.md)
+- [comment-performance-fix.md](comment-performance-fix.md)
+- [review-image-loading.md](review-image-loading.md)
+
+이 문서들에 `backend/`, Worker, DB schema, migration 경로가 남아 있어도 현재 Web Front 레포의 소유권을 의미하지 않습니다. 최신 구현과 운영 정본은 `ClarusIubar/JamIssue_admin`에서 확인합니다.

--- a/docs/api-contract-ownership.md
+++ b/docs/api-contract-ownership.md
@@ -1,0 +1,81 @@
+# API Contract Ownership
+
+이 문서는 backend 제거 이후 `STH-1-Class-One-Group/JamIssue` Web Front 레포에 남아 있는 API 관련 책임과, `ClarusIubar/JamIssue_admin`으로 이관된 backend/API 책임을 분리합니다.
+
+## 결론
+
+이 레포는 **consumer-side API contract**만 소유합니다.
+
+Backend API 구현, Cloudflare Worker handler, DB schema/migration, provider-side contract test, OAuth/backend secret은 `ClarusIubar/JamIssue_admin`이 소유합니다.
+
+## 소유권 구분
+
+| 구분 | 소유 레포 | 의미 |
+| --- | --- | --- |
+| Consumer-side API client | `STH-1-Class-One-Group/JamIssue` | Web Front가 호출하는 endpoint, request payload, response DTO 기대값 |
+| Consumer-side DTO/type | `STH-1-Class-One-Group/JamIssue` | React 화면과 hook이 사용하는 TypeScript 타입 |
+| Provider-side API contract | `ClarusIubar/JamIssue_admin` | Worker/FastAPI가 실제로 보장해야 하는 endpoint, status, response shape |
+| Backend implementation | `ClarusIubar/JamIssue_admin` | Cloudflare Worker, DB access, OAuth, admin API, migration |
+| Runtime secret | `ClarusIubar/JamIssue_admin` | OAuth secret, service-role key, Worker runtime secret |
+
+## 이 레포에 남아 있는 API 관련 파일
+
+| 위치 | 책임 |
+| --- | --- |
+| [../src/api/core.ts](../src/api/core.ts) | `fetchJson`, API base URL, cache, `ApiError`, 인증 만료 이벤트 |
+| [../src/api/bootstrapClient.ts](../src/api/bootstrapClient.ts) | bootstrap, map bootstrap, curated courses, festivals, public event banner 호출 |
+| [../src/api/authClient.ts](../src/api/authClient.ts) | provider login URL 생성, logout, profile update 호출 |
+| [../src/api/reviewsClient.ts](../src/api/reviewsClient.ts) | review, feed, comment, like, upload 호출 |
+| [../src/api/myClient.ts](../src/api/myClient.ts) | my page summary, notification, my comments 호출 |
+| [../src/api/routesClient.ts](../src/api/routesClient.ts) | community route 생성/조회/like 호출 |
+| [../src/api/stampClient.ts](../src/api/stampClient.ts) | stamp claim 호출 |
+| [../src/api/adminClient.ts](../src/api/adminClient.ts) | Web Front에서 남아 있는 admin import/visibility 호출부 |
+| [../src/types.ts](../src/types.ts) | Web Front consumer DTO barrel |
+| [../src/types](../src/types) | auth, core, review, my-page, admin DTO |
+
+## 주요 consumer endpoint 목록
+
+이 목록은 Web Front가 기대하는 호출면입니다. Provider-side 정본은 `ClarusIubar/JamIssue_admin`에서 관리합니다.
+
+| 영역 | Endpoint |
+| --- | --- |
+| Bootstrap | `GET /api/bootstrap`, `GET /api/map-bootstrap`, `GET /api/courses/curated` |
+| Event | `GET /api/banner/events`, `GET /api/festivals` |
+| Auth | `GET /api/auth/{provider}/login`, `POST /api/auth/logout`, `PATCH /api/auth/profile` |
+| Review | `GET /api/reviews`, `GET /api/review-feed`, `GET /api/reviews/{reviewId}`, `POST /api/reviews`, `PATCH /api/reviews/{reviewId}`, `DELETE /api/reviews/{reviewId}` |
+| Review interaction | `POST /api/reviews/{reviewId}/like`, `GET /api/reviews/{reviewId}/comments`, `POST /api/reviews/{reviewId}/comments`, `PATCH /api/reviews/{reviewId}/comments/{commentId}`, `DELETE /api/reviews/{reviewId}/comments/{commentId}` |
+| Upload | `POST /api/reviews/upload` |
+| My page | `GET /api/my/summary`, `GET /api/my/notifications`, `GET /api/my/notifications/realtime-channel`, `GET /api/my/comments` |
+| Notification | `PATCH /api/notifications/{notificationId}/read`, `PATCH /api/notifications/read-all`, `DELETE /api/notifications/{notificationId}` |
+| Stamp | `POST /api/stamps/toggle` |
+| Route | `GET /api/community-routes`, `POST /api/community-routes`, `POST /api/community-routes/{routeId}/like` |
+| Admin-facing client | `PATCH /api/admin/places/{placeId}`, `POST /api/admin/import/public-data` |
+
+## 변경 규칙
+
+Web Front에서 API client나 DTO를 변경할 때는 아래 기준을 따릅니다.
+
+1. UI 내부 상태 이름 변경은 Web Front 레포에서 처리할 수 있습니다.
+2. Endpoint path, request payload, response DTO shape 변경은 provider-side contract 변경이므로 `ClarusIubar/JamIssue_admin`에서 먼저 확정해야 합니다.
+3. Web Front는 provider-side 변경이 병합된 뒤 consumer client와 DTO를 맞춥니다.
+4. DB schema, migration, OAuth secret, Worker runtime config는 이 레포에 추가하지 않습니다.
+5. API contract 변경 PR에는 관련 provider PR 또는 issue 링크를 남깁니다.
+
+## 검증 기준
+
+Web Front 레포에서 API 관련 변경을 할 때 최소 검증은 아래와 같습니다.
+
+```powershell
+npm.cmd run typecheck
+npm.cmd run lint
+npm.cmd run test:unit
+npm.cmd run build
+```
+
+Provider-side API contract 검증, DB migration 검증, Worker route integration test는 `ClarusIubar/JamIssue_admin`에서 수행합니다.
+
+## 현재 남은 문서 리스크
+
+이 레포의 일부 `docs` 문서는 Web Front와 backend가 같은 레포에 있던 시기의 경로를 포함합니다. 예를 들어 `backend/app`, Worker, DB migration 경로가 남아 있을 수 있습니다.
+
+해당 문서는 최신 backend 정본이 아니라 legacy/reference 문서로 봅니다. 최신 소유권은 이 문서와 [README.md](../README.md)를 기준으로 합니다.


### PR DESCRIPTION
## 요약
- README 한글 인코딩 깨짐을 복구하고 Web Front 레포의 소유 범위를 다시 명시했습니다.
- docs/api-contract-ownership.md를 추가해 consumer-side API contract와 provider-side API contract를 분리했습니다.
- docs/README.md를 최신 정본/legacy reference 기준으로 재정리했습니다.

## 소유권 기준
- 이 레포: src/api, src/types에 남은 Web Front consumer-side contract
- ClarusIubar/JamIssue_admin: Backend API 구현, Worker, DB schema/migration, provider-side API contract test, runtime secret

## 검증
- UTF-8 read check
- markdown relative link check
- git diff --check

## 참고
- 현재 작업은 문서 전용 변경입니다.
- stale backend 설계 문서 전체 삭제/이관은 별도 작업으로 분리합니다.