### PR TITLE
avoid intermediate array allocations in state upserts

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,3 +1,0 @@
-## 2026-06-01 - Avoid spread operator combined with .filter()
-**Learning:** When prepending items to a React state array or performing upserts, using the spread operator combined with `.filter()` (e.g., `[nextItem, ...current.filter(...)]`) creates an unnecessary intermediate array, triggering memory allocation and GC pressure.
-**Action:** Use a single-pass `for...of` loop to construct the new array directly, avoiding intermediate allocations.

--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-01 - Avoid spread operator combined with .filter()
+**Learning:** When prepending items to a React state array or performing upserts, using the spread operator combined with `.filter()` (e.g., `[nextItem, ...current.filter(...)]`) creates an unnecessary intermediate array, triggering memory allocation and GC pressure.
+**Action:** Use a single-pass `for...of` loop to construct the new array directly, avoiding intermediate allocations.

--- a/src/hooks/app-data/useReviewCollectionState.ts
+++ b/src/hooks/app-data/useReviewCollectionState.ts
@@ -1,17 +1,24 @@
-import { useRef, useState } from 'react';
-import { toReviewSummary } from '../../lib/reviews';
-import type { BootstrapResponse } from '../../types/review';
+import { useRef, useState } from "react";
+import { toReviewSummary } from "../../lib/reviews";
+import type { BootstrapResponse } from "../../types/review";
 
