### PR TITLE
⚡ Bolt: [Performance Improvement] Prevent O(N) allocations and re-renders on missing state item deletions

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2026-06-09 - [Optimizing Single Item Array Removals]
+**Learning:** In state array updates (like `useAppReviewCrudActions.ts`), using `.filter()` unconditionally creates O(N) intermediate array allocations and object recreation, triggering React state updates even if the element doesn't exist in the array. This happens when deleting items where the item may not be present in multiple state stores.
+**Action:** Replace `current.filter(...)` with `current.findIndex(...)`. If the item isn't found (returns -1), return the exact `current` array reference to skip unnecessary reconciliation. If found, use `splice` on a shallow copy to remove the item optimally.

--- a/src/store/notification-store/actions.ts
+++ b/src/store/notification-store/actions.ts
@@ -168,10 +168,17 @@ export function createNotificationStoreActions(set: SetState, get: GetState): No
     async deleteNotification(notificationId) {
       await deleteNotificationRequest(notificationId);
       set((state) => {
-        const notifications = state.notifications.filter((notification) => notification.id !== notificationId);
+        const idx = state.notifications.findIndex((notification) => notification.id === notificationId);
+        if (idx === -1) {
+          return state;
+        }
+
+        const nextNotifications = [...state.notifications];
+        nextNotifications.splice(idx, 1);
+
         return {
-          notifications,
-          unreadCount: countUnread(notifications),
+          notifications: nextNotifications,
+          unreadCount: countUnread(nextNotifications),
         };
       });
     },

--- a/src/store/notification-store/helpers.ts
+++ b/src/store/notification-store/helpers.ts
@@ -97,8 +97,19 @@ export function applyDeletedNotification(
   state: NotificationStoreState,
   { notificationId, unreadCount }: NotificationReadPayload,
 ): Partial<NotificationStoreState> {
+  const idx = state.notifications.findIndex((notification) => notification.id === notificationId);
+  if (idx === -1) {
+    return {
+      unreadCount,
+      connected: true,
+    };
+  }
+
+  const nextNotifications = [...state.notifications];
+  nextNotifications.splice(idx, 1);
+
   return {
-    notifications: state.notifications.filter((notification) => notification.id !== notificationId),
+    notifications: nextNotifications,
     unreadCount,
     connected: true,
   };


### PR DESCRIPTION
💡 What: Replaced unconditional `.filter()` operations with `.findIndex()` lookups when removing single items from React state arrays in `src/store/notification-store/actions.ts` and `src/store/notification-store/helpers.ts`. When an item is not found, the original array reference is returned to abort the update entirely.

🎯 Why: Calling `.filter()` always creates a brand new array, triggering O(N) memory allocations, garbage collection pressure, and, importantly, unnecessary React state reconciliations, even if the target item does not exist in the array. This happens frequently when deleting a resource that might be present in some state arrays but not others.

📊 Impact: Reduces O(N) memory allocations and eliminates unnecessary React component tree re-renders for missing targets, resulting in a tighter, more efficient state update cycle for deletions.

🔬 Measurement: Review `src/store/notification-store/actions.ts` and `helpers.ts`. Array object identities remain stable across `deleteNotification` dispatches if the item was already absent from the local view. The tests pass cleanly.

---
*PR created automatically by Jules for task [12753926019551412995](https://jules.google.com/task/12753926019551412995) started by @ClarusIubar*