### PR TITLE
Prevent O(N) intermediate array allocations in count operations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Prevent O(N) array allocation in count operations
+**Learning:** Using `array.filter(condition).length` to count elements creates a full intermediate array in memory, causing O(N) memory allocation and subsequent garbage collection. For large arrays like notifications or stamp logs, this puts unnecessary pressure on the GC, particularly if calculated during state updates or renders.
+**Action:** Replace `array.filter(condition).length` with a standard `for` loop and a counter variable (`let count = 0; ... count++;`). This achieves the same count with O(1) memory complexity.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2024-05-18 - Prevent O(N) array allocation in count operations
-**Learning:** Using `array.filter(condition).length` to count elements creates a full intermediate array in memory, causing O(N) memory allocation and subsequent garbage collection. For large arrays like notifications or stamp logs, this puts unnecessary pressure on the GC, particularly if calculated during state updates or renders.
-**Action:** Replace `array.filter(condition).length` with a standard `for` loop and a counter variable (`let count = 0; ... count++;`). This achieves the same count with O(1) memory complexity.

--- a/src/lib/visits.ts
+++ b/src/lib/visits.ts
@@ -32,7 +32,14 @@ export function getTodayStampLog(stampLogs: StampLog[], placeId: string) {
 }
 
 export function getPlaceVisitCount(stampLogs: StampLog[], placeId: string) {
-  return stampLogs.filter((stampLog) => stampLog.placeId === placeId).length;
+  // Count stamp logs without creating an intermediate array to reduce memory pressure
+  let count = 0;
+  for (const stampLog of stampLogs) {
+    if (stampLog.placeId === placeId) {
+      count++;
+    }
+  }
+  return count;
 }
 
 export function getLatestPlaceStamp(stampLogs: StampLog[], placeId: string) {

--- a/src/store/notification-store/actions.ts
+++ b/src/store/notification-store/actions.ts
@@ -130,9 +130,18 @@ export function createNotificationStoreActions(set: SetState, get: GetState): No
         }
         const nextNotifications = [...state.notifications];
         nextNotifications[idx] = { ...nextNotifications[idx], isRead: true };
+
+        // Count unread notifications without creating an intermediate array to reduce memory pressure
+        let nextUnreadCount = 0;
+        for (const notification of state.notifications) {
+          if (!notification.isRead && notification.id !== notificationId) {
+            nextUnreadCount++;
+          }
+        }
+
         return {
           notifications: nextNotifications,
-          unreadCount: Math.max(0, state.notifications.filter((notification) => !notification.isRead && notification.id !== notificationId).length),
+          unreadCount: Math.max(0, nextUnreadCount),
         };
       });
     },

--- a/src/store/notification-store/helpers.ts
+++ b/src/store/notification-store/helpers.ts
@@ -14,7 +14,14 @@ type NotificationReadPayload = {
 type NotificationAllReadPayload = { unreadCount: number };
 
 export function countUnread(notifications: UserNotification[]) {
-  return notifications.filter((notification) => !notification.isRead).length;
+  // Count unread notifications without creating an intermediate array to reduce memory pressure
+  let count = 0;
+  for (const notification of notifications) {
+    if (!notification.isRead) {
+      count++;
+    }
+  }
+  return count;
 }
 
 export function clearReconnectTimer(timer: number | null) {


### PR DESCRIPTION
💡 **What:** Replaced `array.filter(...).length` patterns with a standard `for...of` loop and counter variable in `actions.ts`, `helpers.ts`, and `visits.ts`.
🎯 **Why:** To count elements, `filter()` creates a completely new, intermediate array in memory that is immediately discarded. For arrays that can grow large (like `notifications` and `stampLogs`), this puts unnecessary O(N) pressure on the Javascript Garbage Collector, especially since these derived counts run during state updates.
📊 **Impact:** Reduces memory allocation from O(N) to O(1) for these count operations, removing intermediate array creation and lowering GC overhead.
🔬 **Measurement:** Verify by running standard unit/regression tests (`npm run test:all`), checking performance via memory profiling, and observing stable behavior across UI interactions that update notification/stamp counts.

---
*PR created automatically by Jules for task [15503575911997929249](https://jules.google.com/task/15503575911997929249) started by @ClarusIubar*