### PR TITLE
TSK-013-01 KTO tourism contract consumption

### DIFF
--- a/deploy/api-worker-shell/config/runtime.ts
+++ b/deploy/api-worker-shell/config/runtime.ts
@@ -41,6 +41,12 @@ export class WorkerFestivalRuntimeConfig {
   static readonly internalSourceUrl = 'https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504';
 }
 
+export class WorkerTourismRuntimeConfig {
+  static readonly defaultPlacesLimit = 50;
+  static readonly maxPlacesLimit = 100;
+  static readonly facetQueryLimit = 10000;
+}
+
 export class WorkerNotificationRuntimeConfig {
   static readonly defaultListLimit = 30;
   static readonly myNotificationsListLimit = 50;

--- a/deploy/api-worker-shell/runtime/route-registry.ts
+++ b/deploy/api-worker-shell/runtime/route-registry.ts
@@ -11,6 +11,7 @@ import {
   readSessionUser,
 } from '../services/auth';
 import { handleBannerEvents, handleFestivalImport, handleFestivals } from '../services/festivals';
+import { handleTourismPlaces } from '../services/tourism';
 import {
   handleDeleteNotification,
   handleMarkAllNotificationsRead,
@@ -64,6 +65,7 @@ export function createExactRoutes(request: Request, env: WorkerEnv, url: URL, ru
     ['PATCH', '/api/notifications/read-all', () => handleMarkAllNotificationsRead(request, env)],
     ['GET', '/api/festivals', () => handleFestivals(request, env)],
     ['GET', '/api/banner/events', () => handleBannerEvents(request, env)],
+    ['GET', '/api/tourism/places', () => handleTourismPlaces(request, env)],
     ['POST', '/api/internal/public-events/import', () => handleFestivalImport(request, env)],
     ['GET', '/api/admin/summary', () => runtime.adminService.handleAdminSummary(request, env)],
     ['POST', '/api/admin/import/public-data', () => runtime.adminService.handleAdminImportPublicData(request, env)],

--- a/deploy/api-worker-shell/services/festival-domain/read-service.ts
+++ b/deploy/api-worker-shell/services/festival-domain/read-service.ts
@@ -12,10 +12,18 @@ import { buildBannerItem, buildFestivalCard, getFestivalWindowEnd, getTargetFest
 import { loadFestivalRows, loadFestivalSourceMetadata } from './repository';
 
 async function loadConfiguredFestivalRows(env: WorkerEnv, now: number, limit: number) {
+  const source = (await loadFestivalSourceMetadata(env))[0] ?? null;
+  if (!source?.source_id) {
+    return [];
+  }
+  return loadConfiguredFestivalRowsForSource(env, source.source_id, now, limit);
+}
+
+async function loadConfiguredFestivalRowsForSource(env: WorkerEnv, sourceId: string | number, now: number, limit: number) {
   const nowIso = new Date(now).toISOString();
   const windowEndIso = getFestivalWindowEnd(now).toISOString();
   const cityKeyword = getTargetFestivalCityKeyword(env);
-  const rows = await loadFestivalRows(env, nowIso, windowEndIso, limit);
+  const rows = await loadFestivalRows(env, sourceId, nowIso, windowEndIso, limit);
   return groupFestivalRowsBySeries((rows || []).filter((row) => isFestivalRowInConfiguredArea(row, cityKeyword)));
 }
 
@@ -39,11 +47,16 @@ export async function loadFestivalCards(env: WorkerEnv, now: number) {
  * Loads banner event response fields for `/api/banner/events`.
  */
 export async function loadBannerEvents(now: number, env: WorkerEnv) {
-  const [eventRows, sourceRows] = await Promise.all([
-    loadConfiguredFestivalRows(env, now, WorkerFestivalRuntimeConfig.bannerQueryLimit),
-    loadFestivalSourceMetadata(env),
-  ]);
-  const source = sourceRows[0] ?? null;
+  const source = (await loadFestivalSourceMetadata(env))[0] ?? null;
+  if (!source?.source_id) {
+    return {
+      sourceReady: false,
+      sourceName: null,
+      importedAt: null,
+      items: [],
+    };
+  }
+  const eventRows = await loadConfiguredFestivalRowsForSource(env, source.source_id, now, WorkerFestivalRuntimeConfig.bannerQueryLimit);
   const items =
     eventRows.length > 0
       ? eventRows.slice(0, WorkerFestivalRuntimeConfig.bannerDisplayLimit).map((row) => buildBannerItem(row, now))

--- a/deploy/api-worker-shell/services/festival-domain/repository.ts
+++ b/deploy/api-worker-shell/services/festival-domain/repository.ts
@@ -96,10 +96,10 @@ export function updateFestivalSourceMetadata(
 /**
  * Loads upcoming public event rows for festival card and banner responses.
  */
-export function loadFestivalRows(env: WorkerEnv, nowIso: string, windowEndIso: string, limit: number) {
+export function loadFestivalRows(env: WorkerEnv, sourceId: string | number, nowIso: string, windowEndIso: string, limit: number) {
   return supabaseRequest<FestivalEventRow[]>(
     env,
-    `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`,
+    `public_event?select=public_event_id,title,venue_name,district,address,road_address,starts_at,ends_at,summary,source_page_url,latitude,longitude&source_id=eq.${encodeFilterValue(sourceId)}&sync_status=neq.stale&ends_at=gte.${encodeFilterValue(nowIso)}&starts_at=lte.${encodeFilterValue(windowEndIso)}&order=starts_at.asc&limit=${limit}`,
   );
 }
 
@@ -107,8 +107,8 @@ export function loadFestivalRows(env: WorkerEnv, nowIso: string, windowEndIso: s
  * Loads source metadata for the banner response readiness fields.
  */
 export function loadFestivalSourceMetadata(env: WorkerEnv) {
-  return supabaseRequest<Array<Pick<FestivalSourceRow, 'name' | 'last_imported_at'>>>(
+  return supabaseRequest<Array<Pick<FestivalSourceRow, 'source_id' | 'name' | 'last_imported_at'>>>(
     env,
-    `public_data_source?select=name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`,
+    `public_data_source?select=source_id,name,last_imported_at&source_key=eq.${encodeFilterValue(INTERNAL_FESTIVAL_SOURCE_KEY)}&limit=1`,
   );
 }

--- a/deploy/api-worker-shell/services/tourism-domain/contracts.ts
+++ b/deploy/api-worker-shell/services/tourism-domain/contracts.ts
@@ -1,0 +1,102 @@
+/*
+ * File: contracts.ts
+ * Purpose: Define public tourism read-model contracts for Worker responses.
+ * Primary Responsibility: Keep stored KTO row shapes and Front DTO shapes near the tourism read domain.
+ * Design Intent: Expose KTO-backed tourism data without leaking Supabase internals or upstream raw payloads.
+ * Non-Goals: This file does not sync KTO data, call external APIs, or modify curated map data.
+ * Dependencies: Worker JSON primitives and Supabase kto_place/kto_sync_state rows.
+ */
+import type { WorkerJsonRecord } from '../../types';
+
+export interface TourismSourceRow extends WorkerJsonRecord {
+  resource_type: 'places';
+  source_name?: string | null;
+  last_success_at?: string | null;
+  last_imported_at?: string | null;
+}
+
+export interface TourismCuratedLinkRow {
+  map?: {
+    position_id?: string | number | null;
+    slug?: string | null;
+    name?: string | null;
+  } | null;
+}
+
+export interface TourismPlaceRow extends WorkerJsonRecord {
+  external_id: string;
+  display_name: string;
+  category: string;
+  district: string;
+  content_type_id?: string | null;
+  content_type_label?: string | null;
+  cat1?: string | null;
+  cat1_label?: string | null;
+  cat2?: string | null;
+  cat2_label?: string | null;
+  cat3?: string | null;
+  cat3_label?: string | null;
+  kto_facet?: string | null;
+  address?: string | null;
+  road_address?: string | null;
+  summary?: string | null;
+  image_url?: string | null;
+  source_page_url?: string | null;
+  latitude?: string | number | null;
+  longitude?: string | number | null;
+  source_updated_at?: string | null;
+  kto_place_map_link?: TourismCuratedLinkRow[] | null;
+}
+
+export interface TourismFacetRow extends WorkerJsonRecord {
+  content_type_id?: string | null;
+  content_type_label?: string | null;
+  kto_facet?: string | null;
+  district?: string | null;
+}
+
+export interface TourismCuratedPlace {
+  positionId: number;
+  slug: string;
+  name: string;
+}
+
+export interface TourismFacets {
+  contentTypes: Array<{ id: string; label: string | null; count: number }>;
+  ktoFacets: Array<{ key: string; label: string | null; count: number }>;
+  districts: Array<{ name: string; count: number }>;
+}
+
+export interface TourismPlaceItem {
+  id: string;
+  name: string;
+  category: string;
+  ktoContentTypeId: string | null;
+  ktoContentTypeLabel: string | null;
+  ktoCategoryCode1: string | null;
+  ktoCategoryLabel1: string | null;
+  ktoCategoryCode2: string | null;
+  ktoCategoryLabel2: string | null;
+  ktoCategoryCode3: string | null;
+  ktoCategoryLabel3: string | null;
+  ktoFacet: string | null;
+  district: string;
+  address: string | null;
+  roadAddress: string | null;
+  summary: string;
+  imageUrl: string | null;
+  sourcePageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  sourceUpdatedAt: string | null;
+  isCurated: boolean;
+  curatedPlace: TourismCuratedPlace | null;
+}
+
+export interface TourismPlacesResponse {
+  sourceReady: boolean;
+  sourceName: string | null;
+  importedAt: string | null;
+  facets: TourismFacets;
+  items: TourismPlaceItem[];
+}

--- a/deploy/api-worker-shell/services/tourism-domain/index.ts
+++ b/deploy/api-worker-shell/services/tourism-domain/index.ts
@@ -1,0 +1,9 @@
+/*
+ * File: index.ts
+ * Purpose: Re-export the tourism read-domain public surface.
+ * Primary Responsibility: Keep route handlers decoupled from tourism-domain file layout.
+ * Design Intent: Preserve a small import boundary as the domain grows beyond the first read endpoint.
+ * Non-Goals: This file does not implement mapping, querying, or HTTP response creation.
+ * Dependencies: Tourism read service.
+ */
+export { loadTourismPlaces } from './read-service';

--- a/deploy/api-worker-shell/services/tourism-domain/mapper.ts
+++ b/deploy/api-worker-shell/services/tourism-domain/mapper.ts
@@ -1,0 +1,69 @@
+/*
+ * File: mapper.ts
+ * Purpose: Map stored public-place rows to the public tourism Front DTO.
+ * Primary Responsibility: Convert Supabase row naming and scalar types into stable API response fields.
+ * Design Intent: Keep public JSON allowlisted so internal IDs, payloads, and provider secrets cannot leak.
+ * Non-Goals: This file does not query Supabase, decide filters, or sync upstream KTO records.
+ * Dependencies: Tourism domain contracts.
+ */
+import type { TourismCuratedPlace, TourismPlaceItem, TourismPlaceRow } from './contracts';
+
+function parseCoordinate(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function mapCuratedPlace(row: TourismPlaceRow): TourismCuratedPlace | null {
+  const link = row.kto_place_map_link?.find((candidate) => {
+    const map = candidate?.map;
+    return map?.position_id !== null && map?.position_id !== undefined && Boolean(map?.slug) && Boolean(map?.name);
+  });
+  if (!link?.map) {
+    return null;
+  }
+  const positionId = Number(link.map.position_id);
+  if (!Number.isFinite(positionId)) {
+    return null;
+  }
+  return {
+    positionId,
+    slug: String(link.map.slug),
+    name: String(link.map.name),
+  };
+}
+
+/**
+ * Builds the Front-safe tourism place item.
+ *
+ * Adding new public fields must happen through the documented API contract and
+ * tests because this mapper is the boundary that prevents raw KTO/Supabase data
+ * from reaching browsers.
+ */
+export function mapTourismPlace(row: TourismPlaceRow): TourismPlaceItem {
+  const curatedPlace = mapCuratedPlace(row);
+  return {
+    id: String(row.external_id),
+    name: row.display_name,
+    category: row.category,
+    ktoContentTypeId: row.content_type_id ?? null,
+    ktoContentTypeLabel: row.content_type_label ?? null,
+    ktoCategoryCode1: row.cat1 ?? null,
+    ktoCategoryLabel1: row.cat1_label ?? null,
+    ktoCategoryCode2: row.cat2 ?? null,
+    ktoCategoryLabel2: row.cat2_label ?? null,
+    ktoCategoryCode3: row.cat3 ?? null,
+    ktoCategoryLabel3: row.cat3_label ?? null,
+    ktoFacet: row.kto_facet ?? null,
+    district: row.district,
+    address: row.address ?? null,
+    roadAddress: row.road_address ?? null,
+    summary: row.summary ?? '',
+    imageUrl: row.image_url ?? null,
+    sourcePageUrl: row.source_page_url ?? null,
+    latitude: parseCoordinate(row.latitude),
+    longitude: parseCoordinate(row.longitude),
+    sourceUpdatedAt: row.source_updated_at ?? null,
+    isCurated: Boolean(curatedPlace),
+    curatedPlace,
+  };
+}

--- a/deploy/api-worker-shell/services/tourism-domain/read-service.ts
+++ b/deploy/api-worker-shell/services/tourism-domain/read-service.ts
@@ -1,0 +1,120 @@
+/*
+ * File: read-service.ts
+ * Purpose: Build public tourism read responses from stored KTO place rows.
+ * Primary Responsibility: Parse read options, load source/place rows, and assemble a stable Front contract.
+ * Design Intent: Keep public reads database-backed so Front traffic never calls KTO TourAPI directly.
+ * Non-Goals: This file does not schedule syncs, update Supabase rows, or expose admin-only status.
+ * Dependencies: Tourism repository, mapper, Worker runtime limits, and Supabase limit parser.
+ */
+import { WorkerTourismRuntimeConfig } from '../../config/runtime';
+import { parseListLimit } from '../../lib/supabase';
+import type { WorkerEnv } from '../../types';
+import type { TourismFacetRow, TourismFacets, TourismPlacesResponse } from './contracts';
+import { mapTourismPlace } from './mapper';
+import { loadKtoTourismFacetRows, loadKtoTourismPlaces, loadKtoTourismSource } from './repository';
+
+const facetLabels: Record<string, string> = {
+  attraction: '관광지',
+  culture: '문화시설',
+  leports: '레포츠',
+  lodging: '숙박',
+  restaurant: '음식점',
+  shopping: '쇼핑',
+};
+
+function readFilter(url: URL, key: string) {
+  const value = url.searchParams.get(key)?.trim() ?? '';
+  return value.length > 0 ? value : null;
+}
+
+function incrementCount<T extends { count: number }>(map: Map<string, T>, key: string, build: () => T) {
+  const current = map.get(key);
+  if (current) {
+    current.count += 1;
+    return;
+  }
+  const created = build();
+  created.count = 1;
+  map.set(key, created);
+}
+
+function sortByKey<T>(values: T[], read: (value: T) => string) {
+  return values.sort((left, right) => read(left).localeCompare(read(right), 'ko'));
+}
+
+function buildTourismFacets(rows: TourismFacetRow[]): TourismFacets {
+  const contentTypes = new Map<string, { id: string; label: string | null; count: number }>();
+  const ktoFacets = new Map<string, { key: string; label: string | null; count: number }>();
+  const districts = new Map<string, { name: string; count: number }>();
+
+  for (const row of rows ?? []) {
+    const contentTypeId = row.content_type_id ? String(row.content_type_id) : '';
+    const contentTypeLabel = row.content_type_label ? String(row.content_type_label) : null;
+    const ktoFacet = row.kto_facet ? String(row.kto_facet) : '';
+    const district = row.district ? String(row.district) : '';
+
+    if (contentTypeId) {
+      incrementCount(contentTypes, contentTypeId, () => ({ id: contentTypeId, label: contentTypeLabel, count: 0 }));
+    }
+    if (ktoFacet) {
+      incrementCount(ktoFacets, ktoFacet, () => ({ key: ktoFacet, label: facetLabels[ktoFacet] ?? contentTypeLabel, count: 0 }));
+    }
+    if (district) {
+      incrementCount(districts, district, () => ({ name: district, count: 0 }));
+    }
+  }
+
+  return {
+    contentTypes: sortByKey([...contentTypes.values()], (value) => value.id),
+    ktoFacets: sortByKey([...ktoFacets.values()], (value) => value.key),
+    districts: sortByKey([...districts.values()], (value) => value.name),
+  };
+}
+
+function emptyTourismResponse(): TourismPlacesResponse {
+  return { sourceReady: false, sourceName: null, importedAt: null, facets: buildTourismFacets([]), items: [] };
+}
+
+function isMissingKtoSchemaError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false;
+  }
+  return error.message.includes('PGRST205') && (error.message.includes('public.kto_sync_state') || error.message.includes('public.kto_place'));
+}
+
+/**
+ * Builds the KTO tourism places response for Front consumers.
+ *
+ * If KTO tables are not present yet, the response remains a 200-compatible
+ * empty contract so clients can render an empty state without retry loops.
+ */
+export async function loadTourismPlaces(env: WorkerEnv, url: URL): Promise<TourismPlacesResponse> {
+  try {
+    const source = await loadKtoTourismSource(env);
+    if (!source) {
+      return emptyTourismResponse();
+    }
+    const [facetRows, rows] = await Promise.all([
+      loadKtoTourismFacetRows(env),
+      loadKtoTourismPlaces(env, {
+        category: readFilter(url, 'category'),
+        district: readFilter(url, 'district'),
+        ktoContentTypeId: readFilter(url, 'ktoContentTypeId'),
+        ktoFacet: readFilter(url, 'ktoFacet'),
+        limit: parseListLimit(url, WorkerTourismRuntimeConfig.defaultPlacesLimit, WorkerTourismRuntimeConfig.maxPlacesLimit),
+      }),
+    ]);
+    return {
+      sourceReady: rows.length > 0 || Boolean(source.last_success_at || source.last_imported_at),
+      sourceName: source.source_name ?? null,
+      importedAt: source.last_success_at ?? source.last_imported_at ?? null,
+      facets: buildTourismFacets(facetRows),
+      items: rows.map(mapTourismPlace),
+    };
+  } catch (error) {
+    if (isMissingKtoSchemaError(error)) {
+      return emptyTourismResponse();
+    }
+    throw error;
+  }
+}

--- a/deploy/api-worker-shell/services/tourism-domain/repository.ts
+++ b/deploy/api-worker-shell/services/tourism-domain/repository.ts
@@ -1,0 +1,96 @@
+/*
+ * File: repository.ts
+ * Purpose: Encapsulate Supabase REST reads for the public tourism API.
+ * Primary Responsibility: Own KTO sync-state lookup and filtered kto_place queries for Front read contracts.
+ * Design Intent: Keep query construction away from handlers so response mapping remains testable and safe.
+ * Non-Goals: This file does not call KTO APIs, perform sync writes, or merge data into curated map rows.
+ * Dependencies: Worker Supabase REST helper, Worker runtime limits, and tourism read contracts.
+ */
+import { WorkerTourismRuntimeConfig } from '../../config/runtime';
+import { encodeFilterValue, supabaseRequest } from '../../lib/supabase';
+import type { WorkerEnv } from '../../types';
+import type { TourismFacetRow, TourismPlaceRow, TourismSourceRow } from './contracts';
+
+export interface TourismPlaceQueryOptions {
+  category: string | null;
+  district: string | null;
+  ktoContentTypeId: string | null;
+  ktoFacet: string | null;
+  limit: number;
+}
+
+const TOURISM_PLACE_SELECT = [
+  'external_id',
+  'display_name',
+  'category',
+  'district',
+  'content_type_id',
+  'content_type_label',
+  'cat1',
+  'cat1_label',
+  'cat2',
+  'cat2_label',
+  'cat3',
+  'cat3_label',
+  'kto_facet',
+  'address',
+  'road_address',
+  'summary',
+  'image_url',
+  'source_page_url',
+  'latitude',
+  'longitude',
+  'source_updated_at',
+  'kto_place_map_link(map(position_id,slug,name))',
+].join(',');
+
+/**
+ * Loads KTO source metadata used by the public tourism read response.
+ *
+ * A missing row means sync has not initialized the places resource yet; callers
+ * convert that state into a stable empty public response.
+ */
+export async function loadKtoTourismSource(env: WorkerEnv) {
+  const rows = await supabaseRequest<TourismSourceRow[]>(
+    env,
+    'kto_sync_state?select=resource_type,source_name,last_success_at,last_imported_at&resource_type=eq.places&limit=1',
+  );
+  return rows?.[0] ?? null;
+}
+
+/**
+ * Loads non-stale KTO public places for Front tourism lists.
+ *
+ * Filters are intentionally small and explicit to preserve the first public
+ * contract and keep ranking/recommendation policy out of this read layer.
+ */
+export function loadKtoTourismPlaces(env: WorkerEnv, options: TourismPlaceQueryOptions) {
+  const filters = ['sync_status=neq.stale'];
+  if (options.category) {
+    filters.push(`category=eq.${encodeFilterValue(options.category)}`);
+  }
+  if (options.district) {
+    filters.push(`district=eq.${encodeFilterValue(options.district)}`);
+  }
+  if (options.ktoContentTypeId) {
+    filters.push(`content_type_id=eq.${encodeFilterValue(options.ktoContentTypeId)}`);
+  }
+  if (options.ktoFacet) {
+    filters.push(`kto_facet=eq.${encodeFilterValue(options.ktoFacet)}`);
+  }
+  return supabaseRequest<TourismPlaceRow[]>(
+    env,
+    `kto_place?select=${TOURISM_PLACE_SELECT}&${filters.join('&')}&order=display_name.asc&limit=${options.limit}`,
+  );
+}
+
+/**
+ * Loads facet source rows from the whole non-stale place set, not the limited
+ * card list, so filters remain useful even when the visible list is capped.
+ */
+export function loadKtoTourismFacetRows(env: WorkerEnv) {
+  return supabaseRequest<TourismFacetRow[]>(
+    env,
+    `kto_place?select=content_type_id,content_type_label,kto_facet,district&sync_status=neq.stale&limit=${WorkerTourismRuntimeConfig.facetQueryLimit}`,
+  );
+}

--- a/deploy/api-worker-shell/services/tourism.ts
+++ b/deploy/api-worker-shell/services/tourism.ts
@@ -1,0 +1,21 @@
+/*
+ * File: tourism.ts
+ * Purpose: Expose public tourism Worker HTTP handlers.
+ * Primary Responsibility: Render stored KTO tourism read-model responses for Front consumers.
+ * Design Intent: Keep Front-facing reads separate from KTO sync and curated map bootstrap paths.
+ * Non-Goals: This file does not call KTO TourAPI, mutate Supabase, or handle admin source operations.
+ * Dependencies: Worker HTTP helpers and tourism-domain read service.
+ */
+import { jsonResponse } from '../lib/http';
+import type { WorkerEnv } from '../types';
+import { loadTourismPlaces } from './tourism-domain';
+
+/**
+ * Handles `GET /api/tourism/places`.
+ *
+ * This handler is read-only and database-backed; the domain service owns the
+ * stable empty response for not-yet-created KTO tables.
+ */
+export async function handleTourismPlaces(request: Request, env: WorkerEnv) {
+  return jsonResponse(200, await loadTourismPlaces(env, new URL(request.url)), env, request);
+}

--- a/docs/GOVERNANCE_INDEX.md
+++ b/docs/GOVERNANCE_INDEX.md
@@ -1,0 +1,8 @@
+# Governance Index
+
+This repository-local index maps durable Core task IDs to their owning parent
+issues so implementation children can be checked against the intended roadmap.
+
+| Core | Parent Issue | Responsibility | Keywords | Misroute Examples |
+| --- | --- | --- | --- | --- |
+| `TSK-013-00` | https://github.com/STH-1-Class-One-Group/JamIssue/issues/389 | KTO tourism public contract consumption in the Web repo. | kto; tourism; tourapi; tourism places; tourism contract; api tourism places; public api contract | Supabase schema migration; KTO import button; new bottom tab; full UI shell redesign |

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "check:numeric-literals": "tsx scripts/numeric-literal-audit.ts --check",
     "smoke": "tsx scripts/run-public-smoke-checks.ts",
     "smoke:public": "tsx scripts/run-public-smoke-checks.ts",
+    "smoke:worker-tourism": "tsx scripts/smoke-worker-tourism-contract.ts",
     "smoke:protected": "tsx scripts/run-protected-smoke-checks.ts",
     "smoke:protected:write": "tsx scripts/run-protected-write-smoke-checks.ts"
   },

--- a/scripts/numeric-literal-baseline.json
+++ b/scripts/numeric-literal-baseline.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "generatedFrom": "7e3820dfeb5d739fe65ec1ba7b41f7a27c6ab3cb",
+  "generatedFrom": "756bd8ca2d7a8ec87e4411dc84bdc64a56693bc2",
   "policy": "TSK-002 requires every production numeric literal file to be classified before config extraction work starts.",
   "files": [
     {
@@ -1120,7 +1120,7 @@
     },
     {
       "path": "deploy/api-worker-shell/config/runtime.ts",
-      "count": 31,
+      "count": 34,
       "owner": "worker-backend",
       "category": "worker-runtime-config-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -1403,32 +1403,32 @@
       "examples": [
         {
           "value": "1",
-          "line": 75,
+          "line": 77,
           "column": 116
         },
         {
           "value": "1",
-          "line": 76,
+          "line": 78,
           "column": 92
         },
         {
           "value": "1",
-          "line": 77,
+          "line": 79,
           "column": 93
         },
         {
           "value": "1",
-          "line": 83,
+          "line": 85,
           "column": 87
         },
         {
           "value": "200",
-          "line": 84,
+          "line": 86,
           "column": 29
         },
         {
           "value": "1",
-          "line": 87,
+          "line": 89,
           "column": 102
         }
       ]
@@ -1915,7 +1915,7 @@
     },
     {
       "path": "deploy/api-worker-shell/services/festival-domain/read-service.ts",
-      "count": 5,
+      "count": 6,
       "owner": "worker-backend",
       "category": "worker-runtime-limit-baseline",
       "scopeId": "TSK-002-05-WORKER-RUNTIME-CONFIG",
@@ -1923,27 +1923,32 @@
       "examples": [
         {
           "value": "0",
-          "line": 34,
+          "line": 15,
+          "column": 58
+        },
+        {
+          "value": "0",
+          "line": 42,
           "column": 12
         },
         {
           "value": "0",
-          "line": 46,
-          "column": 29
+          "line": 50,
+          "column": 58
         },
         {
           "value": "0",
-          "line": 48,
+          "line": 61,
           "column": 24
         },
         {
           "value": "0",
-          "line": 49,
+          "line": 62,
           "column": 25
         },
         {
           "value": "0",
-          "line": 52,
+          "line": 65,
           "column": 33
         }
       ]
@@ -3593,33 +3598,33 @@
       "examples": [
         {
           "value": "9",
-          "line": 24,
+          "line": 28,
           "column": 29
         },
         {
           "value": "2",
-          "line": 24,
+          "line": 28,
           "column": 33
         },
         {
           "value": "2",
-          "line": 25,
+          "line": 29,
           "column": 18
         },
         {
           "value": "0",
-          "line": 68,
-          "column": 31
+          "line": 89,
+          "column": 29
         },
         {
           "value": "30",
-          "line": 69,
-          "column": 48
+          "line": 90,
+          "column": 46
         },
         {
           "value": "0",
-          "line": 86,
-          "column": 81
+          "line": 107,
+          "column": 79
         }
       ]
     },
@@ -4609,7 +4614,7 @@
         {
           "value": "30",
           "line": 7,
-          "column": 66
+          "column": 89
         },
         {
           "value": "20",
@@ -4850,7 +4855,7 @@
     },
     {
       "path": "src/index.css",
-      "count": 1534,
+      "count": 1549,
       "owner": "frontend-ui",
       "category": "css-layout-token-baseline",
       "scopeId": "TSK-002-03-FRONTEND-UI-TOKEN-CONFIG",

--- a/scripts/smoke-worker-tourism-contract.ts
+++ b/scripts/smoke-worker-tourism-contract.ts
@@ -1,0 +1,72 @@
+/*
+ * File: smoke-worker-tourism-contract.ts
+ * Purpose: Validate the deployed Worker tourism places public contract.
+ * Primary Responsibility: Check `/api/tourism/places` response shape and forbidden field omission.
+ * Design Intent: Provide an operator-safe smoke that verifies Front-facing contract readiness without calling KTO/OpenAPI directly.
+ * Non-Goals: This script does not mutate data, validate Supabase RLS, or run KTO sync/import operations.
+ * Dependencies: Node fetch runtime and deployed JamIssue Worker public API.
+ */
+const DEFAULT_API_BASE_URL = 'https://api.daejeon.jamissue.com';
+const forbiddenFields = ['kto_place_id', 'raw_payload', 'normalized_payload', 'serviceKey', 'service_key'];
+
+interface SmokeFailure {
+  field: string;
+  detail: string;
+}
+
+function assert(condition: unknown, field: string, detail: string, failures: SmokeFailure[]) {
+  if (!condition) {
+    failures.push({ field, detail });
+  }
+}
+
+async function main() {
+  const apiBaseUrl = process.env.JAMISSUE_API_BASE_URL || DEFAULT_API_BASE_URL;
+  const url = `${apiBaseUrl.replace(/\/$/, '')}/api/tourism/places?limit=3`;
+  const response = await fetch(url, { headers: { accept: 'application/json' } });
+  const failures: SmokeFailure[] = [];
+
+  assert(response.ok, 'status', `expected 2xx, got ${response.status}`, failures);
+  const payload = await response.json() as Record<string, unknown>;
+
+  assert(typeof payload.sourceReady === 'boolean', 'sourceReady', 'must be boolean', failures);
+  assert('sourceName' in payload, 'sourceName', 'must be present', failures);
+  assert('importedAt' in payload, 'importedAt', 'must be present', failures);
+  assert(typeof payload.facets === 'object' && payload.facets !== null, 'facets', 'must be object', failures);
+  assert(Array.isArray(payload.items), 'items', 'must be array', failures);
+
+  const facets = payload.facets as Record<string, unknown>;
+  assert(Array.isArray(facets.contentTypes), 'facets.contentTypes', 'must be array', failures);
+  assert(Array.isArray(facets.ktoFacets), 'facets.ktoFacets', 'must be array', failures);
+  assert(Array.isArray(facets.districts), 'facets.districts', 'must be array', failures);
+
+  const serialized = JSON.stringify(payload);
+  for (const field of forbiddenFields) {
+    assert(!serialized.includes(field), field, 'must not appear in public tourism JSON', failures);
+  }
+
+  if (Array.isArray(payload.items) && payload.items.length > 0) {
+    const item = payload.items[0] as Record<string, unknown>;
+    for (const field of ['id', 'name', 'category', 'district', 'isCurated', 'curatedPlace']) {
+      assert(field in item, `items[0].${field}`, 'must be present', failures);
+    }
+  }
+
+  if (failures.length > 0) {
+    console.error(JSON.stringify({ ok: false, url, failures }, null, 2));
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(JSON.stringify({
+    ok: true,
+    url,
+    sourceReady: payload.sourceReady,
+    itemCount: Array.isArray(payload.items) ? payload.items.length : 0,
+  }));
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -27,3 +27,5 @@ export {
 } from './myClient';
 export { getAdminSummary, importPublicData, updatePlaceVisibility } from './adminClient';
 export { claimStamp } from './stampClient';
+export { getTourismPlaces } from './tourismClient';
+export type { TourismPlacesParams } from './tourismClient';

--- a/src/api/tourismClient.ts
+++ b/src/api/tourismClient.ts
@@ -1,0 +1,42 @@
+/*
+ * File: tourismClient.ts
+ * Purpose: Provide Front consumers with the Worker tourism places API client.
+ * Primary Responsibility: Build supported `/api/tourism/places` query strings from public filter params.
+ * Design Intent: Hide Worker endpoint mechanics behind a small typed client while avoiding any Supabase/KTO browser calls.
+ * Non-Goals: This file does not call KTO/OpenAPI, read Supabase directly, or implement tourism rendering policy.
+ * Dependencies: Front fetchJson helper and tourism public contract types.
+ */
+import type { TourismPlacesResponse } from '../tourismTypes';
+import { fetchJson } from './core';
+
+export interface TourismPlacesParams {
+  category?: string | null;
+  district?: string | null;
+  ktoContentTypeId?: string | null;
+  ktoFacet?: string | null;
+  limit?: number | null;
+}
+
+function appendParam(searchParams: URLSearchParams, key: string, value: string | number | null | undefined) {
+  if (value === null || value === undefined || value === '') {
+    return;
+  }
+  searchParams.set(key, String(value));
+}
+
+/**
+ * Loads KTO tourism places through the Worker public API.
+ *
+ * The browser intentionally knows only this contract and supported filters; all
+ * Supabase row mapping and KTO sync details stay inside the Worker/Admin side.
+ */
+export function getTourismPlaces(params: TourismPlacesParams = {}) {
+  const searchParams = new URLSearchParams();
+  appendParam(searchParams, 'category', params.category);
+  appendParam(searchParams, 'district', params.district);
+  appendParam(searchParams, 'ktoContentTypeId', params.ktoContentTypeId);
+  appendParam(searchParams, 'ktoFacet', params.ktoFacet);
+  appendParam(searchParams, 'limit', params.limit);
+  const query = searchParams.toString();
+  return fetchJson<TourismPlacesResponse>(`/api/tourism/places${query ? `?${query}` : ''}`);
+}

--- a/src/components/EventTab.tsx
+++ b/src/components/EventTab.tsx
@@ -1,13 +1,17 @@
+import { useState } from 'react';
 import { useScrollRestoration } from '../hooks/useScrollRestoration';
 import type { FestivalItem } from '../types/core';
+import { EventTabTourismSection } from './EventTabTourismSection';
 
 interface EventTabProps {
   festivals: FestivalItem[];
 }
 
+type EventSegment = 'festivals' | 'tourism';
+
 function formatFestivalPeriod(festival: FestivalItem) {
   if (!festival.startDate && !festival.endDate) {
-    return '일정 정보가 아직 없어요.';
+    return '일정 정보가 아직 없어요';
   }
   if (festival.startDate === festival.endDate) {
     return festival.startDate;
@@ -19,7 +23,7 @@ function formatFestivalTitle(title: string) {
   return title
     .replace(/\[[^\]]*\]/g, ' ')
     .replace(/\([^)]*\)/g, ' ')
-    .replace(/[&_·•/|]+/g, ' ')
+    .replace(/[&·•|]+/g, ' ')
     .replace(/\s+-\s+/g, ' ')
     .replace(/\s+[A-Z][A-Z0-9-]{2,}$/g, '')
     .replace(/\s{2,}/g, ' ')
@@ -31,7 +35,7 @@ function getFestivalLocationLines(festival: FestivalItem) {
   const roadAddress = festival.roadAddress?.trim() || null;
 
   if (!venueName && !roadAddress) {
-    return ['개최 장소 정보가 아직 없어요.'];
+    return ['개최 장소 정보가 아직 없어요'];
   }
 
   if (venueName && roadAddress && venueName === roadAddress) {
@@ -43,6 +47,7 @@ function getFestivalLocationLines(festival: FestivalItem) {
 
 export function EventTab({ festivals }: EventTabProps) {
   const scrollRef = useScrollRestoration<HTMLElement>('event');
+  const [segment, setSegment] = useState<EventSegment>('festivals');
 
   return (
     <section ref={scrollRef} className="page-panel page-panel--scrollable">
@@ -50,59 +55,74 @@ export function EventTab({ festivals }: EventTabProps) {
         <p className="eyebrow">EVENT</p>
         <h2>행사</h2>
         <p>
-          대전에서 진행 중이거나 곧 열릴 행사를
+          대전에서 진행 중이거나 곧 열릴 행사와 관광장소를
           <br />
-          한 번에 보고 빠르게 훑어볼 수 있어요.
+          한 번에 보고 빠르게 확인할 수 있어요.
         </p>
       </header>
 
-      <section className="sheet-card stack-gap">
-        <div className="section-title-row section-title-row--tight">
-          <div>
-            <p className="eyebrow">DAEJEON FESTIVALS</p>
-            <h3>지금 확인할 행사</h3>
-          </div>
-          <span className="counter-pill">{festivals.length}개</span>
+      <div className="event-segment" role="tablist" aria-label="행사 콘텐츠 구분">
+        <button type="button" className={`chip ${segment === 'festivals' ? 'is-active' : ''}`} onClick={() => setSegment('festivals')}>
+          행사
+        </button>
+        <button type="button" className={`chip ${segment === 'tourism' ? 'is-active' : ''}`} onClick={() => setSegment('tourism')}>
+          관광장소
+        </button>
+      </div>
+
+      {segment === 'festivals' ? <FestivalSection festivals={festivals} /> : <EventTabTourismSection active={segment === 'tourism'} />}
+    </section>
+  );
+}
+
+function FestivalSection({ festivals }: { festivals: FestivalItem[] }) {
+  return (
+    <section className="sheet-card stack-gap">
+      <div className="section-title-row section-title-row--tight">
+        <div>
+          <p className="eyebrow">DAEJEON FESTIVALS</p>
+          <h3>지금 확인할 행사</h3>
         </div>
+        <span className="counter-pill">{festivals.length}개</span>
+      </div>
 
-        {festivals.length === 0 ? (
-          <p className="empty-copy">현재 진행 중이거나 30일 이내 예정된 대전 행사가 없어요.</p>
-        ) : (
-          <div className="community-route-list festival-card-list">
-            {festivals.map((festival) => {
-              const locationLines = getFestivalLocationLines(festival);
-              return (
-                <article key={festival.id} className="community-route-card community-route-card--curated festival-card">
-                  <div className="festival-card__content">
-                    <div className="festival-card__meta-row">
-                      <span className="festival-card__date">{formatFestivalPeriod(festival)}</span>
-                      {festival.isOngoing ? <span className="soft-tag festival-card__status-chip">진행 중</span> : null}
-                    </div>
-
-                    <h4 className="festival-card__title">{formatFestivalTitle(festival.title)}</h4>
-
-                    <div className="festival-card__location">
-                      {locationLines.map((line, index) => (
-                        <p key={`${festival.id}-${index}`} className={index === 0 ? 'festival-card__location-primary' : 'festival-card__location-secondary'}>
-                          {line}
-                        </p>
-                      ))}
-                    </div>
+      {festivals.length === 0 ? (
+        <p className="empty-copy">현재 진행 중이거나 30일 이내 예정된 대전 행사가 없어요.</p>
+      ) : (
+        <div className="community-route-list festival-card-list">
+          {festivals.map((festival) => {
+            const locationLines = getFestivalLocationLines(festival);
+            return (
+              <article key={festival.id} className="community-route-card community-route-card--curated festival-card">
+                <div className="festival-card__content">
+                  <div className="festival-card__meta-row">
+                    <span className="festival-card__date">{formatFestivalPeriod(festival)}</span>
+                    {festival.isOngoing ? <span className="soft-tag festival-card__status-chip">진행 중</span> : null}
                   </div>
 
-                  {festival.homepageUrl ? (
-                    <div className="festival-card__footer">
-                      <a className="festival-card__link" href={festival.homepageUrl} target="_blank" rel="noreferrer">
-                        홈페이지 열기
-                      </a>
-                    </div>
-                  ) : null}
-                </article>
-              );
-            })}
-          </div>
-        )}
-      </section>
+                  <h4 className="festival-card__title">{formatFestivalTitle(festival.title)}</h4>
+
+                  <div className="festival-card__location">
+                    {locationLines.map((line, index) => (
+                      <p key={`${festival.id}-${index}`} className={index === 0 ? 'festival-card__location-primary' : 'festival-card__location-secondary'}>
+                        {line}
+                      </p>
+                    ))}
+                  </div>
+                </div>
+
+                {festival.homepageUrl ? (
+                  <div className="festival-card__footer">
+                    <a className="festival-card__link" href={festival.homepageUrl} target="_blank" rel="noreferrer">
+                      홈페이지 열기
+                    </a>
+                  </div>
+                ) : null}
+              </article>
+            );
+          })}
+        </div>
+      )}
     </section>
   );
 }

--- a/src/components/EventTabTourismSection.tsx
+++ b/src/components/EventTabTourismSection.tsx
@@ -1,0 +1,177 @@
+/*
+ * File: EventTabTourismSection.tsx
+ * Purpose: Render the KTO tourism segment inside the existing Event tab.
+ * Primary Responsibility: Own tourism filters, local loading state, and KTO place cards.
+ * Design Intent: Keep KTO tourism UI separate from festival cards and curated map places while consuming only Worker public API.
+ * Non-Goals: This file does not navigate the map, call Supabase, call KTO/OpenAPI, or trigger import/sync operations.
+ * Dependencies: React state/effect hooks, tourism API client, and public tourism response types.
+ */
+import { useEffect, useState } from 'react';
+import { getTourismPlaces } from '../api/client';
+import type { TourismPlacesResponse, TourismPlaceItem } from '../tourismTypes';
+
+interface TourismFilters {
+  district: string | null;
+  ktoContentTypeId: string | null;
+  ktoFacet: string | null;
+}
+
+const emptyTourismResponse: TourismPlacesResponse = {
+  sourceReady: false,
+  sourceName: null,
+  importedAt: null,
+  facets: { contentTypes: [], ktoFacets: [], districts: [] },
+  items: [],
+};
+
+function primaryTourismAddress(place: TourismPlaceItem) {
+  return place.roadAddress || place.address || place.district || '주소 정보가 아직 없어요';
+}
+
+function secondaryTourismMeta(place: TourismPlaceItem) {
+  return [place.ktoContentTypeLabel, place.ktoCategoryLabel3, place.ktoFacet].filter(Boolean).join(' · ');
+}
+
+function useTourismPlaces(active: boolean, filters: TourismFilters) {
+  const [tourism, setTourism] = useState<TourismPlacesResponse>(emptyTourismResponse);
+  const [status, setStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+
+  useEffect(() => {
+    if (!active) {
+      return;
+    }
+    let cancelled = false;
+    setStatus('loading');
+    getTourismPlaces(filters)
+      .then((response) => {
+        if (!cancelled) {
+          setTourism(response);
+          setStatus('ready');
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setTourism(emptyTourismResponse);
+          setStatus('error');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [active, filters.district, filters.ktoContentTypeId, filters.ktoFacet]);
+
+  return { tourism, status };
+}
+
+export function EventTabTourismSection({ active }: { active: boolean }) {
+  const [filters, setFilters] = useState<TourismFilters>({ district: null, ktoContentTypeId: null, ktoFacet: null });
+  const { tourism, status } = useTourismPlaces(active, filters);
+
+  const setFilter = (key: keyof TourismFilters, value: string) => {
+    setFilters((current) => ({
+      ...current,
+      [key]: current[key] === value ? null : value,
+    }));
+  };
+
+  return (
+    <section className="sheet-card stack-gap">
+      <div className="section-title-row section-title-row--tight">
+        <div>
+          <p className="eyebrow">KTO TOURISM PLACES</p>
+          <h3>관광장소</h3>
+        </div>
+        <span className="counter-pill">{tourism.items.length}개</span>
+      </div>
+
+      <div className="tourism-filter-panel" aria-label="관광장소 필터">
+        <FacetRow
+          label="지역"
+          items={tourism.facets.districts.map((item) => ({ key: item.name, label: item.name, count: item.count }))}
+          selected={filters.district}
+          onSelect={(value) => setFilter('district', value)}
+        />
+        <FacetRow
+          label="유형"
+          items={tourism.facets.contentTypes.map((item) => ({ key: item.id, label: item.label || item.id, count: item.count }))}
+          selected={filters.ktoContentTypeId}
+          onSelect={(value) => setFilter('ktoContentTypeId', value)}
+        />
+        <FacetRow
+          label="테마"
+          items={tourism.facets.ktoFacets.map((item) => ({ key: item.key, label: item.label || item.key, count: item.count }))}
+          selected={filters.ktoFacet}
+          onSelect={(value) => setFilter('ktoFacet', value)}
+        />
+      </div>
+
+      {status === 'loading' ? <p className="empty-copy">관광장소를 불러오는 중이에요.</p> : null}
+      {status === 'error' ? <p className="empty-copy">관광장소 정보를 불러오지 못했어요.</p> : null}
+      {status !== 'loading' && status !== 'error' && tourism.items.length === 0 ? <p className="empty-copy">표시할 관광장소가 아직 없어요.</p> : null}
+
+      {tourism.items.length > 0 ? (
+        <div className="community-route-list festival-card-list tourism-card-list">
+          {tourism.items.map((place) => (
+            <TourismCard key={place.id} place={place} />
+          ))}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+
+function FacetRow({
+  label,
+  items,
+  selected,
+  onSelect,
+}: {
+  label: string;
+  items: Array<{ key: string; label: string; count: number }>;
+  selected: string | null;
+  onSelect: (value: string) => void;
+}) {
+  if (items.length === 0) {
+    return null;
+  }
+  return (
+    <div className="tourism-filter-row">
+      <span className="tourism-filter-row__label">{label}</span>
+      <div className="chip-row tourism-filter-row__chips">
+        {items.map((item) => (
+          <button key={item.key} type="button" className={`chip ${selected === item.key ? 'is-active' : ''}`} onClick={() => onSelect(item.key)}>
+            {item.label} {item.count}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function TourismCard({ place }: { place: TourismPlaceItem }) {
+  const secondaryMeta = secondaryTourismMeta(place);
+  return (
+    <article className="community-route-card community-route-card--curated festival-card tourism-card">
+      <div className="festival-card__content">
+        <div className="festival-card__meta-row">
+          <span className="festival-card__date">{place.district}</span>
+          {place.isCurated ? <span className="soft-tag festival-card__status-chip">지도 연결</span> : null}
+        </div>
+
+        <h4 className="festival-card__title">{place.name}</h4>
+        <p className="festival-card__location-primary">{primaryTourismAddress(place)}</p>
+        {secondaryMeta ? <p className="festival-card__location-secondary">{secondaryMeta}</p> : null}
+        {place.summary ? <p className="tourism-card__summary">{place.summary}</p> : null}
+        {place.curatedPlace ? <p className="tourism-card__curated">연결된 지도 장소: {place.curatedPlace.name}</p> : null}
+      </div>
+
+      {place.sourcePageUrl ? (
+        <div className="festival-card__footer">
+          <a className="festival-card__link" href={place.sourcePageUrl} target="_blank" rel="noreferrer">
+            출처 보기
+          </a>
+        </div>
+      ) : null}
+    </article>
+  );
+}

--- a/src/config/runtimeLimitConfig.ts
+++ b/src/config/runtimeLimitConfig.ts
@@ -4,7 +4,7 @@ export class ApiCacheConfig {
   static readonly defaultGetTtlMs = 15 * ApiCacheConfig.secondMs;
 
   static readonly endpointTtlRules = [
-    { prefixes: ['/api/festivals', '/api/banner/events'], ttlMs: 30 * ApiCacheConfig.minuteMs },
+    { prefixes: ['/api/festivals', '/api/banner/events', '/api/tourism/places'], ttlMs: 30 * ApiCacheConfig.minuteMs },
     { prefixes: ['/api/courses/curated'], ttlMs: ApiCacheConfig.minuteMs },
     { prefixes: ['/api/map-bootstrap', '/api/community-routes'], ttlMs: 20 * ApiCacheConfig.secondMs },
     { prefixes: ['/api/reviews', '/api/my/summary'], ttlMs: 10 * ApiCacheConfig.secondMs },

--- a/src/index.css
+++ b/src/index.css
@@ -1171,6 +1171,45 @@ textarea {
   opacity: 0.88;
 }
 
+.event-segment {
+  display: flex;
+  gap: 8px;
+  margin: 0 0 14px;
+}
+
+.tourism-filter-panel {
+  display: grid;
+  gap: 12px;
+}
+
+.tourism-filter-row {
+  display: grid;
+  gap: 7px;
+}
+
+.tourism-filter-row__label {
+  color: var(--muted);
+  font-size: 12px;
+  font-weight: 700;
+}
+
+.tourism-filter-row__chips {
+  gap: 8px;
+}
+
+.tourism-card__summary,
+.tourism-card__curated {
+  margin: 0;
+  color: var(--muted);
+  font-size: 12px;
+  line-height: 1.45;
+}
+
+.tourism-card__curated {
+  color: color-mix(in srgb, var(--pink-deep) 82%, #2f2a33 18%);
+  font-weight: 650;
+}
+
 .comment-thread {
   margin-top: 10px;
 }

--- a/src/tourismTypes.ts
+++ b/src/tourismTypes.ts
@@ -1,0 +1,53 @@
+/*
+ * File: tourismTypes.ts
+ * Purpose: Define Front-facing tourism API contracts consumed from the Worker.
+ * Primary Responsibility: Keep KTO tourism response types separate from Supabase and upstream row details.
+ * Design Intent: Make the browser depend only on documented Worker public JSON, not KTO/OpenAPI/Admin schema internals.
+ * Non-Goals: This file does not define Supabase rows, KTO raw payloads, or curated map bootstrap models.
+ * Dependencies: Worker `GET /api/tourism/places` public contract.
+ */
+export interface TourismCuratedPlace {
+  positionId: number;
+  slug: string;
+  name: string;
+}
+
+export interface TourismPlaceItem {
+  id: string;
+  name: string;
+  category: string;
+  ktoContentTypeId: string | null;
+  ktoContentTypeLabel: string | null;
+  ktoCategoryCode1: string | null;
+  ktoCategoryLabel1: string | null;
+  ktoCategoryCode2: string | null;
+  ktoCategoryLabel2: string | null;
+  ktoCategoryCode3: string | null;
+  ktoCategoryLabel3: string | null;
+  ktoFacet: string | null;
+  district: string;
+  address: string | null;
+  roadAddress: string | null;
+  summary: string;
+  imageUrl: string | null;
+  sourcePageUrl: string | null;
+  latitude: number | null;
+  longitude: number | null;
+  sourceUpdatedAt: string | null;
+  isCurated: boolean;
+  curatedPlace: TourismCuratedPlace | null;
+}
+
+export interface TourismFacets {
+  contentTypes: Array<{ id: string; label: string | null; count: number }>;
+  ktoFacets: Array<{ key: string; label: string | null; count: number }>;
+  districts: Array<{ name: string; count: number }>;
+}
+
+export interface TourismPlacesResponse {
+  sourceReady: boolean;
+  sourceName: string | null;
+  importedAt: string | null;
+  facets: TourismFacets;
+  items: TourismPlaceItem[];
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,4 @@ export * from './types/auth';
 export * from './types/review';
 export * from './types/my-page';
 export * from './types/admin';
+export * from './tourismTypes';

--- a/test/unit/EventTabTourismSection.test.tsx
+++ b/test/unit/EventTabTourismSection.test.tsx
@@ -1,0 +1,98 @@
+/*
+ * File: EventTabTourismSection.test.tsx
+ * Purpose: Verify the Event tab renders KTO tourism places as a separate segment.
+ * Primary Responsibility: Pin segment switching, facet refetch, and curated projection display behavior.
+ * Design Intent: Ensure KTO tourism cards never mix with festival cards or curated map bootstrap data.
+ * Non-Goals: This file does not test map navigation, Supabase rows, or deployed Worker availability.
+ * Dependencies: React Testing Library, Vitest, and EventTab public props.
+ */
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { EventTab } from '../../src/components/EventTab';
+import type { FestivalItem } from '../../src/types/core';
+import type { TourismPlacesResponse } from '../../src/tourismTypes';
+
+const apiMocks = vi.hoisted(() => ({
+  getTourismPlaces: vi.fn(),
+}));
+
+vi.mock('../../src/api/client', () => apiMocks);
+
+const festival: FestivalItem = {
+  id: 'festival-1',
+  title: '[Daejeon] Festival Title (2026) ABC',
+  venueName: 'Daejeon Hall',
+  startDate: '2026-05-14',
+  endDate: '2026-05-15',
+  homepageUrl: 'https://festival.example.test',
+  roadAddress: 'Daejeon Road',
+  latitude: 36.35,
+  longitude: 127.38,
+  isOngoing: true,
+};
+
+const tourismFixture: TourismPlacesResponse = {
+  sourceReady: true,
+  sourceName: 'KTO',
+  importedAt: '2026-06-01T00:00:00Z',
+  facets: {
+    contentTypes: [{ id: '12', label: '관광지', count: 1 }],
+    ktoFacets: [{ key: 'attraction', label: '관광지', count: 1 }],
+    districts: [{ name: '유성구', count: 1 }],
+  },
+  items: [{
+    id: 'kto-1',
+    name: '대전 관광지',
+    category: 'tourism',
+    ktoContentTypeId: '12',
+    ktoContentTypeLabel: '관광지',
+    ktoCategoryCode1: null,
+    ktoCategoryLabel1: null,
+    ktoCategoryCode2: null,
+    ktoCategoryLabel2: null,
+    ktoCategoryCode3: null,
+    ktoCategoryLabel3: null,
+    ktoFacet: 'attraction',
+    district: '유성구',
+    address: null,
+    roadAddress: null,
+    summary: '',
+    imageUrl: null,
+    sourcePageUrl: null,
+    latitude: null,
+    longitude: null,
+    sourceUpdatedAt: null,
+    isCurated: true,
+    curatedPlace: { positionId: 101, slug: 'daejeon-place', name: '지도 장소' },
+  }],
+};
+
+describe('EventTab tourism segment', () => {
+  beforeEach(() => {
+    apiMocks.getTourismPlaces.mockResolvedValue(tourismFixture);
+  });
+
+  it('switches from festivals to tourism places and refetches with selected facets', async () => {
+    const user = userEvent.setup();
+    const { container, findByText } = render(<EventTab festivals={[festival]} />);
+
+    expect(container.querySelectorAll('.festival-card')).toHaveLength(1);
+    await user.click(await findByText('관광장소'));
+    await findByText('대전 관광지');
+    await user.click(await findByText('유성구 1'));
+
+    expect(apiMocks.getTourismPlaces).toHaveBeenNthCalledWith(1, {
+      district: null,
+      ktoContentTypeId: null,
+      ktoFacet: null,
+    });
+    expect(apiMocks.getTourismPlaces).toHaveBeenNthCalledWith(2, {
+      district: '유성구',
+      ktoContentTypeId: null,
+      ktoFacet: null,
+    });
+    expect(container.querySelector('.tourism-card__curated')?.textContent).toContain('지도 장소');
+  });
+});

--- a/test/unit/runtime-limit-config.test.ts
+++ b/test/unit/runtime-limit-config.test.ts
@@ -13,6 +13,7 @@ describe('runtime limit config', () => {
   it('preserves API cache TTL rules by endpoint prefix', () => {
     expect(ApiCacheConfig.getTtlForPath('/api/festivals')).toBe(30 * 60 * 1000);
     expect(ApiCacheConfig.getTtlForPath('/api/banner/events/current')).toBe(30 * 60 * 1000);
+    expect(ApiCacheConfig.getTtlForPath('/api/tourism/places?district=%EC%9C%A0%EC%84%B1%EA%B5%AC')).toBe(30 * 60 * 1000);
     expect(ApiCacheConfig.getTtlForPath('/api/courses/curated')).toBe(60 * 1000);
     expect(ApiCacheConfig.getTtlForPath('/api/map-bootstrap')).toBe(20 * 1000);
     expect(ApiCacheConfig.getTtlForPath('/api/community-routes')).toBe(20 * 1000);

--- a/test/unit/tourism-api-client.test.ts
+++ b/test/unit/tourism-api-client.test.ts
@@ -1,0 +1,57 @@
+/*
+ * File: tourism-api-client.test.ts
+ * Purpose: Verify the Front tourism API client consumes only the Worker public contract.
+ * Primary Responsibility: Pin supported query parameter construction for `/api/tourism/places`.
+ * Design Intent: Keep KTO/OpenAPI/Supabase details outside browser client tests and code.
+ * Non-Goals: This file does not render UI, test Supabase rows, or validate deployed Worker data.
+ * Dependencies: Vitest, browser fetch stubs, and Front runtime config.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getTourismPlaces } from '../../src/api/tourismClient';
+import { invalidateApiCache } from '../../src/api/core';
+
+const API_BASE_URL = 'https://api.example.test';
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    headers: { 'content-type': 'application/json' },
+    status: 200,
+  });
+}
+
+beforeEach(() => {
+  invalidateApiCache();
+  window.__JAMISSUE_CONFIG__ = {
+    apiBaseUrl: API_BASE_URL,
+    naverMapClientId: 'naver-client',
+    supabaseUrl: 'https://supabase.example.test',
+    supabaseAnonKey: 'supabase-anon',
+  };
+});
+
+describe('tourism API client', () => {
+  it('builds supported Worker query filters without exposing upstream dependencies', async () => {
+    const fetchMock = vi.fn(async () => jsonResponse({
+      sourceReady: true,
+      sourceName: 'KTO',
+      importedAt: null,
+      facets: { contentTypes: [], ktoFacets: [], districts: [] },
+      items: [],
+    }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(getTourismPlaces({
+      category: 'tourism',
+      district: '유성구',
+      ktoContentTypeId: '12',
+      ktoFacet: 'attraction',
+      limit: 100,
+    })).resolves.toMatchObject({ sourceReady: true, items: [] });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      `${API_BASE_URL}/api/tourism/places?category=tourism&district=%EC%9C%A0%EC%84%B1%EA%B5%AC&ktoContentTypeId=12&ktoFacet=attraction&limit=100`,
+    );
+  });
+});

--- a/test/unit/worker-festival-domain.test.ts
+++ b/test/unit/worker-festival-domain.test.ts
@@ -50,7 +50,10 @@ describe('worker festival domain boundary', () => {
   it('keeps /api/festivals response shape and cache hit semantics', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-11T00:00:00+09:00'));
-    const fetchMock = vi.fn().mockResolvedValue(jsonResponse([sampleFestivalRow()]));
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([{ source_id: 7, name: 'Daejeon Official Event Search', last_imported_at: '2026-05-11T00:00:00.000Z' }]))
+      .mockResolvedValueOnce(jsonResponse([sampleFestivalRow()]));
     vi.stubGlobal('fetch', fetchMock);
 
     const request = new Request(`${apiUrl}/api/festivals`);
@@ -73,7 +76,9 @@ describe('worker festival domain boundary', () => {
         isOngoing: true,
       },
     ]);
-    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(String(fetchMock.mock.calls[1][0])).toContain('source_id=eq.7');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('sync_status=neq.stale');
   });
 
   it('keeps /api/banner/events source and item response shape', async () => {
@@ -81,8 +86,8 @@ describe('worker festival domain boundary', () => {
     vi.setSystemTime(new Date('2026-05-11T00:00:00+09:00'));
     const fetchMock = vi
       .fn()
-      .mockResolvedValueOnce(jsonResponse([sampleFestivalRow()]))
-      .mockResolvedValueOnce(jsonResponse([{ name: 'Daejeon Official Event Search', last_imported_at: '2026-05-11T00:00:00.000Z' }]));
+      .mockResolvedValueOnce(jsonResponse([{ source_id: 7, name: 'Daejeon Official Event Search', last_imported_at: '2026-05-11T00:00:00.000Z' }]))
+      .mockResolvedValueOnce(jsonResponse([sampleFestivalRow()]));
     vi.stubGlobal('fetch', fetchMock);
 
     const response = await handleBannerEvents(new Request(`${apiUrl}/api/banner/events`), buildEnv());
@@ -108,6 +113,8 @@ describe('worker festival domain boundary', () => {
         },
       ],
     });
+    expect(String(fetchMock.mock.calls[1][0])).toContain('source_id=eq.7');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('sync_status=neq.stale');
   });
 
   it('keeps festival import token and valid path semantics', async () => {

--- a/test/unit/worker-routing-runtime.test.ts
+++ b/test/unit/worker-routing-runtime.test.ts
@@ -9,6 +9,10 @@ import type { WorkerEnv, WorkerSessionUser } from '../../deploy/api-worker-shell
 const supabaseMock = vi.hoisted(() => ({
   encodeFilterValue: (value: unknown) => encodeURIComponent(String(value)),
   getSupabaseKey: vi.fn(() => 'service-role-key'),
+  parseListLimit: (url: URL, defaultLimit: number, maxLimit: number) => {
+    const raw = Number(url.searchParams.get('limit') ?? defaultLimit);
+    return Number.isFinite(raw) && raw > 0 ? Math.min(Math.floor(raw), maxLimit) : defaultLimit;
+  },
   supabaseRequest: vi.fn(),
 }));
 
@@ -126,6 +130,22 @@ describe('worker routing runtime', () => {
     expect(response.status).toBe(200);
     expect(await readJson<{ route: string }>(response)).toEqual({ route: 'handler' });
     expect(runtime.reviewReadService.handleReviewFeed).toHaveBeenCalledTimes(1);
+  });
+
+  it('dispatches the public tourism route through the route registry', async () => {
+    supabaseMock.supabaseRequest
+      .mockResolvedValueOnce([{ resource_type: 'places', source_name: 'KTO', last_success_at: '2026-06-01T00:00:00Z' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const response = await createRouteRequest(createRuntime())(new Request(`${apiUrl}/api/tourism/places`), env);
+
+    expect(response.status).toBe(200);
+    await expect(readJson(response)).resolves.toMatchObject({
+      sourceReady: true,
+      sourceName: 'KTO',
+      items: [],
+    });
   });
 
   it('dispatches pattern routes through the route registry', async () => {

--- a/test/unit/worker-runtime-config.test.ts
+++ b/test/unit/worker-runtime-config.test.ts
@@ -9,6 +9,7 @@ import {
   WorkerStampRuntimeConfig,
   WorkerSupabaseRuntimeConfig,
   WorkerTimeConfig,
+  WorkerTourismRuntimeConfig,
 } from '../../deploy/api-worker-shell/config/runtime';
 
 describe('Worker runtime config', () => {
@@ -50,6 +51,12 @@ describe('Worker runtime config', () => {
     expect(WorkerFestivalRuntimeConfig.internalSourceKey).toBe('jamissue-public-event-feed');
     expect(WorkerFestivalRuntimeConfig.internalSourceName).toBe('Daejeon Official Event Search');
     expect(WorkerFestivalRuntimeConfig.internalSourceUrl).toBe('https://www.daejeon.go.kr/fvu/FvuEventList.do?menuSeq=504');
+  });
+
+  it('preserves tourism runtime settings', () => {
+    expect(WorkerTourismRuntimeConfig.defaultPlacesLimit).toBe(50);
+    expect(WorkerTourismRuntimeConfig.maxPlacesLimit).toBe(100);
+    expect(WorkerTourismRuntimeConfig.facetQueryLimit).toBe(10000);
   });
 
   it('preserves notification runtime limits', () => {

--- a/test/unit/worker-tourism-domain.test.ts
+++ b/test/unit/worker-tourism-domain.test.ts
@@ -1,0 +1,164 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { handleTourismPlaces } from '../../deploy/api-worker-shell/services/tourism';
+import type { WorkerEnv } from '../../deploy/api-worker-shell/types';
+
+const apiUrl = 'https://api.daejeon.jamissue.com';
+
+function buildEnv(overrides: WorkerEnv = {}): WorkerEnv {
+  return {
+    APP_SUPABASE_URL: 'https://supabase.example.test',
+    APP_SUPABASE_SERVICE_ROLE_KEY: 'service-role-key',
+    ...overrides,
+  };
+}
+
+function jsonResponse(body: unknown, init: ResponseInit = {}) {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+function tourismPlaceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    external_id: 'kto-1',
+    display_name: '대전 관광지',
+    category: 'tourism',
+    district: '유성구',
+    content_type_id: '12',
+    content_type_label: '관광지',
+    cat1: 'A01',
+    cat1_label: '자연',
+    cat2: null,
+    cat2_label: null,
+    cat3: null,
+    cat3_label: null,
+    kto_facet: 'attraction',
+    address: null,
+    road_address: '대전 유성구 테스트로 1',
+    summary: '관광지 설명',
+    image_url: null,
+    source_page_url: 'https://kto.example.test/place',
+    latitude: '36.36',
+    longitude: '127.36',
+    source_updated_at: '2026-06-01T00:00:00Z',
+    raw_payload: { secret: true },
+    kto_place_id: 99,
+    kto_place_map_link: [{ map: { position_id: 101, slug: 'daejeon-place', name: '지도 장소' } }],
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('worker tourism public contract', () => {
+  it('returns allowlisted tourism places, facets, and curated projection from non-stale rows', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([{ resource_type: 'places', source_name: 'KTO', last_success_at: '2026-06-01T00:00:00Z' }]))
+      .mockResolvedValueOnce(jsonResponse([
+        { content_type_id: '12', content_type_label: '관광지', kto_facet: 'attraction', district: '유성구' },
+        { content_type_id: '39', content_type_label: '음식점', kto_facet: 'restaurant', district: '중구' },
+      ]))
+      .mockResolvedValueOnce(jsonResponse([tourismPlaceRow()]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handleTourismPlaces(
+      new Request(`${apiUrl}/api/tourism/places?district=유성구&ktoContentTypeId=12&ktoFacet=attraction&limit=999`),
+      buildEnv(),
+    );
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(payload).toEqual({
+      sourceReady: true,
+      sourceName: 'KTO',
+      importedAt: '2026-06-01T00:00:00Z',
+      facets: {
+        contentTypes: [
+          { id: '12', label: '관광지', count: 1 },
+          { id: '39', label: '음식점', count: 1 },
+        ],
+        ktoFacets: [
+          { key: 'attraction', label: '관광지', count: 1 },
+          { key: 'restaurant', label: '음식점', count: 1 },
+        ],
+        districts: [
+          { name: '유성구', count: 1 },
+          { name: '중구', count: 1 },
+        ],
+      },
+      items: [
+        {
+          id: 'kto-1',
+          name: '대전 관광지',
+          category: 'tourism',
+          ktoContentTypeId: '12',
+          ktoContentTypeLabel: '관광지',
+          ktoCategoryCode1: 'A01',
+          ktoCategoryLabel1: '자연',
+          ktoCategoryCode2: null,
+          ktoCategoryLabel2: null,
+          ktoCategoryCode3: null,
+          ktoCategoryLabel3: null,
+          ktoFacet: 'attraction',
+          district: '유성구',
+          address: null,
+          roadAddress: '대전 유성구 테스트로 1',
+          summary: '관광지 설명',
+          imageUrl: null,
+          sourcePageUrl: 'https://kto.example.test/place',
+          latitude: 36.36,
+          longitude: 127.36,
+          sourceUpdatedAt: '2026-06-01T00:00:00Z',
+          isCurated: true,
+          curatedPlace: { positionId: 101, slug: 'daejeon-place', name: '지도 장소' },
+        },
+      ],
+    });
+    expect(JSON.stringify(payload)).not.toContain('kto_place_id');
+    expect(JSON.stringify(payload)).not.toContain('raw_payload');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('sync_status=neq.stale');
+    expect(String(fetchMock.mock.calls[1][0])).toContain('limit=10000');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('kto_place_map_link(map(position_id,slug,name))');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('district=eq.%EC%9C%A0%EC%84%B1%EA%B5%AC');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('content_type_id=eq.12');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('kto_facet=eq.attraction');
+    expect(String(fetchMock.mock.calls[2][0])).toContain('limit=100');
+  });
+
+  it('maps missing curated links to an explicit false/null contract', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([{ resource_type: 'places', source_name: 'KTO', last_imported_at: '2026-06-01T00:00:00Z' }]))
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse([tourismPlaceRow({ kto_place_map_link: [] })]));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const response = await handleTourismPlaces(new Request(`${apiUrl}/api/tourism/places`), buildEnv());
+    const payload = await response.json();
+
+    expect(payload.items[0]).toMatchObject({
+      isCurated: false,
+      curatedPlace: null,
+    });
+  });
+
+  it('returns a stable empty response when KTO schema is missing', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(jsonResponse({ code: 'PGRST205', message: 'Could not find public.kto_place' }, { status: 404 })));
+
+    const response = await handleTourismPlaces(new Request(`${apiUrl}/api/tourism/places`), buildEnv());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      sourceReady: false,
+      sourceName: null,
+      importedAt: null,
+      facets: { contentTypes: [], ktoFacets: [], districts: [] },
+      items: [],
+    });
+  });
+});


### PR DESCRIPTION
## Scope
TSK-013-01 KTO 관광 contract 소비 구현입니다.

이 PR은 Web repo가 Admin repo의 public API contract를 Worker public API로 소비하도록 맞춥니다. Front는 KTO/OpenAPI/Supabase를 직접 호출하지 않고, 기존 5개 bottom tab 구조를 유지하며 `행사` 탭 내부에서 `행사 / 관광장소` segment로 분리 렌더링합니다.

## Changes
- Worker `GET /api/tourism/places` route, tourism read domain, mapper, repository 추가
- `kto_place` non-stale 필터, limit 기본 `50`/최대 `100`, 전체 non-stale 기준 facets 계산 추가
- `kto_place_map_link` 기반 `isCurated`/safe `curatedPlace` projection 추가
- KTO schema missing 시 `200 sourceReady:false` empty response 유지
- Front `TourismPlacesResponse`, `TourismPlaceItem`, `TourismFacets`, `getTourismPlaces()` 추가
- `EventTab` 안에 `행사 / 관광장소` segment와 facet filter UI 추가
- 기존 `/api/festivals`, `/api/banner/events` shape 유지, source/stale read 조건 보정
- deployed Worker tourism smoke script 추가

## Validation
- `npm.cmd run test:unit` passed
- `npm.cmd run typecheck` passed
- `npm.cmd run smoke` passed, 9/9 public checks
- `npm.cmd run smoke:worker-tourism` passed, `sourceReady:true`, `itemCount:3`
- `git diff --check` passed

## Architecture Boundary Evidence
- Responsibility map: Worker route registry는 HTTP dispatch, tourism-domain read service는 contract policy, repository는 Supabase query, mapper는 public allowlist, Front API client는 URL construction, EventTabTourismSection은 local filter/rendering을 소유합니다.
- Dependency direction: Front -> Worker public API -> Supabase REST. Front -> Supabase/KTO/OpenAPI 직접 의존은 없습니다.
- Validation seam: Worker/Front unit tests는 mock 기반으로 검증하고, deployed smoke는 live public contract만 별도로 확인합니다.
- Scope map: Worker tourism files, Front tourism client/types/UI, festival source/stale correction, contract tests, smoke script가 TSK-013-01 checklist에 매핑됩니다.
- Architecture risk: Supabase embedded join `kto_place_map_link(map(...))` 이름은 deployed schema와 일치해야 합니다. 현재 deployed tourism smoke는 통과했습니다.

Closes https://github.com/STH-1-Class-One-Group/JamIssue/issues/390