### PR TITLE
docs: align Web Front service ownership entry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # JamIssue Web Front
 
-`STH-1-Class-One-Group/JamIssue`는 MSA 전환을 위해 분리된 JamIssue Web Front 서비스 레포입니다.
+`STH-1-Class-One-Group/JamIssue`는 MSA 전환을 위해 분리한 JamIssue Web Front service 레포입니다.
 
 이 레포는 사용자가 접속하는 React 기반 Web Front와 Cloudflare Pages 배포를 담당합니다. Backend API 구현, Cloudflare Worker, DB schema/migration, 관리자 서비스, provider-side API contract의 정본은 별도 서비스 레포인 `ClarusIubar/JamIssue_admin`에서 관리합니다.
 
-** 아키텍처 변경 이전 코드는 <1.3버전의 release 혹은 https://github.com/ClarusIubar/JamIssue_fork 를 참조하세요.
+아키텍처 변경 이전 코드와 release 맥락은 `ClarusIubar/JamIssue_fork`와 이전 release 기록을 참고합니다. 현재 이 레포의 소유권 판단 기준은 과거 same-repo 구조가 아니라 Web Front service 경계입니다.
 
 ## MSA 서비스 분리 기준
 
@@ -14,7 +14,7 @@
 | Backend/API service | Cloudflare Worker/API 구현, OAuth/session, provider-side API contract, runtime secret |
 | Admin/Data service | 관리자 기능, DB schema/migration, 데이터 운영, service-role 작업 |
 
-`SPA`는 이 레포의 프론트 구현 형태입니다. 레포의 소유권과 아키텍처 기준은 `Web Front service`입니다.
+`SPA`는 이 레포의 프론트 구현 방식입니다. 레포의 소유권과 아키텍처 기준은 `Web Front service`입니다.
 
 ## 이 레포가 소유하는 것
 
@@ -57,9 +57,9 @@ Provider-side API contract, Worker handler, DB row/schema, migration, OAuth runt
 PUBLIC_APP_BASE_URL=https://api.daejeon.jamissue.com
 ```
 
-`PUBLIC_APP_BASE_URL`은 이름에 `APP`이 들어가지만, 현재 Web Front에서는 API base URL로 사용합니다.
+`PUBLIC_APP_BASE_URL`은 이름에 `APP`가 들어가지만 현재 Web Front에서는 API base URL로 사용합니다.
 
-선택 public env:
+주요 public env:
 
 ```env
 PUBLIC_NAVER_MAP_CLIENT_ID=
