### PR TITLE
[TSK-010-03] 로그인 guard 계약 반영 및 연동 URL 회귀 고정

### DIFF
--- a/docs/auth-provider-contract.md
+++ b/docs/auth-provider-contract.md
@@ -1,0 +1,16 @@
+# Auth Provider Contract
+
+## URL 선택 규칙
+
+Web Front는 `/api/auth/providers` 응답의 provider URL을 다음처럼 구분해 사용한다.
+
+- 비로그인 일반 로그인 버튼은 `loginUrl`만 사용한다.
+- 로그인 상태의 계정 연동 UI는 `linkUrl`만 사용한다.
+- `linkUrl`이 없거나 provider가 disabled이면 계정 연동 버튼을 노출하지 않는다.
+- 이미 연결된 provider는 `SessionUser.linkedProviders`를 기준으로 `연결됨` 상태만 표시하고 연동 액션으로 노출하지 않는다.
+
+## Backend Login Guard
+
+Backend/provider Worker는 로그인된 사용자가 다른 provider의 `/api/auth/{provider}/login`을 호출하는 오사용을 link-mode OAuth state로 방어한다. 같은 provider의 `/login` 재호출은 OAuth를 시작하지 않고 `provider-already-linked` error redirect를 반환한다.
+
+이 guard는 방어막일 뿐 Web Front의 정상 연동 경로가 아니다. Web Front 계정 연동 UI와 action은 계속 `providers[].linkUrl`을 사용해야 한다.

--- a/test/unit/auth-provider-contract.test.tsx
+++ b/test/unit/auth-provider-contract.test.tsx
@@ -84,6 +84,19 @@ describe('auth provider contract', () => {
     expect(getProviderLinkUrl({ ...naverProvider, linkUrl: null }, FRONTEND_RETURN_URL)).toBeNull();
   });
 
+  it('does not use loginUrl as an authenticated account-link fallback', () => {
+    const guardedLoginProvider: AuthProvider = {
+      ...naverProvider,
+      loginUrl: '/api/auth/naver/login',
+      linkUrl: null,
+    };
+
+    expect(getProviderLoginUrl(guardedLoginProvider, FRONTEND_RETURN_URL)).toBe(
+      `${API_BASE_URL}/api/auth/naver/login?next=https%3A%2F%2Fdaejeon.jamissue.com%2F%3Ftab%3Dmy`,
+    );
+    expect(getProviderLinkUrl(guardedLoginProvider, FRONTEND_RETURN_URL)).toBeNull();
+  });
+
   it('preserves absolute provider origins while adding the return URL', () => {
     expect(buildProviderAuthUrl('https://oauth.example.test/auth/link?prompt=login', FRONTEND_RETURN_URL)).toBe(
       'https://oauth.example.test/auth/link?prompt=login&next=https%3A%2F%2Fdaejeon.jamissue.com%2F%3Ftab%3Dmy',
@@ -156,6 +169,22 @@ describe('provider login and account-link controls', () => {
     expect(screen.getByText(KAKAO_LABEL)).toBeInTheDocument();
     expect(screen.queryByText(NAVER_LABEL)).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: new RegExp(LINK_ACCOUNT_LABEL) })).not.toBeInTheDocument();
+  });
+
+  it('does not expose backend login guard paths as account-link buttons', () => {
+    renderSettingsSection({
+      providers: [
+        kakaoProvider,
+        {
+          ...naverProvider,
+          loginUrl: '/api/auth/naver/login',
+          linkUrl: null,
+        },
+      ],
+    });
+
+    expect(screen.getByLabelText(`${KAKAO_LABEL} ${CONNECTED_LABEL}`)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: `${NAVER_LABEL} ${LINK_ACCOUNT_LABEL}` })).not.toBeInTheDocument();
   });
 
 });


### PR DESCRIPTION
## Summary
- Backend/provider PR #57의 로그인 guard 계약을 Web Front 문서에 명시했습니다.
- 계정 연동 UI/action은 계속 `providers[].linkUrl`만 정상 경로로 사용해야 한다는 회귀 테스트를 추가했습니다.
- `loginUrl`은 비로그인 일반 로그인용으로 유지하고, authenticated account-link fallback으로 쓰지 않도록 고정했습니다.

## Backend Contract 확인
- 참조 repo: `ClarusIubar/JamIssue_admin`
- 확인 PR: https://github.com/ClarusIubar/JamIssue_admin/pull/57
- 백엔드 repo는 수정하지 않았습니다.

## Validation
- `npm.cmd run typecheck` PASS
- `npx vitest run test/unit/auth-provider-contract.test.tsx test/regression/my-page-panel.test.tsx test/smoke/component-smoke.test.tsx` PASS, 3 files / 11 tests
- `npm.cmd run lint` PASS
- `npm.cmd run build` PASS
- `git diff --check` PASS

Closes #362