-type ReviewSummary = BootstrapResponse['reviews'][number];
+type ReviewSummary = BootstrapResponse["reviews"][number];
 
 export function useReviewCollectionState(selectedPlaceId: string | null) {
-  const [reviews, setReviews] = useState<BootstrapResponse['reviews']>([]);
-  const [selectedPlaceReviews, setSelectedPlaceReviews] = useState<BootstrapResponse['reviews']>([]);
-  const placeReviewsCacheRef = useRef<Record<string, BootstrapResponse['reviews']>>({});
+  const [reviews, setReviews] = useState<BootstrapResponse["reviews"]>([]);
+  const [selectedPlaceReviews, setSelectedPlaceReviews] = useState<
+    BootstrapResponse["reviews"]
+  >([]);
+  const placeReviewsCacheRef = useRef<
+    Record<string, BootstrapResponse["reviews"]>
+  >({});
   const feedLoadedRef = useRef(false);
   const coursesLoadedRef = useRef(false);
 
-  function patchReviewCollections(reviewId: string, updater: (review: ReviewSummary) => ReviewSummary) {
+  function patchReviewCollections(
+    reviewId: string,
+    updater: (review: ReviewSummary) => ReviewSummary,
+  ) {
     const hasReview = (r: ReviewSummary) => r.id === reviewId;
     let patchedReview: ReviewSummary | null = null;
     const getPatched = (original: ReviewSummary) => {
@@ -37,7 +44,8 @@ export function useReviewCollectionState(selectedPlaceId: string | null) {
       return next;
     });
 
-    const existingReview = reviews.find(hasReview) || selectedPlaceReviews.find(hasReview);
+    const existingReview =
+      reviews.find(hasReview) || selectedPlaceReviews.find(hasReview);
     if (existingReview) {
       const { placeId } = existingReview;
       const collection = placeReviewsCacheRef.current[placeId];
@@ -67,18 +75,37 @@ export function useReviewCollectionState(selectedPlaceId: string | null) {
 
   function upsertReviewCollections(review: ReviewSummary) {
     const nextReview = toReviewSummary(review);
-    setReviews((current) => [nextReview, ...current.filter((currentReview) => currentReview.id !== review.id)]);
+    // Optimization: Using for...of instead of spread+filter to avoid intermediate array allocation
+    setReviews((current) => {
+      const next = [nextReview];
+      for (const currentReview of current) {
+        if (currentReview.id !== review.id) {
+          next.push(currentReview);
+        }
+      }
+      return next;
+    });
     if (selectedPlaceId === review.placeId) {
-      setSelectedPlaceReviews((current) => [
-        nextReview,
-        ...current.filter((currentReview) => currentReview.id !== review.id),
-      ]);
+      // Optimization: Using for...of instead of spread+filter to avoid intermediate array allocation
+      setSelectedPlaceReviews((current) => {
+        const next = [nextReview];
+        for (const currentReview of current) {
+          if (currentReview.id !== review.id) {
+            next.push(currentReview);
+          }
+        }
+        return next;
+      });
     }
-    const cachedPlaceReviews = placeReviewsCacheRef.current[review.placeId] ?? [];
-    placeReviewsCacheRef.current[review.placeId] = [
-      nextReview,
-      ...cachedPlaceReviews.filter((currentReview) => currentReview.id !== review.id),
-    ];
+    const cachedPlaceReviews =
+      placeReviewsCacheRef.current[review.placeId] ?? [];
+    const nextCached = [nextReview];
+    for (const currentReview of cachedPlaceReviews) {
+      if (currentReview.id !== review.id) {
+        nextCached.push(currentReview);
+      }
+    }
+    placeReviewsCacheRef.current[review.placeId] = nextCached;
   }
 
   function resetReviewCaches() {

--- a/src/hooks/app-route-actions/publishRouteAction.ts
+++ b/src/hooks/app-route-actions/publishRouteAction.ts
@@ -1,12 +1,12 @@
-import type { Dispatch, MutableRefObject, SetStateAction } from 'react';
-import { createUserRoute } from '../../api/routesClient';
-import type { MyPageTabKey, Tab } from '../../types/core';
-import type { SessionUser } from '../../types/auth';
-import type { UserRoute } from '../../types/review';
-import type { MyPageResponse } from '../../types/my-page';
+import type { Dispatch, MutableRefObject, SetStateAction } from "react";
+import { createUserRoute } from "../../api/routesClient";
+import type { MyPageTabKey, Tab } from "../../types/core";
+import type { SessionUser } from "../../types/auth";
+import type { UserRoute } from "../../types/review";
+import type { MyPageResponse } from "../../types/my-page";
 
-type CommunityRoutesCache = Partial<Record<'popular' | 'latest', UserRoute[]>>;
-type HistoryMode = 'push' | 'replace';
+type CommunityRoutesCache = Partial<Record<"popular" | "latest", UserRoute[]>>;
+type HistoryMode = "push" | "replace";
 
 interface CreatePublishRouteHandlerParams {
   sessionUser: SessionUser | null;
@@ -16,7 +16,10 @@ interface CreatePublishRouteHandlerParams {
   setMyPageTab: (value: MyPageTabKey) => void;
   setMyPage: Dispatch<SetStateAction<MyPageResponse | null>>;
   communityRoutesCacheRef: MutableRefObject<CommunityRoutesCache>;
-  refreshMyPageForUser: (user: SessionUser | null, force?: boolean) => Promise<MyPageResponse | null>;
+  refreshMyPageForUser: (
+    user: SessionUser | null,
+    force?: boolean,
+  ) => Promise<MyPageResponse | null>;
   formatErrorMessage: (error: unknown) => string;
   goToTab: (nextTab: Tab, historyMode?: HistoryMode) => void;
 }
@@ -40,8 +43,8 @@ export function createPublishRouteHandler({
     mood: string;
   }) {
     if (!sessionUser) {
-      goToTab('my');
-      setRouteError('로그인하면 여행 세션을 코스로 발행할 수 있어요.');
+      goToTab("my");
+      setRouteError("로그인하면 여행 세션을 코스로 발행할 수 있어요.");
       return;
     }
 
@@ -55,30 +58,51 @@ export function createPublishRouteHandler({
         mood: payload.mood,
         isPublic: true,
       });
+      // Optimization: Using for...of instead of spread+filter to avoid intermediate array allocation
+      const nextLatest = [createdRoute];
+      const currentLatest = communityRoutesCacheRef.current.latest ?? [];
+      for (const route of currentLatest) {
+        if (route.id !== createdRoute.id) {
+          nextLatest.push(route);
+        }
+      }
+
       communityRoutesCacheRef.current = {
         ...communityRoutesCacheRef.current,
-        latest: [createdRoute, ...(communityRoutesCacheRef.current.latest ?? []).filter((route) => route.id !== createdRoute.id)],
+        latest: nextLatest,
       };
       delete communityRoutesCacheRef.current.popular;
       setMyPage((current) => {
         if (!current) {
           return current;
         }
-        const routeExists = current.routes.some((route) => route.id === createdRoute.id);
+        const routeExists = current.routes.some(
+          (route) => route.id === createdRoute.id,
+        );
+        const nextRoutes = [createdRoute];
+        for (const route of current.routes) {
+          if (route.id !== createdRoute.id) {
+            nextRoutes.push(route);
+          }
+        }
         return {
           ...current,
-          routes: [createdRoute, ...current.routes.filter((route) => route.id !== createdRoute.id)],
+          routes: nextRoutes,
           travelSessions: current.travelSessions.map((session) =>
-            session.id === payload.travelSessionId ? { ...session, publishedRouteId: createdRoute.id } : session,
+            session.id === payload.travelSessionId
+              ? { ...session, publishedRouteId: createdRoute.id }
+              : session,
           ),
           stats: {
             ...current.stats,
-            routeCount: routeExists ? current.stats.routeCount : current.stats.routeCount + 1,
+            routeCount: routeExists
+              ? current.stats.routeCount
+              : current.stats.routeCount + 1,
           },
         };
       });
-      setNotice('코스를 발행했어요. 공개 경로 탭에서 바로 확인할 수 있어요.');
-      setMyPageTab('routes');
+      setNotice("코스를 발행했어요. 공개 경로 탭에서 바로 확인할 수 있어요.");
+      setMyPageTab("routes");
       await refreshMyPageForUser(sessionUser, true);
     } catch (error) {
       setRouteError(formatErrorMessage(error));

--- a/src/store/notification-store/helpers.ts
+++ b/src/store/notification-store/helpers.ts
@@ -1,5 +1,5 @@
-import type { NotificationStoreState } from './types';
-import type { UserNotification } from '../../types';
+import type { NotificationStoreState } from "./types";
+import type { UserNotification } from "../../types";
 
 type NotificationCreatedPayload = {
   notification: UserNotification;
@@ -25,7 +25,7 @@ export function countUnread(notifications: UserNotification[]) {
 }
 
 export function clearReconnectTimer(timer: number | null) {
-  if (timer !== null && typeof window !== 'undefined') {
+  if (timer !== null && typeof window !== "undefined") {
     window.clearTimeout(timer);
   }
 }
@@ -34,11 +34,18 @@ export function applyCreatedNotification(
   state: NotificationStoreState,
   { notification, unreadCount }: NotificationCreatedPayload,
 ): Partial<NotificationStoreState> {
+  // Optimization: Using for...of instead of spread+filter to avoid intermediate array allocation
+  const notifications = [notification];
+  for (const item of state.notifications) {
+    if (item.id !== notification.id) {
+      notifications.push(item);
+    }
+  }
   return {
-    notifications: [notification, ...state.notifications.filter((item) => item.id !== notification.id)],
+    notifications,
     unreadCount,
     connected: true,
-    status: 'ready',
+    status: "ready",
     error: null,
   };
 }
@@ -47,7 +54,9 @@ export function applyReadNotification(
   state: NotificationStoreState,
   { notificationId, unreadCount }: NotificationReadPayload,
 ): Partial<NotificationStoreState> {
-  const idx = state.notifications.findIndex((notification) => notification.id === notificationId);
+  const idx = state.notifications.findIndex(
+    (notification) => notification.id === notificationId,
+  );
   if (idx === -1) {
     return {
       unreadCount,
@@ -91,7 +100,9 @@ export function applyDeletedNotification(
   { notificationId, unreadCount }: NotificationReadPayload,
 ): Partial<NotificationStoreState> {
   return {
-    notifications: state.notifications.filter((notification) => notification.id !== notificationId),
+    notifications: state.notifications.filter(
+      (notification) => notification.id !== notificationId,
+    ),
     unreadCount,
     connected: true,
   };
@@ -101,7 +112,7 @@ export const initialNotificationStoreState: NotificationStoreState = {
   notifications: [],
   unreadCount: 0,
   connected: false,
-  status: 'idle',
+  status: "idle",
   error: null,
   channel: null,
   reconnectTimer: null,


### PR DESCRIPTION
💡 What: Replaced array upsert patterns that combined the spread operator with `.filter()` with a single-pass `for...of` loop in `useReviewCollectionState`, `notification-store/helpers`, and `publishRouteAction`. Added code comments to prevent regressions.

🎯 Why: Using `[nextItem, ...current.filter(...)]` creates an intermediate array solely for filtering elements before spreading them, causing unnecessary memory allocation and garbage collection overhead on state updates.

📊 Impact: Reduces memory allocation by avoiding intermediate arrays during multiple frequent UI interactions (e.g., publishing reviews, handling notifications, and creating routes).

🔬 Measurement: Verifiable via heap allocation snapshotting under frequent update interactions; ensuring identical length arrays without intermediate objects being marked for collection. Unit and integration test suites pass, proving behavior is unaffected.

---
*PR created automatically by Jules for task [1158295290345149768](https://jules.google.com/task/1158295290345149768) started by @ClarusIubar*