@@ -67,7 +67,7 @@ PUBLIC_SUPABASE_URL=
 PUBLIC_SUPABASE_ANON_KEY=
 ```
 
-이 레포에는 public client env만 둡니다. service-role key, OAuth secret, Worker runtime secret, DB migration credential은 저장하지 않습니다.
+이 레포에는 public client env만 둡니다. service-role key, OAuth secret, Worker runtime secret, DB migration credential은 두지 않습니다.
 
 ## Cloudflare
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,28 +7,24 @@ JamIssue Web Front service 문서는 아래 기준으로 관리합니다.
 - [api-contract-ownership.md](api-contract-ownership.md)
   - MSA 분리 이후 Web Front service가 소유하는 consumer-side API contract
   - `ClarusIubar/JamIssue_admin`이 소유하는 provider-side API contract
-  - backend 제거 이후 이 레포에 남아 있는 API 관련 파일 위치
+  - 현재 레포에 남아 있는 API 관련 파일 위치
 - [prd-compliance.md](prd-compliance.md)
   - PRD 대비 현재 구현 상태
   - 구현됨 / 부분 구현 / 미구현 구분
-- [ui-ux-qa-matrix.md](ui-ux-qa-matrix.md)
-  - UI/UX 기대 동작 추적
-  - 자동 테스트와 수동 QA 근거 연결
 - [testing-coverage.md](testing-coverage.md)
   - 테스트/커버리지 기준
   - Web Front service 검증 명령
 
-## 2. 배포 기준 문서
+## 2. 운영 문서
 
 - [growgardens-deploy-runbook.md](growgardens-deploy-runbook.md)
-  - `main` 배포 기준
-  - GitHub Actions 배포 방식
-  - GitHub / Cloudflare / Naver / Kakao에 넣어야 할 키 위치
+  - 현재 문서는 historical/reference 성격이 강합니다.
+  - backend/API/Worker 운영 정본으로 사용하지 않습니다.
 - [data-operations-runbook.md](data-operations-runbook.md)
-  - 장소, 이미지, 공공데이터 운영 수정 절차
-  - 전체 리셋 및 재적재 절차
+  - 현재 문서는 historical/reference 성격이 강합니다.
+  - DB 재적재와 운영 데이터 절차의 최신 정본은 `ClarusIubar/JamIssue_admin`에서 확인합니다.
 
-주의: Backend/API/Worker/DB/admin 운영 절차의 정본은 `ClarusIubar/JamIssue_admin`입니다. 이 레포의 runbook은 MSA 중 Web Front service 관점에서 필요한 참조만 유지합니다.
+주의: Backend/API/Worker/DB/admin 운영 절차의 정본은 `ClarusIubar/JamIssue_admin`입니다. 이 레포의 runbook은 Web Front service 관점의 참조만 유지합니다.
 
 ## 3. 화면/기능 설계 문서
 
@@ -37,19 +33,14 @@ JamIssue Web Front service 문서는 아래 기준으로 관리합니다.
 - [account-identity-schema.md](account-identity-schema.md)
 - [search-recommendation-scope.md](search-recommendation-scope.md)
 
-## 4. 리팩터링과 추적성 문서
+## 4. 추적성 문서
 
 - [operations-refactor-roadmap.md](operations-refactor-roadmap.md)
-- [worker-backend-solid-traceability.md](worker-backend-solid-traceability.md)
-- [config-hardening-traceability.md](config-hardening-traceability.md)
-- [interface-locality-baseline.md](interface-locality-baseline.md)
-- [interface-locality-traceability.md](interface-locality-traceability.md)
-- [architecture-regression-traceability.md](architecture-regression-traceability.md)
-- [human-readable-architecture-baseline.md](human-readable-architecture-baseline.md)
-- [human-readable-architecture-traceability.md](human-readable-architecture-traceability.md)
 - [release-1.2.10-traceability.md](release-1.2.10-traceability.md)
+- [architecture-regression-traceability.md](architecture-regression-traceability.md)
+- [human-readable-architecture-traceability.md](human-readable-architecture-traceability.md)
 
-## 5. Legacy/reference 문서
+## 5. Legacy/Reference 문서
 
 아래 문서는 Web Front와 backend가 같은 레포에 있던 시기의 설계/분석 기록을 포함할 수 있습니다. 최신 backend/API 정본으로 사용하지 않습니다.
 
@@ -58,8 +49,12 @@ JamIssue Web Front service 문서는 아래 기준으로 관리합니다.
 - [issue-55-improved.md](issue-55-improved.md)
 - [worker-first-poc.md](worker-first-poc.md)
 - [worker-backend-solid-baseline.md](worker-backend-solid-baseline.md)
+- [worker-backend-solid-traceability.md](worker-backend-solid-traceability.md)
 - [worker-residual-boundary-traceability.md](worker-residual-boundary-traceability.md)
 - [comment-performance-fix.md](comment-performance-fix.md)
 - [review-image-loading.md](review-image-loading.md)
+- [config-hardening-traceability.md](config-hardening-traceability.md)
+- [interface-locality-baseline.md](interface-locality-baseline.md)
+- [interface-locality-traceability.md](interface-locality-traceability.md)
 
 이 문서들에 `backend/`, Worker, DB schema, migration 경로가 남아 있어도 현재 Web Front service 레포의 소유권을 의미하지 않습니다. 최신 구현과 운영 정본은 `ClarusIubar/JamIssue_admin`에서 확인합니다.

--- a/docs/api-contract-ownership.md
+++ b/docs/api-contract-ownership.md
@@ -33,13 +33,13 @@ Backend API 구현, Cloudflare Worker handler, DB schema/migration, provider-sid
 | 위치 | 책임 |
 | --- | --- |
 | [../src/api/core.ts](../src/api/core.ts) | `fetchJson`, API base URL, cache, `ApiError`, 인증 만료 이벤트 |
-| [../src/api/bootstrapClient.ts](../src/api/bootstrapClient.ts) | bootstrap, map bootstrap, curated courses 호출 + 초기 화면에 필요한 event 계열(festivals, public event banner) 호출 |
+| [../src/api/bootstrapClient.ts](../src/api/bootstrapClient.ts) | bootstrap, map bootstrap, curated courses, event 계열 호출 |
 | [../src/api/authClient.ts](../src/api/authClient.ts) | provider login URL 생성, logout, profile update 호출 |
 | [../src/api/reviewsClient.ts](../src/api/reviewsClient.ts) | review, feed, comment, like, upload 호출 |
 | [../src/api/myClient.ts](../src/api/myClient.ts) | my page summary, notification, my comments 호출 |
 | [../src/api/routesClient.ts](../src/api/routesClient.ts) | community route 생성/조회/like 호출 |
 | [../src/api/stampClient.ts](../src/api/stampClient.ts) | stamp claim 호출 |
-| [../src/api/adminClient.ts](../src/api/adminClient.ts) | Web Front에서 남아 있는 admin import/public-data, places/{placeId} 호출부 |
+| [../src/api/adminClient.ts](../src/api/adminClient.ts) | Web Front에 남아 있는 admin import/public-data, places 호출부 |
 | [../src/types.ts](../src/types.ts) | Web Front consumer DTO barrel |
 | [../src/types](../src/types) | auth, core, review, my-page, admin DTO |
 
@@ -84,7 +84,7 @@ npm.cmd run build
 
 Provider-side API contract 검증, DB migration 검증, Worker route integration test는 `ClarusIubar/JamIssue_admin`에서 수행합니다.
 
-## 현재 남은 문서 리스크
+## Legacy/Reference 문서 기준
 
 이 레포의 일부 `docs` 문서는 Web Front와 backend가 같은 레포에 있던 시기의 경로를 포함합니다. 예를 들어 `backend/app`, Worker, DB migration 경로가 남아 있을 수 있습니다.
 

--- a/reports/completion/TSK-010-02-web-front-ownership-docs.md
+++ b/reports/completion/TSK-010-02-web-front-ownership-docs.md
@@ -1,0 +1,30 @@
+# TSK-010-02 Web Front Ownership Docs
+
+- Scope-ID: `TSK-010-02`
+- Issue: `#371`
+- Branch: `web-front-ownership-docs`
+- Status: `in_progress`
+- Parent Issue: `#369`
+- Child Issue: `#371`
+
+## Change Summary
+
+- `README.md`를 Web Front service ownership 기준으로 정리했습니다.
+- `docs/README.md`를 현재 정본 문서와 legacy/reference 문서 구분 기준에 맞게 정리했습니다.
+- `docs/api-contract-ownership.md`를 consumer-side vs provider-side contract 경계 기준으로 다시 정리했습니다.
+- GitHub Wiki의 `Home`, `MSA-Service-Ownership`, `Architecture-Overview`를 같은 ownership 기준으로 정리했습니다.
+
+## Validation
+
+- `git status --short --branch`
+- UTF-8 read check
+- Markdown link check
+- Wiki link check
+- `git diff --check`
+
+## Evidence To Record After Publish
+
+- Repo commit SHA
+- Repo push URL or PR URL
+- Wiki commit SHA
+- Main merge SHA or docs-only push SHA


### PR DESCRIPTION
## Summary
- align README with the Web Front service ownership baseline from #370
- align docs ownership guidance and add a scope-first completion report
- keep provider-side ownership pointed at ClarusIubar/JamIssue_admin

## Validation
- git diff --check
- UTF-8 read check
- Markdown link check

Closes #371