### PR TITLE
refactor: introduce app shell layout boundary

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,7 @@
 import { useState } from 'react';
 import { AppMapStageView } from './components/AppMapStageView';
 import { AppPageStage } from './components/AppPageStage';
-import { BottomNav } from './components/BottomNav';
-import { FloatingBackButton } from './components/FloatingBackButton';
-import { GlobalSettingsMenu } from './components/GlobalSettingsMenu';
-import { GlobalStatusBanner } from './components/GlobalStatusBanner';
+import { AppShell } from './components/app-shell/AppShell';
 import {
   useAppRouteState,
   getInitialMapViewport,
@@ -55,37 +52,23 @@ export default function App() {
     pageStageProps,
   } = useAppStageProps(coordinator);
   return (
-    <div className="map-app-shell">
-      <div
-        className={[
-          'phone-shell',
-          activeTab === 'map' ? 'phone-shell--map' : '',
-        ].filter(Boolean).join(' ')}
-      >
-        {globalStatus && (
-          <div className="phone-shell__status-slot">
-            <GlobalStatusBanner
-              tone={globalStatus.tone}
-              message={globalStatus.message}
-              layout={activeTab === 'map' ? 'map' : 'page'}
-            />
-          </div>
-        )}
-        <div className="phone-shell__utility-slot">
-          <GlobalSettingsMenu {...globalUtility} />
-        </div>
-        <div className="phone-shell__body">
-          {activeTab === 'map' ? (
-            <AppMapStageView {...mapStageProps} />
-          ) : (
-            <AppPageStage {...pageStageProps} />
-          )}
-
-          {canNavigateBack && <FloatingBackButton onNavigateBack={handleNavigateBack} />}
-
-          <BottomNav activeTab={activeTab} onChange={handleBottomNavChange} />
-        </div>
-      </div>
-    </div>
+    <AppShell
+      activeTab={activeTab}
+      canNavigateBack={canNavigateBack}
+      globalStatus={globalStatus ? {
+        tone: globalStatus.tone,
+        message: globalStatus.message,
+        layout: activeTab === 'map' ? 'map' : 'page',
+      } : null}
+      globalUtility={globalUtility}
+      onBottomTabChange={handleBottomNavChange}
+      onNavigateBack={handleNavigateBack}
+    >
+      {activeTab === 'map' ? (
+        <AppMapStageView {...mapStageProps} />
+      ) : (
+        <AppPageStage {...pageStageProps} />
+      )}
+    </AppShell>
   );
 }

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -1,0 +1,66 @@
+import type { ComponentProps, ReactNode } from 'react';
+import type { Tab } from '../../types/core';
+import { BottomNav } from '../BottomNav';
+import { FloatingBackButton } from '../FloatingBackButton';
+import { GlobalSettingsMenu } from '../GlobalSettingsMenu';
+import { GlobalStatusBanner } from '../GlobalStatusBanner';
+
+interface AppShellProps {
+  activeTab: Tab;
+  canNavigateBack: boolean;
+  children: ReactNode;
+  globalStatus: ComponentProps<typeof GlobalStatusBanner> | null;
+  globalUtility: ComponentProps<typeof GlobalSettingsMenu>;
+  onBottomTabChange: (nextTab: Tab) => void;
+  onNavigateBack: () => void;
+}
+
+export function AppShell({
+  activeTab,
+  canNavigateBack,
+  children,
+  globalStatus,
+  globalUtility,
+  onBottomTabChange,
+  onNavigateBack,
+}: AppShellProps) {
+  const isMapStage = activeTab === 'map';
+
+  return (
+    <div className="map-app-shell" data-app-shell="root">
+      <div
+        className={[
+          'phone-shell',
+          isMapStage ? 'phone-shell--map' : '',
+        ].filter(Boolean).join(' ')}
+        data-app-shell="phone"
+      >
+        {globalStatus && (
+          <div className="phone-shell__status-slot app-shell__status-safe-area" data-app-shell-slot="status">
+            <GlobalStatusBanner
+              tone={globalStatus.tone}
+              message={globalStatus.message}
+              layout={globalStatus.layout}
+            />
+          </div>
+        )}
+        <div className="phone-shell__utility-slot app-shell__header-actions" data-app-shell-slot="header-actions">
+          <GlobalSettingsMenu {...globalUtility} />
+        </div>
+        <div className="phone-shell__body" data-app-shell-slot="body">
+          <div className="app-shell__content-slot" data-app-shell-slot="content">
+            {children}
+          </div>
+          {canNavigateBack && (
+            <div className="app-shell__overlay-slot" data-app-shell-slot="overlay">
+              <FloatingBackButton onNavigateBack={onNavigateBack} />
+            </div>
+          )}
+          <div className="app-shell__bottom-tab-slot" data-app-shell-slot="bottom-tab">
+            <BottomNav activeTab={activeTab} onChange={onBottomTabChange} />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,4 @@
-﻿:root {
+:root {
   --app-height: 100dvh;
   --app-width: 100vw;
   --bottom-nav-offset: calc(76px + env(safe-area-inset-bottom));
@@ -161,6 +161,16 @@ textarea {
 .phone-shell__body {
   position: absolute;
   inset: 0;
+}
+
+.app-shell__content-slot {
+  position: absolute;
+  inset: 0;
+}
+
+.app-shell__overlay-slot,
+.app-shell__bottom-tab-slot {
+  display: contents;
 }
 
 .phone-shell__status-slot .global-status-banner {
@@ -1464,7 +1474,7 @@ textarea {
   min-height: var(--bottom-nav-offset);
   z-index: 40;
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 10px;
   padding: 10px 14px calc(10px + env(safe-area-inset-bottom));
   background: rgba(255, 252, 249, 0.9);

--- a/test/e2e/app-shell.spec.ts
+++ b/test/e2e/app-shell.spec.ts
@@ -1,5 +1,13 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Locator } from '@playwright/test';
 import { createE2EAppState, installApiFixtures } from './fixtures';
+
+async function requireBoundingBox(locator: Locator) {
+  const box = await locator.boundingBox();
+  if (!box) {
+    throw new Error('Expected locator to have a bounding box.');
+  }
+  return box;
+}
 
 test('mobile app shell exposes primary tabs from the built bundle', async ({ page }) => {
   await installApiFixtures(page, createE2EAppState({ authenticated: false }));
@@ -11,4 +19,34 @@ test('mobile app shell exposes primary tabs from the built bundle', async ({ pag
   await expect(page.getByRole('button', { name: '피드' })).toBeVisible();
   await expect(page.getByRole('button', { name: '코스' })).toBeVisible();
   await expect(page.getByRole('button', { name: '마이' })).toBeVisible();
+});
+
+test('UIUX-001 keeps shell slots and five-tab bar inside the phone shell', async ({ page }) => {
+  await installApiFixtures(page, createE2EAppState({ authenticated: false }));
+
+  await page.goto('/');
+
+  const phoneShell = page.locator('[data-app-shell="phone"]');
+  const contentSlot = page.locator('[data-app-shell-slot="content"]');
+  const headerActions = page.locator('[data-app-shell-slot="header-actions"]');
+  const bottomTabSlot = page.locator('[data-app-shell-slot="bottom-tab"]');
+  const bottomNav = page.getByRole('navigation', { name: '하단 네비게이션' });
+  const bottomNavItems = bottomNav.locator('.bottom-nav__item');
+
+  await expect(phoneShell).toBeVisible();
+  await expect(contentSlot).toBeVisible();
+  await expect(headerActions).toBeVisible();
+  await expect(bottomTabSlot).toBeAttached();
+  await expect(bottomNavItems).toHaveCount(5);
+
+  const shellBox = await requireBoundingBox(phoneShell);
+  const navBox = await requireBoundingBox(bottomNav);
+  expect(navBox.x).toBeGreaterThanOrEqual(shellBox.x - 1);
+  expect(navBox.x + navBox.width).toBeLessThanOrEqual(shellBox.x + shellBox.width + 1);
+  expect(navBox.y + navBox.height).toBeLessThanOrEqual(shellBox.y + shellBox.height + 1);
+
+  const itemBoxes = await bottomNavItems.evaluateAll((items) => items.map((item) => item.getBoundingClientRect().width));
+  const widest = Math.max(...itemBoxes);
+  const narrowest = Math.min(...itemBoxes);
+  expect(widest - narrowest).toBeLessThan(2);
 });

--- a/test/unit/architecture-readability-source-quality.test.ts
+++ b/test/unit/architecture-readability-source-quality.test.ts
@@ -57,7 +57,7 @@ describe('architecture readability source quality baseline', () => {
     expect(largeFiles).toEqual([]);
   });
 
-  it('keeps import hot spots explicit before app-shell and Worker entrypoint readability work', () => {
+  it('keeps import hot spots explicit after app-shell composition moves out of App', () => {
     const hotSpots = collectTrackedFiles(['src'])
       .filter((path) => trackedFrontendExtensions.test(path))
       .map((path) => ({ path, imports: countImportStatements(path) }))
@@ -65,7 +65,7 @@ describe('architecture readability source quality baseline', () => {
       .sort((left, right) => left.path.localeCompare(right.path));
 
     expect(hotSpots).toEqual([
-      { path: 'src/App.tsx', imports: 18 },
+      { path: 'src/App.tsx', imports: 15 },
       { path: 'src/components/MyPagePanel.tsx', imports: 11 },
       { path: 'src/hooks/app-bootstrap/useAppBootstrapLifecycle.ts', imports: 11 },
       { path: 'src/hooks/app-tab-loaders/useAppTabDataLoaders.ts', imports: 11 },


### PR DESCRIPTION
## 요약

Closes #382

공통 앱 셸 조립 책임을 `AppShell` 컴포넌트로 분리하고, 모바일 5탭 하단 탭바가 phone shell 안에서 동일 폭으로 배치되는지 E2E로 고정했습니다.

## 변경 사항

- `src/components/app-shell/AppShell.tsx` 추가
  - status safe area, header actions, content, overlay, bottom tab slot을 한 곳에서 조립
  - `App.tsx`는 route/domain state 조립과 stage 선택에 집중
- `src/index.css`
  - content slot을 shell 내부 absolute slot으로 고정
  - 기본 `.bottom-nav` grid를 5탭 기준으로 수정
  - 수정 파일 BOM 제거
- `test/e2e/app-shell.spec.ts`
  - `UIUX-001` shell slot, phone shell bounds, 5개 탭 균등 배치 검증 추가
- `test/unit/architecture-readability-source-quality.test.ts`
  - `App.tsx` import hot spot 기준을 18 -> 15로 낮춰 shell composition 이동 효과를 고정

## 아키텍처 경계

- Responsibility map: #382는 AppShell/safe-area/layout wrapper를 소유합니다. #383은 map sheet, #384는 IA/tab key, #386은 token/numeric gate를 소유합니다.
- Dependency direction: `App.tsx`가 feature state/stage를 조립하고, `AppShell`이 shell slot과 shell UI controls를 조립합니다. AppShell은 domain 로직을 직접 소유하지 않습니다.
- Test seam: `test/e2e/app-shell.spec.ts`, `test/e2e/critical-ui-flow.spec.ts`, architecture readability source-quality gate.
- Scope map: frontend shell/layout files와 관련 E2E/source-quality test만 변경했습니다.
- Architecture risk: 바텀시트 상태와 5탭 IA 전환은 의도적으로 #383/#384에 남겼습니다.

## 검증

통과:

```powershell
npm.cmd run lint
npm.cmd run typecheck
npm.cmd run test:unit
npm.cmd run test:integration
npm.cmd run test:regression
npm.cmd run test:e2e
npm.cmd run test:coverage:ts
npm.cmd run build
git diff --check
UTF-8 integrity check
```

확인된 gap:

```powershell
npm.cmd run check:numeric-literals
```

현재 `main`의 `package.json`에는 `check:numeric-literals` script가 없어 실행 불가입니다. 이 PR은 해당 명령을 완료 근거로 사용하지 않고, design token / numeric literal gate는 #386에서 처리하도록 #382 verification contract에 명시했습니다.

## 비범위

- API path, response shape, DB schema, OAuth 경로 변경 없음
- 사용자-facing runtime copy 변경 없음
- 바텀시트 `hidden / peek / half / full` 구현 없음
- 5탭 IA 전환 추가 변경 없음