### PR TITLE
Remove reduce closure overhead in countCommentsInThread

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-
-## 2024-05-29 - Reduce overhead in recursive loops
-**Learning:** `Array.prototype.reduce()` has significant CPU and memory overhead compared to a basic `for...of` loop, particularly when used in recursive functions dealing with arrays, because it creates a new closure allocation on every function call.
-**Action:** When counting or aggregating values recursively, replace `.reduce()` with a `for...of` loop and a mutable accumulator variable to reduce GC pressure and unnecessary memory allocations.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-29 - Reduce overhead in recursive loops
+**Learning:** `Array.prototype.reduce()` has significant CPU and memory overhead compared to a basic `for...of` loop, particularly when used in recursive functions dealing with arrays, because it creates a new closure allocation on every function call.
+**Action:** When counting or aggregating values recursively, replace `.reduce()` with a `for...of` loop and a mutable accumulator variable to reduce GC pressure and unnecessary memory allocations.

--- a/src/lib/reviews.ts
+++ b/src/lib/reviews.ts
@@ -1,7 +1,12 @@
 import type { Comment, Review } from '../types';
 
 export function countCommentsInThread(comments: Comment[]): number {
-  return comments.reduce((total, comment) => total + 1 + countCommentsInThread(comment.replies), 0);
+  // Count comments without using reduce to avoid unnecessary closure allocations
+  let count = 0;
+  for (const comment of comments) {
+    count += 1 + countCommentsInThread(comment.replies);
+  }
+  return count;
 }
 
 export function toReviewSummary(review: Review): Review {


### PR DESCRIPTION
💡 What: Replaced `Array.prototype.reduce()` with a `for...of` loop in `countCommentsInThread`.
🎯 Why: `Array.prototype.reduce()` has significant CPU and memory overhead compared to a basic `for...of` loop, particularly when used in recursive functions dealing with arrays, because it creates a new closure allocation on every function call. Using a `for...of` loop mitigates this overhead, saving GC pressure and making the recursive aggregation faster.
📊 Impact: Reduces memory allocations and GC pressure during nested comment aggregations.
🔬 Measurement: Verified that tests pass via `npm run test:all`.

---
*PR created automatically by Jules for task [10304064991494032301](https://jules.google.com/task/10304064991494032301) started by @ClarusIubar*