### PR TITLE
Add app layout token gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "prebuild": "node scripts/build-frontend.mjs prepare",
     "build": "esbuild src/main.tsx --bundle --outdir=infra/nginx/site/assets --public-path=/assets --entry-names=main-[hash] --chunk-names=chunk-[hash] --asset-names=asset-[hash] --format=esm --splitting --target=es2020,chrome110,safari16 --jsx=automatic --loader:.css=css --loader:.png=file --loader:.otf=file --loader:.ttf=file --loader:.woff=file --loader:.woff2=file --minify --log-level=info && node scripts/build-frontend.mjs finalize",
+    "check:numeric-literals": "node --max-old-space-size=8192 ./node_modules/vitest/vitest.mjs run test/unit/layout-token-source-quality.test.ts test/unit/map-config.test.ts test/unit/runtime-limit-config.test.ts test/unit/ui-token-config.test.ts",
     "lint": "eslint src scripts test",
     "test": "node --max-old-space-size=8192 ./node_modules/vitest/vitest.mjs run",
     "test:unit": "tsx scripts/run-unit-tests.ts",

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,17 @@
 :root {
   --app-height: 100dvh;
   --app-width: 100vw;
-  --bottom-nav-offset: calc(76px + env(safe-area-inset-bottom));
+  --bottom-nav-base-height: 76px;
+  --bottom-nav-offset: calc(var(--bottom-nav-base-height) + env(safe-area-inset-bottom));
+  --bottom-nav-padding-y: 10px;
+  --bottom-nav-padding-x: 14px;
+  --bottom-nav-safe-padding-y: 12px;
+  --map-sheet-tab-gap: 12px;
+  --map-sheet-peek-height: 31%;
+  --map-sheet-half-height: 50%;
+  --map-sheet-full-height: 60%;
+  --map-sheet-closed-translate-y: 120%;
+  --map-sheet-handle-reserved-height: 22px;
   --app-surface-background:
     radial-gradient(circle at top left, rgba(255, 214, 227, 0.82), transparent 36%),
     radial-gradient(circle at top right, rgba(179, 227, 255, 0.78), transparent 32%),
@@ -876,29 +886,29 @@ textarea {
 }
 
 .place-drawer--peek {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
-  height: 31%;
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
+  height: var(--map-sheet-peek-height);
 }
 
 .place-drawer--half {
   bottom: 0;
-  height: 50%;
+  height: var(--map-sheet-half-height);
 }
 
 .place-drawer--closed {
-  transform: translateY(120%);
+  transform: translateY(var(--map-sheet-closed-translate-y));
   opacity: 0;
   pointer-events: none;
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
-  height: 31%;
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
+  height: var(--map-sheet-peek-height);
 }
 
 .place-drawer--full {
   bottom: 0;
-  height: 60%;
+  height: var(--map-sheet-full-height);
 }
 
 .place-drawer__handle {
@@ -919,7 +929,7 @@ textarea {
 }
 
 .place-drawer__content {
-  height: calc(100% - 22px);
+  height: calc(100% - var(--map-sheet-handle-reserved-height));
   overflow-y: auto;
   padding: 0 16px 18px;
   scrollbar-width: none;
@@ -1494,7 +1504,10 @@ textarea {
   display: grid;
   grid-template-columns: repeat(5, minmax(0, 1fr));
   gap: 10px;
-  padding: 10px 14px calc(10px + env(safe-area-inset-bottom));
+  padding:
+    var(--bottom-nav-padding-y)
+    var(--bottom-nav-padding-x)
+    calc(var(--bottom-nav-padding-y) + env(safe-area-inset-bottom));
   background: rgba(255, 252, 249, 0.9);
   border-top: 1px solid rgba(255, 255, 255, 0.82);
   backdrop-filter: blur(14px);
@@ -1589,7 +1602,7 @@ textarea {
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
   height: 34%;
 }
 
@@ -1690,7 +1703,7 @@ textarea {
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
   height: 36%;
 }
 
@@ -1818,13 +1831,13 @@ textarea {
 
 .place-drawer {
   margin: 0 12px;
-  bottom: calc(72px + env(safe-area-inset-bottom));
+  bottom: var(--bottom-nav-offset);
   background: rgba(255, 252, 249, 0.98);
   border-radius: 28px 28px 24px 24px;
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
   height: 30%;
 }
 
@@ -1843,7 +1856,10 @@ textarea {
 }
 
 .bottom-nav {
-  padding: 10px 14px calc(12px + env(safe-area-inset-bottom));
+  padding:
+    var(--bottom-nav-padding-y)
+    var(--bottom-nav-padding-x)
+    calc(var(--bottom-nav-safe-padding-y) + env(safe-area-inset-bottom));
   background: rgba(255, 252, 249, 0.96);
 }
 
@@ -1877,7 +1893,7 @@ textarea {
 /* 2026-03-18 map/page refresh */
 .page-panel {
   position: absolute;
-  inset: 12px 12px calc(76px + env(safe-area-inset-bottom)) 12px;
+  inset: 12px 12px var(--bottom-nav-offset) 12px;
   overflow: hidden;
   border-radius: 28px;
   border: 1px solid rgba(255,255,255,0.84);
@@ -1961,12 +1977,12 @@ textarea {
 
 .place-drawer {
   margin: 0 10px;
-  bottom: calc(76px + env(safe-area-inset-bottom));
+  bottom: var(--bottom-nav-offset);
   border-radius: 28px 28px 22px 22px;
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
   height: 36%;
 }
 
@@ -1990,7 +2006,10 @@ textarea {
 
 .bottom-nav {
   gap: 8px;
-  padding: 10px 12px calc(12px + env(safe-area-inset-bottom));
+  padding:
+    var(--bottom-nav-padding-y)
+    12px
+    calc(var(--bottom-nav-safe-padding-y) + env(safe-area-inset-bottom));
 }
 
 .bottom-nav__item {
@@ -2206,7 +2225,7 @@ textarea {
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px);
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap));
   height: 34%;
 }
 

--- a/src/styles/refinements.css
+++ b/src/styles/refinements.css
@@ -142,28 +142,31 @@
 }
 
 .place-drawer--peek {
-  bottom: calc(var(--bottom-nav-offset) + 12px) !important;
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap)) !important;
   height: 35% !important;
 }
 
 .place-drawer--half {
   bottom: 0 !important;
-  height: 50% !important;
+  height: var(--map-sheet-half-height) !important;
 }
 
 .place-drawer--partial {
-  bottom: calc(var(--bottom-nav-offset) + 12px) !important;
+  bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap)) !important;
   height: 35% !important;
 }
 
 .place-drawer--full {
   bottom: 0 !important;
-  height: 60% !important;
+  height: var(--map-sheet-full-height) !important;
 }
 
 .bottom-nav {
   gap: 8px !important;
-  padding: 10px 12px calc(12px + env(safe-area-inset-bottom)) !important;
+  padding:
+    var(--bottom-nav-padding-y)
+    12px
+    calc(var(--bottom-nav-safe-padding-y) + env(safe-area-inset-bottom)) !important;
 }
 
 .bottom-nav__item {
@@ -193,7 +196,7 @@ input.visually-hidden[type='file'] {
   }
 
   .place-drawer--partial {
-    bottom: calc(var(--bottom-nav-offset) + 12px) !important;
+    bottom: calc(var(--bottom-nav-offset) + var(--map-sheet-tab-gap)) !important;
     height: 34% !important;
   }
 

--- a/test/unit/layout-token-source-quality.test.ts
+++ b/test/unit/layout-token-source-quality.test.ts
@@ -1,0 +1,40 @@
+/*
+ * File: layout-token-source-quality.test.ts
+ * Purpose: Guard the app-shell layout token boundary introduced for TSK-012-06.
+ * Primary Responsibility: Fail when bottom tab and map sheet spacing return to raw repeated literals.
+ * Design Intent: Keep UI layout numbers owned by CSS tokens without changing public behavior.
+ * Non-Goals: This test does not classify every CSS number or enforce visual redesign.
+ * Dependencies: Vitest and repository-relative CSS source files.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const workspaceRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
+
+function readSource(path: string) {
+  return readFileSync(join(workspaceRoot, path), 'utf8');
+}
+
+describe('layout token source quality baseline', () => {
+  it('keeps app shell and map sheet spacing owned by root CSS tokens', () => {
+    const indexCss = readSource('src/index.css');
+
+    expect(indexCss).toContain('--bottom-nav-base-height: 76px;');
+    expect(indexCss).toContain('--bottom-nav-offset: calc(var(--bottom-nav-base-height) + env(safe-area-inset-bottom));');
+    expect(indexCss).toContain('--map-sheet-tab-gap: 12px;');
+    expect(indexCss).toContain('--map-sheet-peek-height: 31%;');
+    expect(indexCss).toContain('--map-sheet-half-height: 50%;');
+    expect(indexCss).toContain('--map-sheet-full-height: 60%;');
+  });
+
+  it('prevents repeated bottom tab and sheet gap literals from returning', () => {
+    const css = `${readSource('src/index.css')}\n${readSource('src/styles/refinements.css')}`;
+
+    expect(css).not.toMatch(/bottom-nav-offset\)\s*\+\s*12px/);
+    expect(css).not.toContain('calc(76px + env(safe-area-inset-bottom))');
+    expect(css).not.toContain('calc(72px + env(safe-area-inset-bottom))');
+    expect(css).not.toMatch(/padding:\s*10px\s+1[24]px\s+calc\(12px\s*\+\s*env\(safe-area-inset-bottom\)\)/);
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #386
- Scope-ID: TSK-012-06
- �� ��/���� ��/���� ��Ʈ���� �ݺ��Ǵ� bottom offset, sheet gap, �⺻ sheet height ���� CSS token���� �̵��߽��ϴ�.
- `check:numeric-literals` npm script�� ���� ���� ������ token/config gate�� �����߽��ϴ�.
- `layout-token-source-quality.test.ts`�� �߰��� raw bottom-nav/sheet gap literal ȸ�͸� �����մϴ�.

## Architecture Boundary Evidence
- Responsibility map: CSS root token layer�� layout ��ġ �������� �����ϰ�, component/page-stage�� ���� class�� DOM contract�� �����մϴ�.
- Dependency direction: presentation CSS�� token�� �Һ��ϸ� API/domain/backend ������ layout token�� �������� �ʽ��ϴ�.
- Test seam: `check:numeric-literals`�� `layout-token-source-quality.test.ts`�� token boundary�� �����ϰ�, ���� E2E�� app shell/map sheet/tab surface ������ �����մϴ�.
- Scope map: `package.json`, `src/index.css`, `src/styles/refinements.css`, source-quality test�� �����߽��ϴ�. API/DB/OAuth/user-facing copy ������ �����ϴ�.
- Architecture risk: ������ tokenȭ�� ���ϱ� ���� �ݺ�/�ǹ� �ִ� bottom offset, sheet gap, �⺻ height�� �̵��߽��ϴ�. �������� ���� height override�� ���� ���� ������ ���� �����߽��ϴ�.

## Validation
- `npm.cmd run check:numeric-literals` passed
- `npm.cmd run lint` passed
- `npm.cmd run typecheck` passed
- `npm.cmd run test:unit` passed
- `npm.cmd run test:integration` passed
- `npm.cmd run test:regression` passed
- `npm.cmd run test:e2e` passed
- `npm.cmd run test:coverage:ts` passed
- `npm.cmd run build` passed on standalone rerun
- `git diff --check` passed
- UTF-8 strict decode passed for changed files

## Notes
- Initial parallel `test:e2e` + `build` run hit the known generated `infra/nginx/site` contention during build finalization. Standalone `npm.cmd run build` passed immediately after.
- `npm.cmd ci` reported one moderate dependency audit item; this PR does not change dependencies and does not address audit scope.
