### PR TITLE
Fix map bottom sheet state machine

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -51,9 +51,15 @@ export default function App() {
     mapStageProps,
     pageStageProps,
   } = useAppStageProps(coordinator);
+  const bottomTabHidden = activeTab === 'map' && (
+    (Boolean(mapStageProps.mapData.selectedPlace) && mapStageProps.mapData.drawerState === 'full') ||
+    (Boolean(mapStageProps.mapData.selectedFestival) && mapStageProps.mapData.drawerState === 'full')
+  );
+
   return (
     <AppShell
       activeTab={activeTab}
+      bottomTabHidden={bottomTabHidden}
       canNavigateBack={canNavigateBack}
       globalStatus={globalStatus ? {
         tone: globalStatus.tone,

--- a/src/components/FestivalDetailSheet.tsx
+++ b/src/components/FestivalDetailSheet.tsx
@@ -1,9 +1,12 @@
 import type { DrawerState, FestivalItem } from '../types/core';
+import type { MapSheetState } from './map-stage/mapSheetState';
+import { buildMapSheetClassName } from './map-stage/mapSheetState';
 
 interface FestivalDetailSheetProps {
   festival: FestivalItem | null;
   isOpen: boolean;
   drawerState: DrawerState;
+  sheetState: MapSheetState;
   onClose: () => void;
   onExpand: () => void;
   onCollapse: () => void;
@@ -24,6 +27,7 @@ export function FestivalDetailSheet({
   festival,
   isOpen,
   drawerState,
+  sheetState,
   onClose,
   onExpand,
   onCollapse,
@@ -32,7 +36,7 @@ export function FestivalDetailSheet({
     return null;
   }
 
-  const sheetClassName = `place-drawer place-drawer--${drawerState}`;
+  const sheetClassName = buildMapSheetClassName('place-drawer', sheetState, drawerState);
   const hasSchedule = Boolean(festival.startDate || festival.endDate);
   const periodLabel = hasSchedule
     ? festival.startDate && festival.endDate
@@ -41,7 +45,7 @@ export function FestivalDetailSheet({
     : '일정 업데이트 전';
 
   return (
-    <section className={sheetClassName} aria-label="행사 상세 서랍">
+    <section className={sheetClassName} data-map-sheet-state={sheetState} aria-label="행사 상세 서랍">
       <button
         type="button"
         className="place-drawer__handle"

--- a/src/components/PlaceDetailSheet.tsx
+++ b/src/components/PlaceDetailSheet.tsx
@@ -5,12 +5,14 @@ import { PlaceDetailReviewSection } from './place/PlaceDetailReviewSection';
 import { PlaceProofCard } from './place/PlaceProofCard';
 import type { PlaceDetailSheetProps } from './place/placeDetailSheetTypes';
 import { usePlaceDrawerHandle } from './place/usePlaceDrawerHandle';
+import { buildMapSheetClassName } from './map-stage/mapSheetState';
 
 export function PlaceDetailSheet({
   place,
   reviews,
   isOpen,
   drawerState,
+  sheetState,
   loggedIn,
   visitCount,
   latestStamp,
@@ -41,13 +43,13 @@ export function PlaceDetailSheet({
     return null;
   }
 
-  const sheetClassName = `place-drawer place-drawer--${drawerState}`;
+  const sheetClassName = buildMapSheetClassName('place-drawer', sheetState, drawerState);
   const visitLabel = latestStamp ? latestStamp.visitLabel : '첫 방문 대기';
   const canClaimStamp = loggedIn && !todayStamp;
   const categoryMeta = categoryInfo[place.category];
 
   return (
-    <section className={sheetClassName} aria-label="장소 상세 시트">
+    <section className={sheetClassName} data-map-sheet-state={sheetState} aria-label="장소 상세 시트">
       <button
         type="button"
         className="place-drawer__handle"

--- a/src/components/app-shell/AppShell.tsx
+++ b/src/components/app-shell/AppShell.tsx
@@ -7,6 +7,7 @@ import { GlobalStatusBanner } from '../GlobalStatusBanner';
 
 interface AppShellProps {
   activeTab: Tab;
+  bottomTabHidden?: boolean;
   canNavigateBack: boolean;
   children: ReactNode;
   globalStatus: ComponentProps<typeof GlobalStatusBanner> | null;
@@ -17,6 +18,7 @@ interface AppShellProps {
 
 export function AppShell({
   activeTab,
+  bottomTabHidden = false,
   canNavigateBack,
   children,
   globalStatus,
@@ -56,7 +58,13 @@ export function AppShell({
               <FloatingBackButton onNavigateBack={onNavigateBack} />
             </div>
           )}
-          <div className="app-shell__bottom-tab-slot" data-app-shell-slot="bottom-tab">
+          <div
+            className={[
+              'app-shell__bottom-tab-slot',
+              bottomTabHidden ? 'app-shell__bottom-tab-slot--hidden' : '',
+            ].filter(Boolean).join(' ')}
+            data-app-shell-slot="bottom-tab"
+          >
             <BottomNav activeTab={activeTab} onChange={onBottomTabChange} />
           </div>
         </div>

--- a/src/components/map-stage/MapStageSheets.tsx
+++ b/src/components/map-stage/MapStageSheets.tsx
@@ -1,6 +1,7 @@
 import { FestivalDetailSheet } from '../FestivalDetailSheet';
 import { PlaceDetailSheet } from '../PlaceDetailSheet';
 import type { MapTabStageProps } from './mapTabStageTypes';
+import { resolveMapSheetState } from './mapSheetState';
 
 interface MapStageSheetsProps {
   placeSheet: MapTabStageProps['placeSheet'];
@@ -8,13 +9,17 @@ interface MapStageSheetsProps {
 }
 
 export function MapStageSheets({ placeSheet, festivalSheet }: MapStageSheetsProps) {
+  const placeSheetState = resolveMapSheetState(Boolean(placeSheet.selectedPlace), placeSheet.drawerState);
+  const festivalSheetState = resolveMapSheetState(Boolean(festivalSheet.selectedFestival), festivalSheet.drawerState);
+
   return (
     <>
       <PlaceDetailSheet
         place={placeSheet.selectedPlace}
         reviews={placeSheet.selectedPlaceReviews}
-        isOpen={Boolean(placeSheet.selectedPlace) && placeSheet.drawerState !== 'closed'}
+        isOpen={placeSheetState !== 'hidden'}
         drawerState={placeSheet.drawerState}
+        sheetState={placeSheetState}
         loggedIn={Boolean(placeSheet.sessionUser)}
         visitCount={placeSheet.visitCount}
         latestStamp={placeSheet.latestStamp}
@@ -37,8 +42,9 @@ export function MapStageSheets({ placeSheet, festivalSheet }: MapStageSheetsProp
 
       <FestivalDetailSheet
         festival={festivalSheet.selectedFestival}
-        isOpen={Boolean(festivalSheet.selectedFestival) && festivalSheet.drawerState !== 'closed'}
+        isOpen={festivalSheetState !== 'hidden'}
         drawerState={festivalSheet.drawerState}
+        sheetState={festivalSheetState}
         onClose={festivalSheet.onCloseDrawer}
         onExpand={festivalSheet.onExpandFestivalDrawer}
         onCollapse={festivalSheet.onCollapseFestivalDrawer}

--- a/src/components/map-stage/mapSheetState.ts
+++ b/src/components/map-stage/mapSheetState.ts
@@ -1,0 +1,20 @@
+import type { DrawerState } from '../../types/core';
+
+export type MapSheetState = 'hidden' | 'peek' | 'half' | 'full';
+
+export function resolveMapSheetState(hasSelection: boolean, drawerState: DrawerState): MapSheetState {
+  if (!hasSelection || drawerState === 'closed') {
+    return 'hidden';
+  }
+
+  return drawerState === 'full' ? 'full' : 'peek';
+}
+
+export function buildMapSheetClassName(baseClassName: string, sheetState: MapSheetState, drawerState: DrawerState) {
+  return Array.from(new Set([
+    baseClassName,
+    `${baseClassName}--${sheetState}`,
+    `${baseClassName}--${drawerState}`,
+    `${baseClassName}--route-${drawerState}`,
+  ])).join(' ');
+}

--- a/src/components/place/placeDetailSheetTypes.ts
+++ b/src/components/place/placeDetailSheetTypes.ts
@@ -1,11 +1,13 @@
 import type { ApiStatus, DrawerState, Place, ReviewMood } from '../../types/core';
 import type { Review, StampLog } from '../../types/review';
+import type { MapSheetState } from '../map-stage/mapSheetState';
 
 export interface PlaceDetailSheetProps {
   place: Place | null;
   reviews: Review[];
   isOpen: boolean;
   drawerState: DrawerState;
+  sheetState: MapSheetState;
   loggedIn: boolean;
   visitCount: number;
   latestStamp: StampLog | null;

--- a/src/index.css
+++ b/src/index.css
@@ -173,6 +173,12 @@ textarea {
   display: contents;
 }
 
+.app-shell__bottom-tab-slot--hidden .bottom-nav {
+  transform: translateY(100%);
+  opacity: 0;
+  pointer-events: none;
+}
+
 .phone-shell__status-slot .global-status-banner {
   position: relative;
   left: auto;
@@ -869,6 +875,16 @@ textarea {
   box-shadow: var(--sheet-shadow);
 }
 
+.place-drawer--peek {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
+  height: 31%;
+}
+
+.place-drawer--half {
+  bottom: 0;
+  height: 50%;
+}
+
 .place-drawer--closed {
   transform: translateY(120%);
   opacity: 0;
@@ -876,10 +892,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 31%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 60%;
 }
 
@@ -1494,6 +1512,7 @@ textarea {
   }
 
   .place-drawer--full {
+    bottom: 0;
     height: 68%;
   }
 
@@ -1570,10 +1589,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 34%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 64%;
 }
 
@@ -1669,10 +1690,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 36%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 68%;
 }
 
@@ -1801,10 +1824,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 30%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 56%;
 }
 
@@ -1941,10 +1966,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 36%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 66%;
 }
 
@@ -2179,10 +2206,12 @@ textarea {
 }
 
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px);
   height: 34%;
 }
 
 .place-drawer--full {
+  bottom: 0;
   height: 62%;
 }
 

--- a/src/styles/refinements.css
+++ b/src/styles/refinements.css
@@ -141,11 +141,23 @@
   background: rgba(255, 252, 249, 0.99) !important;
 }
 
+.place-drawer--peek {
+  bottom: calc(var(--bottom-nav-offset) + 12px) !important;
+  height: 35% !important;
+}
+
+.place-drawer--half {
+  bottom: 0 !important;
+  height: 50% !important;
+}
+
 .place-drawer--partial {
+  bottom: calc(var(--bottom-nav-offset) + 12px) !important;
   height: 35% !important;
 }
 
 .place-drawer--full {
+  bottom: 0 !important;
   height: 60% !important;
 }
 
@@ -181,10 +193,12 @@ input.visually-hidden[type='file'] {
   }
 
   .place-drawer--partial {
+    bottom: calc(var(--bottom-nav-offset) + 12px) !important;
     height: 34% !important;
   }
 
   .place-drawer--full {
+    bottom: 0 !important;
     height: 58% !important;
   }
 }
@@ -204,6 +218,8 @@ input.visually-hidden[type='file'] {
 }
 
 .place-drawer--partial,
+.place-drawer--peek,
+.place-drawer--half,
 .place-drawer--full {
   box-shadow: 0 -20px 40px rgba(66, 40, 60, 0.2) !important;
 }

--- a/test/e2e/critical-ui-flow.spec.ts
+++ b/test/e2e/critical-ui-flow.spec.ts
@@ -20,10 +20,13 @@ test('UIUX-009 keeps drawer and bottom navigation anchored while writing a revie
   await page.goto('/?tab=map&place=place-1&drawer=full');
 
   await expect(page.locator('.place-drawer--full')).toBeVisible();
+  await expect(page.locator('[data-map-sheet-state="full"]')).toBeVisible();
   await expect(page.getByRole('heading', { name: '테스트 카페', exact: true })).toBeVisible();
 
-  const bottomNav = page.getByRole('navigation', { name: '하단 네비게이션' });
+  const bottomNav = page.getByRole('navigation');
   const beforeFocus = await requireBoundingBox(bottomNav);
+  await expect(bottomNav).toHaveCSS('pointer-events', 'none');
+  await expect(bottomNav).toHaveCSS('opacity', '0');
   const reviewBody = page.getByLabel('오늘의 기록');
   await reviewBody.scrollIntoViewIfNeeded();
   await reviewBody.focus();
@@ -58,7 +61,12 @@ test('UIUX-010 supports feed comment creation, like toggle, and place CTA', asyn
   await expect(page.locator('article[data-review-id="review-1"] .review-action-button[aria-pressed="true"]')).toContainText('3');
 
   await page.getByRole('button', { name: '장소 보기' }).click();
-  await expect(page.locator('.place-drawer--partial')).toBeVisible();
+  const peekDrawer = page.locator('[data-map-sheet-state="peek"]');
+  await expect(peekDrawer).toBeVisible();
+  const bottomNav = page.getByRole('navigation');
+  const drawerBox = await requireBoundingBox(peekDrawer);
+  const bottomNavBox = await requireBoundingBox(bottomNav);
+  expect(bottomNavBox.y - (drawerBox.y + drawerBox.height)).toBeGreaterThanOrEqual(12);
   await expect(page.getByRole('heading', { name: '테스트 카페', exact: true })).toBeVisible();
 });
 

--- a/test/integration/place-detail-sheet.test.tsx
+++ b/test/integration/place-detail-sheet.test.tsx
@@ -21,6 +21,7 @@ describe('PlaceDetailSheet integration', () => {
         reviews={[reviewFixture, secondaryReviewFixture]}
         isOpen={true}
         drawerState="partial"
+        sheetState="peek"
         loggedIn={true}
         visitCount={2}
         latestStamp={latestStampFixture}
@@ -63,6 +64,7 @@ describe('PlaceDetailSheet integration', () => {
         reviews={[reviewFixture]}
         isOpen={true}
         drawerState="full"
+        sheetState="full"
         loggedIn={true}
         visitCount={2}
         latestStamp={todayStampFixture}
@@ -94,6 +96,7 @@ describe('PlaceDetailSheet integration', () => {
         reviews={[reviewFixture]}
         isOpen={true}
         drawerState="full"
+        sheetState="full"
         loggedIn={true}
         visitCount={2}
         latestStamp={todayStampFixture}
@@ -122,5 +125,6 @@ describe('PlaceDetailSheet integration', () => {
     expect(textarea).toBeEnabled();
     expect(drawerContent).not.toBeNull();
     expect(drawer).toHaveClass('place-drawer--full');
+    expect(drawer).toHaveAttribute('data-map-sheet-state', 'full');
   });
 });

--- a/test/smoke/component-smoke.test.tsx
+++ b/test/smoke/component-smoke.test.tsx
@@ -40,6 +40,7 @@ describe('component smoke', () => {
         reviews={[reviewFixture]}
         isOpen={true}
         drawerState="partial"
+        sheetState="peek"
         loggedIn={true}
         visitCount={2}
         latestStamp={latestStampFixture}

--- a/test/unit/map-sheet-state.test.ts
+++ b/test/unit/map-sheet-state.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { buildMapSheetClassName, resolveMapSheetState } from '../../src/components/map-stage/mapSheetState';
+
+describe('mapSheetState', () => {
+  it('keeps route drawer states compatible while exposing app sheet states', () => {
+    expect(resolveMapSheetState(false, 'partial')).toBe('hidden');
+    expect(resolveMapSheetState(true, 'closed')).toBe('hidden');
+    expect(resolveMapSheetState(true, 'partial')).toBe('peek');
+    expect(resolveMapSheetState(true, 'full')).toBe('full');
+  });
+
+  it('adds app sheet state classes without dropping legacy route classes', () => {
+    expect(buildMapSheetClassName('place-drawer', 'peek', 'partial')).toBe(
+      'place-drawer place-drawer--peek place-drawer--partial place-drawer--route-partial',
+    );
+    expect(buildMapSheetClassName('place-drawer', 'full', 'full')).toBe(
+      'place-drawer place-drawer--full place-drawer--route-full',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add a map-stage owned sheet state adapter for `hidden | peek | half | full` while preserving existing route drawer states.
- Keep `partial/full` URL and route contracts stable, but expose `data-map-sheet-state` for UI/E2E verification.
- Hide the bottom tab slot when a selected map sheet is in full mode, and keep peek sheets separated from the bottom tab by at least 12px.

## Scope / Issue
- Closes #383
- Scope-ID: `TSK-012-03`
- Branch: `map-bottom-sheet-state-machine`

## Architecture Boundary Evidence
- Responsibility map: `mapSheetState.ts` owns route-to-UI sheet state mapping; `MapStageSheets` resolves sheet state; `AppShell` owns bottom tab visibility.
- Dependency direction: app shell does not import map-stage internals; route state remains `DrawerState` and map-stage adapts it locally.
- Test seam: unit test fixes state mapping/class compatibility; E2E fixes peek/full layout behavior.
- Scope map: frontend UI state/CSS/tests only. API path, response shape, DB schema, OAuth flow, and copy style are unchanged.
- Architecture risk: retained legacy drawer classes as compatibility aliases to avoid breaking existing route/query behavior.

## Validation
- `npm.cmd run lint` passed.
- `npm.cmd run typecheck` passed.
- `npm.cmd run test:unit` passed.
- `npm.cmd run test:integration` passed.
- `npm.cmd run test:regression` passed.
- `npm.cmd run test:e2e` passed when run standalone. A parallel run with `build` failed because both touched `infra/nginx/site`; standalone rerun passed.
- `npm.cmd run test:coverage:ts` passed. Current repo coverage is still baseline-level, no hard threshold in this scope.
- `npm.cmd run build` passed.
- `git diff --check` passed.
- UTF-8 strict decode passed for 13 changed text files.
- `npm.cmd run check:numeric-literals` could not run because the script is not defined in current `package.json`; #386 owns design-token/numeric gate work.
