### PR TITLE
Lock tab content layout surfaces

### DIFF
--- a/src/components/CourseTab.tsx
+++ b/src/components/CourseTab.tsx
@@ -25,7 +25,7 @@ export const CourseTab = memo(function CourseTab({
   void courses;
 
   return (
-    <section ref={scrollRef} className="page-panel page-panel--scrollable">
+    <section ref={scrollRef} className="page-panel page-panel--scrollable" data-page-surface="course">
       <CourseTabHeader />
 
       <section className="sheet-card stack-gap">

--- a/src/components/EventTab.tsx
+++ b/src/components/EventTab.tsx
@@ -45,7 +45,7 @@ export function EventTab({ festivals }: EventTabProps) {
   const scrollRef = useScrollRestoration<HTMLElement>('event');
 
   return (
-    <section ref={scrollRef} className="page-panel page-panel--scrollable">
+    <section ref={scrollRef} className="page-panel page-panel--scrollable" data-page-surface="event">
       <header className="panel-header">
         <p className="eyebrow">EVENT</p>
         <h2>행사</h2>

--- a/src/components/FeedTab.tsx
+++ b/src/components/FeedTab.tsx
@@ -103,7 +103,7 @@ export const FeedTab = memo(function FeedTab({
 
   return (
     <>
-      <section ref={scrollRef} className="page-panel page-panel--scrollable">
+      <section ref={scrollRef} className="page-panel page-panel--scrollable" data-page-surface="feed">
         <FeedTabHeader placeFilterName={placeFilterName} onClearPlaceFilter={onClearPlaceFilter} />
         <ReviewList
           reviews={visibleReviews}

--- a/src/components/MyPagePanel.tsx
+++ b/src/components/MyPagePanel.tsx
@@ -86,14 +86,14 @@ export function MyPagePanel({
 
   if (!sessionUser) {
     return (
-      <section ref={scrollRef} className="page-panel page-panel--scrollable">
+      <section ref={scrollRef} className="page-panel page-panel--scrollable" data-page-surface="my">
         <MyPageGuestState providers={providers} onLogin={onLogin} />
       </section>
     );
   }
 
   return (
-    <section ref={scrollRef} className="page-panel page-panel--scrollable">
+    <section ref={scrollRef} className="page-panel page-panel--scrollable" data-page-surface="my">
       <MyPageHeader sessionUser={sessionUser} />
 
       {!myPage && myPageError && <MyPageLoadError myPageError={myPageError} onRetry={onRetry} />}

--- a/test/e2e/app-shell.spec.ts
+++ b/test/e2e/app-shell.spec.ts
@@ -75,3 +75,23 @@ test('UIUX-013 keeps five-tab IA and hides map stage on non-map tabs', async ({ 
   await expect(bottomNav.locator('[data-tab-key="map"]')).toHaveAttribute('aria-current', 'page');
   await expect(page.locator('.map-stage')).toBeVisible();
 });
+
+test('UIUX-014 keeps tab content surfaces accessible inside the app shell', async ({ page }) => {
+  await installApiFixtures(page, createE2EAppState());
+
+  await page.goto('/');
+
+  const bottomNav = page.getByRole('navigation');
+
+  for (const tabKey of ['event', 'feed', 'course', 'my']) {
+    await bottomNav.locator(`[data-tab-key="${tabKey}"]`).click();
+    const surface = page.locator(`[data-page-surface="${tabKey}"]`);
+    await expect(surface).toBeVisible();
+    await expect(surface).toHaveClass(/page-panel--scrollable/);
+
+    const surfaceBox = await requireBoundingBox(surface);
+    const contentSlotBox = await requireBoundingBox(page.locator('[data-app-shell-slot="content"]'));
+    expect(surfaceBox.x).toBeGreaterThanOrEqual(contentSlotBox.x - 1);
+    expect(surfaceBox.x + surfaceBox.width).toBeLessThanOrEqual(contentSlotBox.x + contentSlotBox.width + 1);
+  }
+});


### PR DESCRIPTION
## Summary
- Closes #385
- Scope-ID: TSK-012-05
- �Ǻ� ������ ��Ʈ�� `data-page-surface`�� �߰��� �� �� ���ο��� �� �� ȭ���� ���� surface�� �����Ǵ��� ���� �����ϰ� �߽��ϴ�.
- Playwright E2E `UIUX-014`�� ����/�ǵ�/�ڽ�/���� �� �������� �� �� content slot �ȿ� ǥ�õǴ��� �����߽��ϴ�.

## Architecture Boundary Evidence
- Responsibility map: �� ������Ʈ�� QA surface selector�� �����ϰ�, app shell/page stage�� ȭ�� ���� å���� �����մϴ�.
- Dependency direction: presentation component�� routing/data loading�� ���� �ʰ�, E2E�� DOM contract�� �����մϴ�.
- Test seam: `UIUX-014` E2E�� tab key -> page surface -> scrollable content slot ���踦 �����մϴ�.
- Scope map: frontend tab surface metadata�� E2E �׽�Ʈ�� �����߽��ϴ�. API/DB/OAuth/user-facing copy ������ �����ϴ�.
- Architecture risk: �ð� polish ��ü�� �ǵ帮�� �ʾҽ��ϴ�. design token/layout constant ������ #386 ������ �����ϴ�.

## Validation
- `npm.cmd run lint` passed
- `npm.cmd run typecheck` passed
- `npm.cmd run test:unit` passed
- `npm.cmd run test:integration` passed
- `npm.cmd run test:regression` passed
- `npm.cmd run test:e2e` passed
- `npm.cmd run test:coverage:ts` passed
- `npm.cmd run build` passed
- `git diff --check` passed
- UTF-8 strict decode passed for changed files
- `npm.cmd run check:numeric-literals` unavailable: missing npm script, tracked as #386-owned follow-up
