### PR TITLE
Lock five-tab information architecture

### DIFF
--- a/src/components/BottomNav.tsx
+++ b/src/components/BottomNav.tsx
@@ -21,6 +21,8 @@ export function BottomNav({ activeTab, onChange }: BottomNavProps) {
           key={item.key}
           type="button"
           className={item.key === activeTab ? 'bottom-nav__item is-active' : 'bottom-nav__item'}
+          data-tab-key={item.key}
+          aria-current={item.key === activeTab ? 'page' : undefined}
           onClick={() => onChange(item.key)}
         >
           {item.label}

--- a/test/e2e/app-shell.spec.ts
+++ b/test/e2e/app-shell.spec.ts
@@ -50,3 +50,28 @@ test('UIUX-001 keeps shell slots and five-tab bar inside the phone shell', async
   const narrowest = Math.min(...itemBoxes);
   expect(widest - narrowest).toBeLessThan(2);
 });
+
+test('UIUX-013 keeps five-tab IA and hides map stage on non-map tabs', async ({ page }) => {
+  await installApiFixtures(page, createE2EAppState({ authenticated: false }));
+
+  await page.goto('/');
+
+  const bottomNav = page.getByRole('navigation');
+  const tabKeys = await bottomNav.locator('.bottom-nav__item').evaluateAll((items) => (
+    items.map((item) => item.getAttribute('data-tab-key'))
+  ));
+  expect(tabKeys).toEqual(['map', 'event', 'feed', 'course', 'my']);
+
+  await expect(page.locator('.map-stage')).toBeVisible();
+
+  for (const tabKey of ['event', 'feed', 'course', 'my']) {
+    await bottomNav.locator(`[data-tab-key="${tabKey}"]`).click();
+    await expect(bottomNav.locator(`[data-tab-key="${tabKey}"]`)).toHaveAttribute('aria-current', 'page');
+    await expect(page.locator('.map-stage')).toHaveCount(0);
+    await expect(page.locator('.page-stage')).toBeVisible();
+  }
+
+  await bottomNav.locator('[data-tab-key="map"]').click();
+  await expect(bottomNav.locator('[data-tab-key="map"]')).toHaveAttribute('aria-current', 'page');
+  await expect(page.locator('.map-stage')).toBeVisible();
+});

--- a/test/unit/bottom-nav-contract.test.tsx
+++ b/test/unit/bottom-nav-contract.test.tsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { BottomNav } from '../../src/components/BottomNav';
+import type { Tab } from '../../src/types/core';
+
+const expectedTabs: Tab[] = ['map', 'event', 'feed', 'course', 'my'];
+
+describe('BottomNav contract', () => {
+  it('exposes the five primary app tabs in order', () => {
+    render(<BottomNav activeTab="event" onChange={vi.fn()} />);
+
+    const items = screen.getAllByRole('button');
+    expect(items).toHaveLength(expectedTabs.length);
+    expect(items.map((item) => item.getAttribute('data-tab-key'))).toEqual(expectedTabs);
+    expect(screen.getByRole('button', { current: 'page' })).toHaveAttribute('data-tab-key', 'event');
+  });
+
+  it('emits the selected tab key without owning routing policy', async () => {
+    const user = userEvent.setup();
+    const onChange = vi.fn();
+
+    render(<BottomNav activeTab="map" onChange={onChange} />);
+
+    await user.click(screen.getByRole('button', { name: '행사' }));
+
+    expect(onChange).toHaveBeenCalledWith('event');
+  });
+});


### PR DESCRIPTION
## Summary
- Lock the existing five-tab app IA contract: `map | event | feed | course | my`.
- Add stable `data-tab-key` and `aria-current` metadata to `BottomNav` for non-copy-dependent tests.
- Add unit and E2E coverage so non-map tabs render page-stage content and do not leak the map stage.

## Scope / Issue
- Closes #384
- Scope-ID: `TSK-012-04`
- Branch: `five-tab-information-architecture`

## Architecture Boundary Evidence
- Responsibility map: `BottomNav` exposes primary tab metadata only; route/page rendering policy remains in existing app navigation and stage composition.
- Dependency direction: `BottomNav` does not own data loading or route commit policy; E2E observes the AppShell/PageStage boundary.
- Test seam: unit test locks the bottom tab order and selected tab callback; E2E locks five-tab IA and non-map map-stage absence.
- Scope map: frontend navigation metadata and tests only. API path, response shape, DB schema, OAuth flow, and copy style are unchanged.
- Architecture risk: current code already had five tabs, so this PR avoids unnecessary rewrites and adds regression gates instead.

## Validation
- `npm.cmd run lint` passed.
- `npm.cmd run typecheck` passed.
- `npm.cmd run test:unit` passed.
- `npm.cmd run test:integration` passed.
- `npm.cmd run test:regression` passed.
- `npm.cmd run test:e2e` passed.
- `npm.cmd run test:coverage:ts` passed. Current repo coverage remains baseline-level, no hard threshold in this scope.
- `npm.cmd run build` passed.
- `git diff --check` passed.
- UTF-8 strict decode passed for 3 changed text files.
- `npm.cmd run check:numeric-literals` could not run because the script is not defined in current `package.json`; #386 owns design-token/numeric gate work.
