### PR TITLE
Prevent O(N) memory allocations when prepending items to state arrays

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,4 +1,0 @@
-
-## 2024-05-30 - Prevent O(N) memory allocations when prepending items
-**Learning:** When adding a new item to the beginning of a React state array using the spread operator (`[nextItem, ...current.filter(...)]`), `array.filter(...)` creates an intermediate array in memory that is immediately discarded after the spread syntax is executed. In large lists (like feed reviews or comments), this causes an unnecessary $O(N)$ memory allocation and subsequent GC pressure during common list updates (upserts).
-**Action:** Instead of combining the spread operator with `filter` for prepending and filtering simultaneously, build the new array in a single pass using a standard `for...of` loop (e.g., `const next = [nextItem]; for (const item of current) { if (item.id !== nextItem.id) next.push(item); }`). This performs the update strictly in one allocation while avoiding intermediate GC garbage.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,4 @@
+
+## 2024-05-30 - Prevent O(N) memory allocations when prepending items
+**Learning:** When adding a new item to the beginning of a React state array using the spread operator (`[nextItem, ...current.filter(...)]`), `array.filter(...)` creates an intermediate array in memory that is immediately discarded after the spread syntax is executed. In large lists (like feed reviews or comments), this causes an unnecessary $O(N)$ memory allocation and subsequent GC pressure during common list updates (upserts).
+**Action:** Instead of combining the spread operator with `filter` for prepending and filtering simultaneously, build the new array in a single pass using a standard `for...of` loop (e.g., `const next = [nextItem]; for (const item of current) { if (item.id !== nextItem.id) next.push(item); }`). This performs the update strictly in one allocation while avoiding intermediate GC garbage.

--- a/src/hooks/app-data/useReviewCollectionState.ts
+++ b/src/hooks/app-data/useReviewCollectionState.ts
@@ -67,18 +67,25 @@ export function useReviewCollectionState(selectedPlaceId: string | null) {
 
   function upsertReviewCollections(review: ReviewSummary) {
     const nextReview = toReviewSummary(review);
-    setReviews((current) => [nextReview, ...current.filter((currentReview) => currentReview.id !== review.id)]);
+
+    // Performance optimization: Avoid intermediate array allocations and GC pressure
+    // by using a single for...of loop instead of [...array.filter()]
+    const insertOrMoveToFront = (collection: ReviewSummary[]) => {
+      const next = [nextReview];
+      for (const item of collection) {
+        if (item.id !== nextReview.id) {
+          next.push(item);
+        }
+      }
+      return next;
+    };
+
+    setReviews(insertOrMoveToFront);
     if (selectedPlaceId === review.placeId) {
-      setSelectedPlaceReviews((current) => [
-        nextReview,
-        ...current.filter((currentReview) => currentReview.id !== review.id),
-      ]);
+      setSelectedPlaceReviews(insertOrMoveToFront);
     }
     const cachedPlaceReviews = placeReviewsCacheRef.current[review.placeId] ?? [];
-    placeReviewsCacheRef.current[review.placeId] = [
-      nextReview,
-      ...cachedPlaceReviews.filter((currentReview) => currentReview.id !== review.id),
-    ];
+    placeReviewsCacheRef.current[review.placeId] = insertOrMoveToFront(cachedPlaceReviews);
   }
 
   function resetReviewCaches() {


### PR DESCRIPTION
💡 **What**: Replaced the inefficient `[nextItem, ...current.filter()]` array generation logic with a single-pass `for...of` loop in `useReviewCollectionState.ts`'s `upsertReviewCollections`.
🎯 **Why**: When updating React state arrays with new items at the front, combining the spread operator with `filter` creates an intermediate array in memory that is immediately discarded after the spread syntax is executed. In large lists (like feed reviews or comments), this causes an unnecessary O(N) memory allocation and subsequent GC pressure.
📊 **Impact**: Reduces O(N) intermediate memory allocations and lowers GC pressure during common list updates (upserts), contributing to smoother UI performance when writing or syncing reviews.
🔬 **Measurement**: Verified by running `npm run test:all` to ensure no regressions in state updates or component behavior.

---
*PR created automatically by Jules for task [4461984074859810480](https://jules.google.com/task/4461984074859810480) started by @ClarusIubar*