### PR TITLE
[TSK-010-02] 소셜 계정 설정 UI 상태/액션 분리

### DIFF
--- a/src/components/my-page/MyPageSettingsSection.tsx
+++ b/src/components/my-page/MyPageSettingsSection.tsx
@@ -57,38 +57,41 @@ export function MyPageSettingsSection({
         )}
       </div>
       {socialProviderKeys.length > 0 && (
-        <div className="settings-card__links" aria-label={'\uC5F0\uACB0\uB41C \uC18C\uC15C \uACC4\uC815'}>
+        <div className="settings-card__social" aria-label={'\uC5F0\uACB0\uB41C \uC18C\uC15C \uACC4\uC815'}>
           <p className="eyebrow">{'\uC18C\uC15C \uACC4\uC815'}</p>
-          {socialProviderKeys.map((providerKey) => {
-            const provider = providerByKey.get(providerKey);
-            const isLinked = linkedProviders.includes(providerKey);
-            const providerLabel = getAuthProviderDisplayLabel({ key: providerKey });
+          <div className="settings-card__social-list">
+            {socialProviderKeys.map((providerKey) => {
+              const provider = providerByKey.get(providerKey);
+              const isLinked = linkedProviders.includes(providerKey);
+              const providerLabel = getAuthProviderDisplayLabel({ key: providerKey });
 
-            if (isLinked) {
+              if (isLinked) {
+                return (
+                  <div key={providerKey} className="settings-card__social-row" aria-label={`${providerLabel} \uC5F0\uACB0\uB428`}>
+                    <span className="settings-card__social-provider">{providerLabel}</span>
+                    <span className="settings-card__social-status">{'\uC5F0\uACB0\uB428'}</span>
+                  </div>
+                );
+              }
+
+              if (!provider) {
+                return null;
+              }
+
               return (
-                <div key={providerKey} className="settings-card__link-button secondary-button is-complete" aria-label={`${providerLabel} \uC5F0\uACB0\uB428`}>
-                  <span>{providerLabel}</span>
-                  <span className="soft-tag is-complete">{'\uC5F0\uACB0\uB428'}</span>
-                </div>
+                <button
+                  key={providerKey}
+                  type="button"
+                  className="settings-card__social-action"
+                  onClick={() => onLinkProvider(provider)}
+                  aria-label={`${providerLabel} \uACC4\uC815 \uC5F0\uB3D9`}
+                >
+                  <span className="settings-card__social-provider">{providerLabel}</span>
+                  <span className="settings-card__social-action-label">{'\uACC4\uC815 \uC5F0\uB3D9'}</span>
+                </button>
               );
-            }
-
-            if (!provider) {
-              return null;
-            }
-
-            return (
-              <button
-                key={providerKey}
-                type="button"
-                className="settings-card__link-button secondary-button"
-                onClick={() => onLinkProvider(provider)}
-              >
-                <span>{providerLabel}</span>
-                <span>{'\uACC4\uC815 \uC5F0\uB3D9'}</span>
-              </button>
-            );
-          })}
+            })}
+          </div>
         </div>
       )}
       <form className="route-builder-form" onSubmit={(event) => void onSubmit(event)}>

--- a/src/index.css
+++ b/src/index.css
@@ -358,17 +358,68 @@ textarea {
   line-height: 1;
 }
 
-.settings-card__links {
+.settings-card__social {
   display: grid;
   gap: 10px;
 }
 
-.settings-card__link-button {
+.settings-card__social-list {
+  display: grid;
+  gap: 8px;
+}
+
+.settings-card__social-row,
+.settings-card__social-action {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   width: 100%;
+  min-height: 48px;
+  padding: 12px 14px;
+  border: 1px solid rgba(255, 127, 168, 0.22);
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.78);
+  color: var(--ink);
   text-decoration: none;
+}
+
+.settings-card__social-row {
+  cursor: default;
+}
+
+.settings-card__social-action {
+  cursor: pointer;
+  font: inherit;
+}
+
+.settings-card__social-action:hover {
+  border-color: rgba(255, 89, 146, 0.58);
+  background: rgba(255, 248, 251, 0.96);
+}
+
+.settings-card__social-provider {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  color: var(--ink);
+  font-weight: 800;
+}
+
+.settings-card__social-status,
+.settings-card__social-action-label {
+  flex: 0 0 auto;
+  color: var(--pink-deep);
+  font-size: 13px;
+  font-weight: 800;
+  white-space: nowrap;
+}
+
+.settings-card__social-status {
+  padding: 5px 9px;
+  border: 1px solid rgba(255, 89, 146, 0.32);
+  border-radius: 999px;
+  background: rgba(255, 240, 246, 0.94);
+  font-size: 12px;
 }
 
 .map-stage {

--- a/test/unit/auth-provider-contract.test.tsx
+++ b/test/unit/auth-provider-contract.test.tsx
@@ -113,9 +113,13 @@ describe('provider login and account-link controls', () => {
 
     expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
     expect(screen.getByText(CONNECTED_LABEL)).toBeInTheDocument();
+    expect(screen.getByLabelText(`${KAKAO_LABEL} ${CONNECTED_LABEL}`)).toHaveClass('settings-card__social-row');
     expect(screen.queryByRole('button', { name: new RegExp(KAKAO_LABEL) })).not.toBeInTheDocument();
 
-    await user.click(screen.getByRole('button', { name: new RegExp(`${NAVER_LABEL}.*${LINK_ACCOUNT_LABEL}`) }));
+    const linkButton = screen.getByRole('button', { name: `${NAVER_LABEL} ${LINK_ACCOUNT_LABEL}` });
+    expect(linkButton).toHaveClass('settings-card__social-action');
+
+    await user.click(linkButton);
 
     expect(onLinkProvider).toHaveBeenCalledWith(naverProvider);
   });


### PR DESCRIPTION
## Summary
- 설정 안의 소셜 계정 영역에서 연결 상태와 연동 액션 UI를 분리했습니다.
- 연결된 provider는 버튼 모양이 아닌 상태 행으로 표시하고, 미연결 provider만 전용 연동 버튼으로 표시합니다.
- 연동 버튼 접근성 이름과 화면 텍스트가 `{provider} 계정 연동`으로 분리되도록 보강했습니다.

## Validation
- npm.cmd run typecheck
- npx vitest run test/unit/auth-provider-contract.test.tsx test/regression/my-page-panel.test.tsx test/smoke/component-smoke.test.tsx
- npm.cmd run lint
- npm.cmd run build
- git diff --check

Closes #359