### PR TITLE
docs: link 1.3.2 GitHub release

### DIFF
--- a/docs/release-1.3.2.md
+++ b/docs/release-1.3.2.md
@@ -13,12 +13,15 @@ This release note does not claim that the work is merged into `main`.
 | --- | --- |
 | Version | `1.3.2` |
 | Date | 2026-06-12 |
-| Status | Documentation release note for merged feature branch work |
+| Status | GitHub Release |
+| Tag | `release-v1.3.2` |
 | Base branch | `typescript-coverage-95` |
 | Implementation commit | `cb7e858112d3eadb0556065401167270d1532709` |
-| Merge commit | `514a6689f0d217548c3cf6af473af12ba11aae54` |
+| Implementation merge commit | `514a6689f0d217548c3cf6af473af12ba11aae54` |
+| Release target commit | `e6fd3517e5ea1a8f98ba2793037b092d0efc086b` |
 | Pull request | https://github.com/STH-1-Class-One-Group/JamIssue/pull/391 |
 | Tracking issue | https://github.com/STH-1-Class-One-Group/JamIssue/issues/390 |
+| GitHub Release | https://github.com/STH-1-Class-One-Group/JamIssue/releases/tag/release-v1.3.2 |
 
 ## Included Changes
 


### PR DESCRIPTION
## Summary
- Update docs/release-1.3.2.md to point to the actual GitHub Release elease-v1.3.2.
- Record release target commit e6fd3517e5ea1a8f98ba2793037b092d0efc086b separately from the PR #391 implementation merge commit.

## Validation
- gh release view release-v1.3.2 --repo STH-1-Class-One-Group/JamIssue --json tagName,name,isPrerelease,targetCommitish,publishedAt,url
- git diff --check

## Scope
Docs only. Wiki was already pushed separately in commit 30171ff.