### PR TITLE
[TSK-010-01] Web Front 소셜 계정 연동 contract 반영

### DIFF
--- a/docs/code-flow-diagrams.md
+++ b/docs/code-flow-diagrams.md
@@ -151,10 +151,15 @@ flowchart TD
 
 ```mermaid
 flowchart TD
-    A["MyPagePanel -> onLogin(provider)"] --> B["App.startProviderLogin()"]
-    B --> C["window.location.assign(getProviderLoginUrl(...))"]
+    A["Guest ProviderButtons -> onLogin(provider)"] --> B["App.startProviderLogin(provider.loginUrl)"]
+    A2["MyPageSettingsSection -> onLinkProvider(provider)"] --> B2["App.startProviderLink(provider.linkUrl)"]
+    B --> C["window.location.assign(getProviderLoginUrl(provider))"]
+    B2 --> C2["window.location.assign(getProviderLinkUrl(provider))"]
     C --> D["GET /api/auth/{provider}/login"]
+    C2 --> D2["GET /api/auth/{provider}/link"]
     D --> E["main.start_login()"]
+    D2 --> E2["main.start_link()"]
+    E2 --> G
     E --> F["request.session['post_login_redirect']"]
     E --> G["generate_oauth_state()"]
     G --> H["build_naver_login_url()"]

--- a/src/api/authClient.ts
+++ b/src/api/authClient.ts
@@ -1,8 +1,29 @@
-import type { AuthSessionResponse, ProfileUpdateRequest, ProviderKey } from '../types';
+import type { AuthProvider, AuthSessionResponse, ProfileUpdateRequest } from '../types';
 import { fetchJson, getApiBaseUrl, invalidateApiCache } from './core';
 
-export function getProviderLoginUrl(provider: ProviderKey, nextUrl: string, mode: 'login' | 'link' = 'login') {
-  return `${getApiBaseUrl()}/api/auth/${provider}/login?next=${encodeURIComponent(nextUrl)}&mode=${mode}`;
+function getProviderUrlBase() {
+  const apiBaseUrl = getApiBaseUrl();
+  if (apiBaseUrl) {
+    return apiBaseUrl;
+  }
+  if (typeof window !== 'undefined') {
+    return window.location.origin;
+  }
+  return 'http://localhost:8000';
+}
+
+export function buildProviderAuthUrl(providerUrl: string, nextUrl: string) {
+  const url = new URL(providerUrl, getProviderUrlBase());
+  url.searchParams.set('next', nextUrl);
+  return url.toString();
+}
+
+export function getProviderLoginUrl(provider: AuthProvider, nextUrl: string) {
+  return provider.loginUrl ? buildProviderAuthUrl(provider.loginUrl, nextUrl) : null;
+}
+
+export function getProviderLinkUrl(provider: AuthProvider, nextUrl: string) {
+  return provider.linkUrl ? buildProviderAuthUrl(provider.linkUrl, nextUrl) : null;
 }
 
 export async function logout() {

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,5 +1,5 @@
 export { ApiError, fetchJson, getApiBaseUrl, invalidateApiCache } from './core';
-export { getProviderLoginUrl, logout, updateProfile } from './authClient';
+export { buildProviderAuthUrl, getProviderLinkUrl, getProviderLoginUrl, logout, updateProfile } from './authClient';
 export { getBootstrap, getCuratedCourses, getFestivals, getMapBootstrap, getPublicEventBanner } from './bootstrapClient';
 export { createUserRoute, getCommunityRoutes, toggleCommunityRouteLike } from './routesClient';
 export {

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -41,6 +41,7 @@ export function MyPagePanel({
   const {
     onChangeTab,
     onLogin,
+    onLinkProvider,
     onRetry,
     onLogout,
     onSaveNickname,
@@ -106,11 +107,14 @@ export function MyPagePanel({
       />
 
       <MyPageSettingsSection
+        sessionUser={sessionUser}
+        providers={providers}
         nickname={nickname}
         showSettings={showSettings}
         profileCompletedAt={sessionUser.profileCompletedAt}
         profileSaving={profileSaving}
         profileError={profileError}
+        onLinkProvider={onLinkProvider}
         onNicknameChange={setNickname}
         onClose={() => setShowSettings(false)}
         onSubmit={handleNicknameSubmit}

--- a/src/components/ProviderButtons.tsx
+++ b/src/components/ProviderButtons.tsx
@@ -1,24 +1,29 @@
-﻿import type { AuthProvider, ProviderKey } from '../types/auth';
+import type { AuthProvider } from '../types/auth';
+import { getAuthProviderDisplayLabel } from '../utils/authProviderDisplay';
 
 interface ProviderButtonsProps {
   providers: AuthProvider[];
-  onLogin: (provider: ProviderKey) => void;
+  onLogin: (provider: AuthProvider) => void;
 }
 
 export function ProviderButtons({ providers, onLogin }: ProviderButtonsProps) {
   return (
     <div className="provider-button-list">
-      {providers.map((provider) => (
-        <button
-          key={provider.key}
-          type="button"
-          className={provider.isEnabled ? 'primary-button provider-button' : 'secondary-button provider-button is-disabled'}
-          disabled={!provider.isEnabled}
-          onClick={() => onLogin(provider.key)}
-        >
-          {provider.isEnabled ? `${provider.label}로 로그인` : `${provider.label} 준비 중`}
-        </button>
-      ))}
+      {providers.map((provider) => {
+        const canLogin = provider.isEnabled && Boolean(provider.loginUrl);
+        const providerLabel = getAuthProviderDisplayLabel(provider);
+        return (
+          <button
+            key={provider.key}
+            type="button"
+            className={canLogin ? 'primary-button provider-button' : 'secondary-button provider-button is-disabled'}
+            disabled={!canLogin}
+            onClick={() => onLogin(provider)}
+          >
+            {canLogin ? `${providerLabel}\uB85C \uB85C\uADF8\uC778` : `${providerLabel} \uC900\uBE44 \uC911`}
+          </button>
+        );
+      })}
     </div>
   );
 }

--- a/src/components/my-page/MyPageGuestState.tsx
+++ b/src/components/my-page/MyPageGuestState.tsx
@@ -1,9 +1,9 @@
-import type { AuthProvider, ProviderKey } from '../../types/auth';
+import type { AuthProvider } from '../../types/auth';
 import { ProviderButtons } from '../ProviderButtons';
 
 interface MyPageGuestStateProps {
   providers: AuthProvider[];
-  onLogin: (provider: ProviderKey) => void;
+  onLogin: (provider: AuthProvider) => void;
 }
 
 export function MyPageGuestState({ providers, onLogin }: MyPageGuestStateProps) {

--- a/src/components/my-page/MyPageSettingsSection.tsx
+++ b/src/components/my-page/MyPageSettingsSection.tsx
@@ -1,22 +1,30 @@
 import type { FormEvent } from 'react';
+import type { AuthProvider, SessionUser } from '../../types/auth';
+import { getAuthProviderDisplayLabel } from '../../utils/authProviderDisplay';
 
 type MyPageSettingsSectionProps = {
+  sessionUser: SessionUser;
+  providers: AuthProvider[];
   nickname: string;
   showSettings: boolean;
   profileCompletedAt: string | null | undefined;
   profileSaving: boolean;
   profileError: string | null;
+  onLinkProvider: (provider: AuthProvider) => void;
   onNicknameChange: (value: string) => void;
   onClose: () => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => Promise<void>;
 };
 
 export function MyPageSettingsSection({
+  sessionUser,
+  providers,
   nickname,
   showSettings,
   profileCompletedAt,
   profileSaving,
   profileError,
+  onLinkProvider,
   onNicknameChange,
   onClose,
   onSubmit,
@@ -25,28 +33,72 @@ export function MyPageSettingsSection({
     return null;
   }
 
+  const linkedProviders = sessionUser.linkedProviders;
+  const providerByKey = new Map(providers.map((provider) => [provider.key, provider]));
+  const socialProviderKeys = [
+    ...linkedProviders,
+    ...providers
+      .filter((provider) => !linkedProviders.includes(provider.key) && provider.isEnabled && Boolean(provider.linkUrl))
+      .map((provider) => provider.key),
+  ];
+
   return (
     <section className="sheet-card stack-gap settings-card">
       <div className="settings-card__header">
         <div>
           <p className="eyebrow">SETTINGS</p>
-          <h3>{profileCompletedAt ? '프로필 설정' : '프로필을 먼저 정해 주세요'}</h3>
-          <p className="section-copy">프로필은 서비스 전체에서 하나만 사용돼요.</p>
+          <h3>{profileCompletedAt ? '\uD504\uB85C\uD544 \uC124\uC815' : '\uD504\uB85C\uD544\uC744 \uBA3C\uC800 \uC815\uD574 \uC8FC\uC138\uC694'}</h3>
+          <p className="section-copy">{'\uD504\uB85C\uD544\uC740 \uC11C\uBE44\uC2A4 \uC804\uCCB4\uC5D0\uC11C \uD558\uB098\uB9CC \uC0AC\uC6A9\uB3FC\uC694.'}</p>
         </div>
         {profileCompletedAt && (
-          <button type="button" className="settings-card__close" onClick={onClose} aria-label="설정 닫기">
-            <span aria-hidden="true">×</span>
+          <button type="button" className="settings-card__close" onClick={onClose} aria-label={'\uC124\uC815 \uB2EB\uAE30'}>
+            <span aria-hidden="true">{'\u00D7'}</span>
           </button>
         )}
       </div>
+      {socialProviderKeys.length > 0 && (
+        <div className="settings-card__links" aria-label={'\uC5F0\uACB0\uB41C \uC18C\uC15C \uACC4\uC815'}>
+          <p className="eyebrow">{'\uC18C\uC15C \uACC4\uC815'}</p>
+          {socialProviderKeys.map((providerKey) => {
+            const provider = providerByKey.get(providerKey);
+            const isLinked = linkedProviders.includes(providerKey);
+            const providerLabel = getAuthProviderDisplayLabel({ key: providerKey });
+
+            if (isLinked) {
+              return (
+                <div key={providerKey} className="settings-card__link-button secondary-button is-complete" aria-label={`${providerLabel} \uC5F0\uACB0\uB428`}>
+                  <span>{providerLabel}</span>
+                  <span className="soft-tag is-complete">{'\uC5F0\uACB0\uB428'}</span>
+                </div>
+              );
+            }
+
+            if (!provider) {
+              return null;
+            }
+
+            return (
+              <button
+                key={providerKey}
+                type="button"
+                className="settings-card__link-button secondary-button"
+                onClick={() => onLinkProvider(provider)}
+              >
+                <span>{providerLabel}</span>
+                <span>{'\uACC4\uC815 \uC5F0\uB3D9'}</span>
+              </button>
+            );
+          })}
+        </div>
+      )}
       <form className="route-builder-form" onSubmit={(event) => void onSubmit(event)}>
         <label className="route-builder-field">
-          <span>프로필명</span>
-          <input value={nickname} onChange={(event) => onNicknameChange(event.target.value)} placeholder="예: 대전산책러" maxLength={40} />
+          <span>{'\uD504\uB85C\uD544\uBA85'}</span>
+          <input value={nickname} onChange={(event) => onNicknameChange(event.target.value)} placeholder={'\uC608: \uB300\uC804\uC0B0\uCC45\uB7EC'} maxLength={40} />
         </label>
         {profileError && <p className="form-error-copy">{profileError}</p>}
         <button type="submit" className="primary-button route-submit-button" disabled={profileSaving || nickname.trim().length < 2}>
-          {profileSaving ? '저장 중' : '프로필 저장'}
+          {profileSaving ? '\uC800\uC7A5 \uC911' : '\uD504\uB85C\uD544 \uC800\uC7A5'}
         </button>
       </form>
     </section>

--- a/src/components/my-page/myPagePanelTypes.ts
+++ b/src/components/my-page/myPagePanelTypes.ts
@@ -31,7 +31,8 @@ export interface MyPagePanelProps {
   };
   panelActions: {
     onChangeTab: (nextTab: MyPageTabKey) => void;
-    onLogin: (provider: 'naver' | 'kakao') => void;
+    onLogin: (provider: AuthProvider) => void;
+    onLinkProvider: (provider: AuthProvider) => void;
     onRetry: () => Promise<void>;
     onLogout: () => Promise<void>;
     onSaveNickname: (nickname: string) => Promise<void>;

--- a/src/components/page-stage/PageStageMyView.tsx
+++ b/src/components/page-stage/PageStageMyView.tsx
@@ -37,6 +37,7 @@ export function PageStageMyView({
       panelActions={{
         onChangeTab: myPageActions.onChangeMyPageTab,
         onLogin: myPageActions.onLogin,
+        onLinkProvider: myPageActions.onLinkProvider,
         onRetry: myPageActions.onRetryMyPage,
         onLogout: myPageActions.onLogout,
         onSaveNickname: myPageActions.onSaveNickname,

--- a/src/components/page-stage/appPageStageTypes.ts
+++ b/src/components/page-stage/appPageStageTypes.ts
@@ -76,7 +76,8 @@ export interface AppPageStageCourseActions {
 
 export interface AppPageStageMyPageActions {
   onChangeMyPageTab: (tab: MyPageTabKey) => void;
-  onLogin: (provider: 'naver' | 'kakao') => void;
+  onLogin: (provider: AuthProvider) => void;
+  onLinkProvider: (provider: AuthProvider) => void;
   onRetryMyPage: () => Promise<void>;
   onLogout: () => Promise<void>;
   onSaveNickname: (nickname: string) => Promise<void>;

--- a/src/hooks/app-bootstrap/bootstrapMapSession.ts
+++ b/src/hooks/app-bootstrap/bootstrapMapSession.ts
@@ -2,13 +2,13 @@ import type * as React from 'react';
 
 import { getMapBootstrap } from '../../api/bootstrapClient';
 import type { Place } from '../../types/core';
-import type { SessionUser } from '../../types/auth';
+import type { AuthProvider, SessionUser } from '../../types/auth';
 import type { StampState } from '../../types/review';
 import type { MyPageResponse } from '../../types/my-page';
 import { handleBootstrapAuthNotice } from './bootstrapAuthNotice';
 import { applyBootstrapSelections, resetBootstrapRuntime } from './bootstrapRuntimeReset';
 
-type SetProviders = (providers: Array<{ key: 'naver' | 'kakao'; label: string; isEnabled: boolean; loginUrl: string | null }>) => void;
+type SetProviders = (providers: AuthProvider[]) => void;
 
 interface BootstrapSharedRefs {
   refreshMyPageForUserRef: { current: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null> };

--- a/src/hooks/app-bootstrap/bootstrapRuntimeReset.ts
+++ b/src/hooks/app-bootstrap/bootstrapRuntimeReset.ts
@@ -1,6 +1,6 @@
-type SetProviders = (
-  providers: Array<{ key: 'naver' | 'kakao'; label: string; isEnabled: boolean; loginUrl: string | null }>
-) => void;
+import type { AuthProvider } from '../../types/auth';
+
+type SetProviders = (providers: AuthProvider[]) => void;
 
 interface ResetBootstrapRuntimeParams {
   setFeedNextCursor: (cursor: string | null) => void;

--- a/src/hooks/app-bootstrap/useAppBootstrapEffects.ts
+++ b/src/hooks/app-bootstrap/useAppBootstrapEffects.ts
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import type { Dispatch, SetStateAction } from 'react';
 
 import type { FestivalItem, Place } from '../../types/core';
-import type { SessionUser } from '../../types/auth';
+import type { AuthProvider, SessionUser } from '../../types/auth';
 import type { StampState } from '../../types/review';
 import type { MyPageResponse } from '../../types/my-page';
 import { bootstrapFestivalLoader } from './bootstrapFestivalLoader';
@@ -10,7 +10,7 @@ import { bootstrapMapSession } from './bootstrapMapSession';
 import { clearAuthQueryParams } from '../app-route/useAppRouteState';
 import type { AppBootstrapSharedRefs } from './useAppBootstrapSharedRefs';
 
-type SetProviders = (providers: Array<{ key: 'naver' | 'kakao'; label: string; isEnabled: boolean; loginUrl: string | null }>) => void;
+type SetProviders = (providers: AuthProvider[]) => void;
 
 interface UseMapBootstrapEffectParams extends AppBootstrapSharedRefs {
   setBootstrapStatus: (status: 'idle' | 'loading' | 'ready' | 'error') => void;

--- a/src/hooks/app-coordinator/useAppCoordinatorAuthLoaders.ts
+++ b/src/hooks/app-coordinator/useAppCoordinatorAuthLoaders.ts
@@ -27,7 +27,7 @@ export function useAppCoordinatorAuthLoaders({
     setReviews,
   } = dataState;
 
-  const { startProviderLogin, handleUpdateProfile, handleLogout } = useAppAuthActions({
+  const { startProviderLogin, startProviderLink, handleUpdateProfile, handleLogout } = useAppAuthActions({
     setMyPage,
     formatErrorMessage: formatCoordinatorErrorMessage,
   });
@@ -53,6 +53,7 @@ export function useAppCoordinatorAuthLoaders({
     sessionUser,
     myPage,
     startProviderLogin,
+    startProviderLink,
     handleUpdateProfile,
     handleLogout,
     dataLoaders,

--- a/src/hooks/app-stage-props/usePageStageProps.ts
+++ b/src/hooks/app-stage-props/usePageStageProps.ts
@@ -119,6 +119,7 @@ export function usePageStageProps(state: AppShellCoordinatorState) {
     myPageActions: {
       onChangeMyPageTab: setMyPageTab,
       onLogin: state.startProviderLogin,
+      onLinkProvider: state.startProviderLink,
       onRetryMyPage: pageStageActions.handleRetryMyPage,
       onLogout: state.handleLogout,
       onSaveNickname: state.handleUpdateProfile,

--- a/src/hooks/useAppAuthActions.ts
+++ b/src/hooks/useAppAuthActions.ts
@@ -1,9 +1,10 @@
-import { getProviderLoginUrl, logout, updateProfile } from '../api/authClient';
+import { getProviderLinkUrl, getProviderLoginUrl, logout, updateProfile } from '../api/authClient';
 import { getLoginReturnUrl } from './app-route/useAppRouteState';
 import type { Dispatch, SetStateAction } from 'react';
 import { useAuthStore } from '../store/auth-store';
 import { useAppPageRuntimeStore } from '../store/app-page-runtime-store';
 import { useAppShellRuntimeStore } from '../store/app-shell-runtime-store';
+import type { AuthProvider } from '../types/auth';
 import type { MyPageResponse } from '../types/my-page';
 
 type SetState<T> = Dispatch<SetStateAction<T>>;
@@ -24,8 +25,18 @@ export function useAppAuthActions({
   const setProfileSaving = useAppPageRuntimeStore((state) => state.setProfileSaving);
   const setProfileError = useAppPageRuntimeStore((state) => state.setProfileError);
 
-  function startProviderLogin(provider: 'naver' | 'kakao') {
-    window.location.assign(getProviderLoginUrl(provider, getLoginReturnUrl()));
+  function startProviderLogin(provider: AuthProvider) {
+    const loginUrl = getProviderLoginUrl(provider, getLoginReturnUrl());
+    if (loginUrl) {
+      window.location.assign(loginUrl);
+    }
+  }
+
+  function startProviderLink(provider: AuthProvider) {
+    const linkUrl = getProviderLinkUrl(provider, getLoginReturnUrl());
+    if (linkUrl) {
+      window.location.assign(linkUrl);
+    }
   }
 
   async function handleUpdateProfile(nextNickname: string) {
@@ -68,6 +79,7 @@ export function useAppAuthActions({
 
   return {
     startProviderLogin,
+    startProviderLink,
     handleUpdateProfile,
     handleLogout,
   };

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -5,6 +5,7 @@ export interface SessionUser {
   nickname: string;
   email: string | null;
   provider: string;
+  linkedProviders: ProviderKey[];
   profileImage: string | null;
   isAdmin: boolean;
   profileCompletedAt: string | null;
@@ -15,6 +16,7 @@ export interface AuthProvider {
   label: string;
   isEnabled: boolean;
   loginUrl: string | null;
+  linkUrl?: string | null;
 }
 
 export interface AuthSessionResponse {

--- a/src/utils/authProviderDisplay.ts
+++ b/src/utils/authProviderDisplay.ts
@@ -1,0 +1,10 @@
+import type { AuthProvider } from '../types/auth';
+
+const PROVIDER_LABELS: Record<AuthProvider['key'], string> = {
+  naver: '\uB124\uC774\uBC84',
+  kakao: '\uCE74\uCE74\uC624',
+};
+
+export function getAuthProviderDisplayLabel(provider: Pick<AuthProvider, 'key'>) {
+  return PROVIDER_LABELS[provider.key];
+}

--- a/test/e2e/fixtures.ts
+++ b/test/e2e/fixtures.ts
@@ -9,6 +9,7 @@ export const e2eUser: SessionUser = {
   nickname: '테스터',
   email: 'tester@example.com',
   provider: 'kakao',
+  linkedProviders: ['kakao'],
   profileImage: null,
   isAdmin: false,
   profileCompletedAt: '2026-05-14T10:00:00.000Z',
@@ -176,8 +177,8 @@ function authPayload(state: E2EAppState) {
     isAuthenticated: Boolean(state.user),
     user: state.user,
     providers: [
-      { key: 'naver', label: 'Naver', isEnabled: false, loginUrl: null },
-      { key: 'kakao', label: 'Kakao', isEnabled: false, loginUrl: null },
+      { key: 'naver', label: 'Naver', isEnabled: false, loginUrl: null, linkUrl: null },
+      { key: 'kakao', label: 'Kakao', isEnabled: false, loginUrl: null, linkUrl: null },
     ],
   };
 }

--- a/test/fixtures/app-fixtures.ts
+++ b/test/fixtures/app-fixtures.ts
@@ -15,6 +15,7 @@ export const sessionUserFixture: SessionUser = {
   nickname: '테스터',
   email: 'tester@example.com',
   provider: 'kakao',
+  linkedProviders: ['kakao'],
   profileImage: null,
   isAdmin: false,
   profileCompletedAt: '2026-03-28T10:00:00.000Z',

--- a/test/regression/my-page-panel.test.tsx
+++ b/test/regression/my-page-panel.test.tsx
@@ -34,6 +34,7 @@ function createPanelProps(activeTab: MyPageTabKey) {
     panelActions: {
       onChangeTab: vi.fn(),
       onLogin: vi.fn(),
+      onLinkProvider: vi.fn(),
       onRetry: vi.fn().mockResolvedValue(undefined),
       onLogout: vi.fn().mockResolvedValue(undefined),
       onSaveNickname: vi.fn().mockResolvedValue(undefined),

--- a/test/smoke/component-smoke.test.tsx
+++ b/test/smoke/component-smoke.test.tsx
@@ -90,6 +90,7 @@ describe('component smoke', () => {
         panelActions={{
           onChangeTab: vi.fn(),
           onLogin: vi.fn(),
+          onLinkProvider: vi.fn(),
           onRetry: vi.fn().mockResolvedValue(undefined),
           onLogout: vi.fn().mockResolvedValue(undefined),
           onSaveNickname: vi.fn().mockResolvedValue(undefined),

--- a/test/unit/auth-provider-contract.test.tsx
+++ b/test/unit/auth-provider-contract.test.tsx
@@ -1,0 +1,157 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { buildProviderAuthUrl, getProviderLinkUrl, getProviderLoginUrl } from '../../src/api/authClient';
+import { ProviderButtons } from '../../src/components/ProviderButtons';
+import { MyPageSettingsSection } from '../../src/components/my-page/MyPageSettingsSection';
+import type { AuthProvider, SessionUser } from '../../src/types/auth';
+
+const API_BASE_URL = 'https://api.example.test';
+const FRONTEND_RETURN_URL = 'https://daejeon.jamissue.com/?tab=my';
+const KAKAO_LABEL = '\uCE74\uCE74\uC624';
+const NAVER_LABEL = '\uB124\uC774\uBC84';
+const CONNECTED_LABEL = '\uC5F0\uACB0\uB428';
+const SOCIAL_ACCOUNT_LABEL = '\uC18C\uC15C \uACC4\uC815';
+const LINK_ACCOUNT_LABEL = '\uACC4\uC815 \uC5F0\uB3D9';
+
+const kakaoProvider: AuthProvider = {
+  key: 'kakao',
+  label: 'Kakao',
+  isEnabled: true,
+  loginUrl: '/api/auth/kakao/login',
+  linkUrl: '/api/auth/kakao/link',
+};
+
+const naverProvider: AuthProvider = {
+  key: 'naver',
+  label: 'Naver',
+  isEnabled: true,
+  loginUrl: '/api/auth/naver/login',
+  linkUrl: '/api/auth/naver/link',
+};
+
+const sessionUser: SessionUser = {
+  id: 'user-1',
+  nickname: 'tester',
+  email: null,
+  provider: 'kakao',
+  linkedProviders: ['kakao'],
+  profileImage: null,
+  isAdmin: false,
+  profileCompletedAt: '2026-05-29T00:00:00.000Z',
+};
+
+function renderSettingsSection({
+  user = sessionUser,
+  providers = [kakaoProvider, naverProvider],
+  onLinkProvider = vi.fn(),
+}: {
+  user?: SessionUser;
+  providers?: AuthProvider[];
+  onLinkProvider?: (provider: AuthProvider) => void;
+} = {}) {
+  render(
+    <MyPageSettingsSection
+      sessionUser={user}
+      providers={providers}
+      nickname={user.nickname}
+      showSettings
+      profileCompletedAt={user.profileCompletedAt}
+      profileSaving={false}
+      profileError={null}
+      onLinkProvider={onLinkProvider}
+      onNicknameChange={vi.fn()}
+      onClose={vi.fn()}
+      onSubmit={async () => undefined}
+    />,
+  );
+}
+
+beforeEach(() => {
+  window.__JAMISSUE_CONFIG__ = {
+    apiBaseUrl: API_BASE_URL,
+  };
+});
+
+describe('auth provider contract', () => {
+  it('builds login and account-link URLs from provider-supplied contract URLs', () => {
+    expect(getProviderLoginUrl(kakaoProvider, FRONTEND_RETURN_URL)).toBe(
+      `${API_BASE_URL}/api/auth/kakao/login?next=https%3A%2F%2Fdaejeon.jamissue.com%2F%3Ftab%3Dmy`,
+    );
+    expect(getProviderLinkUrl(naverProvider, FRONTEND_RETURN_URL)).toBe(
+      `${API_BASE_URL}/api/auth/naver/link?next=https%3A%2F%2Fdaejeon.jamissue.com%2F%3Ftab%3Dmy`,
+    );
+    expect(getProviderLinkUrl({ ...naverProvider, linkUrl: null }, FRONTEND_RETURN_URL)).toBeNull();
+  });
+
+  it('preserves absolute provider origins while adding the return URL', () => {
+    expect(buildProviderAuthUrl('https://oauth.example.test/auth/link?prompt=login', FRONTEND_RETURN_URL)).toBe(
+      'https://oauth.example.test/auth/link?prompt=login&next=https%3A%2F%2Fdaejeon.jamissue.com%2F%3Ftab%3Dmy',
+    );
+  });
+});
+
+describe('provider login and account-link controls', () => {
+  it('uses enabled provider loginUrl availability for guest login buttons', async () => {
+    const user = userEvent.setup();
+    const onLogin = vi.fn();
+    const missingLoginUrl = { ...naverProvider, loginUrl: null };
+
+    render(<ProviderButtons providers={[kakaoProvider, missingLoginUrl]} onLogin={onLogin} />);
+
+    await user.click(screen.getByRole('button', { name: `${KAKAO_LABEL}\uB85C \uB85C\uADF8\uC778` }));
+
+    expect(onLogin).toHaveBeenCalledWith(kakaoProvider);
+    expect(screen.getByRole('button', { name: `${NAVER_LABEL} \uC900\uBE44 \uC911` })).toBeDisabled();
+  });
+
+  it('shows linked providers and account-link buttons from linkedProviders contract', async () => {
+    const user = userEvent.setup();
+    const onLinkProvider = vi.fn();
+
+    renderSettingsSection({ onLinkProvider });
+
+    expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(CONNECTED_LABEL)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: new RegExp(KAKAO_LABEL) })).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole('button', { name: new RegExp(`${NAVER_LABEL}.*${LINK_ACCOUNT_LABEL}`) }));
+
+    expect(onLinkProvider).toHaveBeenCalledWith(naverProvider);
+  });
+
+  it('shows connected account state even when provider list has no linkable rows yet', () => {
+    renderSettingsSection({ providers: [] });
+
+    expect(screen.getByLabelText(`\uC5F0\uACB0\uB41C ${SOCIAL_ACCOUNT_LABEL}`)).toBeInTheDocument();
+    expect(screen.getByText(SOCIAL_ACCOUNT_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(CONNECTED_LABEL)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: new RegExp(LINK_ACCOUNT_LABEL) })).not.toBeInTheDocument();
+  });
+
+  it('shows all linked providers without account-link buttons when both providers are linked', () => {
+    renderSettingsSection({
+      user: { ...sessionUser, linkedProviders: ['kakao', 'naver'] },
+    });
+
+    expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
+    expect(screen.getByText(NAVER_LABEL)).toBeInTheDocument();
+    expect(screen.getAllByText(CONNECTED_LABEL)).toHaveLength(2);
+    expect(screen.queryByRole('button', { name: new RegExp(LINK_ACCOUNT_LABEL) })).not.toBeInTheDocument();
+  });
+
+  it('hides unlinked account-link providers that have no linkUrl or are disabled', () => {
+    renderSettingsSection({
+      providers: [
+        { ...kakaoProvider, isEnabled: false },
+        { ...naverProvider, linkUrl: null },
+      ],
+    });
+
+    expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
+    expect(screen.queryByText(NAVER_LABEL)).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: new RegExp(LINK_ACCOUNT_LABEL) })).not.toBeInTheDocument();
+  });
+
+});

--- a/test/unit/reviewCapability.test.ts
+++ b/test/unit/reviewCapability.test.ts
@@ -8,6 +8,7 @@ const sessionUser = {
   nickname: 'tester',
   email: null,
   provider: 'kakao',
+  linkedProviders: ['kakao'],
   profileImage: null,
   isAdmin: false,
   profileCompletedAt: null,


### PR DESCRIPTION
## 요약
- Backend/provider PR #37, #39 contract에 맞춰 Web Front 소셜 로그인/계정 연동 흐름을 분리했습니다.
- 비로그인 로그인은 `loginUrl`, 로그인 상태 계정 연동은 `linkUrl`만 사용합니다.
- 설정 섹션 안에 소셜 계정 상태를 표시하고, `linkedProviders` 기준으로 연결됨/연동 가능 상태를 구분합니다.
- provider 목록이 비어 있어도 `linkedProviders`만으로 연결된 계정 상태가 보이도록 보강했습니다.

## 주요 변경
- `AuthProvider.linkUrl?: string | null` 추가
- `SessionUser.linkedProviders: ProviderKey[]` 추가
- `MyPageSettingsSection`에 소셜 계정 상태/연동 UI 추가
- provider 표시명을 사용자-facing 한국어(`네이버`, `카카오`)로 고정
- 계정 연동용 `loginUrl` 재사용 경로 제거

## 검증
- `npm.cmd run typecheck`
- `npx vitest run test/unit/auth-provider-contract.test.tsx test/unit/reviewCapability.test.ts test/unit/useAppShellNavigation.test.ts test/regression/my-page-panel.test.tsx test/smoke/component-smoke.test.tsx`
- `npm.cmd run lint`
- `npm.cmd run build`
- `git diff --check`

Closes #357